### PR TITLE
fix: upgrade CI to Node.js 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:
@@ -34,6 +37,7 @@ jobs:
   cross-compile:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target: [x86_64-windows, aarch64-macos, x86_64-linux]
     steps:


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` globally to fix `mlugg/setup-zig@v2` cache "fetch failed" errors caused by deprecated Node.js 20 runtime
- Add `fail-fast: false` to cross-compile matrix so one target failure doesn't cancel others