### PR TITLE
fix: pin Zig to 0.15.2 and add fail-fast: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -19,11 +21,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: latest
+          version: ${{ env.ZIG_VERSION }}
       - run: zig build
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -31,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: latest
+          version: ${{ env.ZIG_VERSION }}
       - run: zig build test
 
   cross-compile:
@@ -44,5 +47,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: latest
+          version: ${{ env.ZIG_VERSION }}
       - run: zig build -Dtarget=${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Pin Zig version to `0.15.2` instead of `latest` — resolves intermittent "fetch failed" when CDN is slow or version resolution differs between runners
- Add `fail-fast: false` to build and test matrices (already added to cross-compile in #80) so one runner failure doesn't cancel others
- Extract `ZIG_VERSION` as a top-level env var for easy updates