### PR TITLE
Fix nil pointer dereference when using ctx.allocator in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,13 @@ By default (`null`/`auto`), ZigZag:
 - probes kitty text-sizing support,
 - applies terminal/multiplexer heuristics (e.g. tmux/screen/zellij favor legacy width).
 
+### Allocator Lifetimes
+
+`ctx.allocator` is a frame allocator that is reset before each `tick()`.
+Use it for temporary values (render strings, per-frame buffers).
+
+For model state that must live across frames, allocate with `ctx.persistent_allocator`.
+
 ### Custom Event Loop
 
 For applications that need to do other work between frames (network polling, background processing, etc.), use `start()` + `tick()` instead of `run()`:

--- a/build.zig
+++ b/build.zig
@@ -55,6 +55,7 @@ pub fn build(b: *std.Build) void {
         "tests/input_tests.zig",
         "tests/layout_tests.zig",
         "tests/unicode_tests.zig",
+        "tests/program_tests.zig",
     };
 
     const test_step = b.step("test", "Run unit tests");

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -66,14 +66,15 @@ pub fn Program(comptime Model: type) type {
 
         /// Initialize with custom options
         pub fn initWithOptions(allocator: std.mem.Allocator, options: Options) !Self {
-            var arena = std.heap.ArenaAllocator.init(allocator);
-
+            const arena = std.heap.ArenaAllocator.init(allocator);
             const self = Self{
                 .allocator = allocator,
                 .arena = arena,
                 .model = undefined,
                 .terminal = null,
-                .context = Context.init(arena.allocator(), allocator),
+                // `self` is returned by value, so don't capture an arena allocator here.
+                // It would point at this function's stack copy and dangle after return.
+                .context = Context.init(allocator, allocator),
                 .options = options,
                 .running = false,
                 .start_time = std.time.nanoTimestamp(),
@@ -172,6 +173,8 @@ pub fn Program(comptime Model: type) type {
             self.context.kitty_text_sizing = width_caps.kitty_text_sizing;
             unicode.setWidthStrategy(effective_width_strategy);
 
+            self.resetFrameAllocator();
+
             // Initialize the model
             const init_cmd = self.model.init(&self.context);
             try self.processCommand(init_cmd);
@@ -206,9 +209,7 @@ pub fn Program(comptime Model: type) type {
             self.context.elapsed = @intCast(self.last_frame_time - self.start_time);
             self.context.frame += 1;
 
-            // Reset arena for this frame
-            _ = self.arena.reset(.retain_capacity);
-            self.context.allocator = self.arena.allocator();
+            self.resetFrameAllocator();
 
             // Check for resize
             if (self.terminal.?.checkResize()) {
@@ -481,6 +482,11 @@ pub fn Program(comptime Model: type) type {
                     }
                 },
             }
+        }
+
+        fn resetFrameAllocator(self: *Self) void {
+            _ = self.arena.reset(.retain_capacity);
+            self.context.allocator = self.arena.allocator();
         }
 
         fn render(self: *Self) !void {

--- a/tests/program_tests.zig
+++ b/tests/program_tests.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const testing = std.testing;
+const zz = @import("zigzag");
+
+const DummyModel = struct {
+    pub const Msg = union(enum) {
+        nop: void,
+    };
+
+    pub fn init(_: *DummyModel, _: *zz.Context) zz.Cmd(Msg) {
+        return .none;
+    }
+
+    pub fn update(_: *DummyModel, _: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        return .none;
+    }
+
+    pub fn view(_: *const DummyModel, _: *const zz.Context) []const u8 {
+        return "";
+    }
+};
+
+test "Program.init context allocator is stable before start and can be rebound to arena" {
+    var program = try zz.Program(DummyModel).init(testing.allocator);
+    defer program.deinit();
+
+    const backing_ptr = @intFromPtr(testing.allocator.ptr);
+    const init_context_allocator_ptr = @intFromPtr(program.context.allocator.ptr);
+    try testing.expectEqual(backing_ptr, init_context_allocator_ptr);
+
+    program.context.allocator = program.arena.allocator();
+    const arena_ptr = @intFromPtr(&program.arena);
+    const rebound_context_allocator_ptr = @intFromPtr(program.context.allocator.ptr);
+    try testing.expectEqual(arena_ptr, rebound_context_allocator_ptr);
+}


### PR DESCRIPTION
- Defer arena allocator binding until after `self` is moved to its final location, fixing a dangling pointer when `ctx.allocator` was used in `model.init()`
- Reset frame allocator before calling `model.init()` so `ctx.allocator` works correctly from the start
- Extract `resetFrameAllocator()` helper to avoid duplicating arena reset logic
- Add allocator stability test and document allocator lifetimes in README