### PR TITLE
Examples for the six new components

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,6 +51,12 @@ pub fn build(b: *std.Build) void {
         "heatmap",
         "gauge",
         "flex_layout",
+        "braille_canvas",
+        "rich_log",
+        "screen_stack",
+        "action_system",
+        "data_table",
+        "dev_console",
     };
 
     for (examples) |example_name| {

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -1,0 +1,225 @@
+//! ZigZag ActionRegistry Example
+//! One registry feeding both an auto-rendered footer and a fuzzy command palette.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+const Model = struct {
+    registry: zz.ActionRegistry,
+    palette: zz.CommandPalette,
+    palette_open: bool,
+    counter: i32,
+    last_action: []const u8,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+    };
+
+    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+        var reg = zz.ActionRegistry.init(ctx.allocator);
+
+        // Footer-visible actions.
+        reg.register(.{
+            .id = "app.quit",
+            .label = "Quit",
+            .description = "Exit the program",
+            .binding = .{ .key = .{ .char = 'q' } },
+            .show_in_footer = true,
+        }) catch {};
+        reg.register(.{
+            .id = "counter.inc",
+            .label = "Increment",
+            .description = "Add one to the counter",
+            .binding = .{ .key = .{ .char = '+' } },
+            .show_in_footer = true,
+        }) catch {};
+        reg.register(.{
+            .id = "counter.dec",
+            .label = "Decrement",
+            .description = "Subtract one from the counter",
+            .binding = .{ .key = .{ .char = '-' } },
+            .show_in_footer = true,
+        }) catch {};
+        reg.register(.{
+            .id = "palette.open",
+            .label = "Command Palette",
+            .description = "Open the searchable command list",
+            .binding = .{ .key = .{ .char = 'p' }, .modifiers = .{ .ctrl = true } },
+            .show_in_footer = true,
+        }) catch {};
+
+        // Hidden-from-footer actions still show up in the palette.
+        reg.register(.{
+            .id = "counter.reset",
+            .label = "Reset counter",
+            .description = "Set the counter back to zero",
+            .category = "Counter",
+        }) catch {};
+        reg.register(.{
+            .id = "counter.times_ten",
+            .label = "Multiply by 10",
+            .description = "Multiply the counter by ten",
+            .category = "Counter",
+        }) catch {};
+        reg.register(.{
+            .id = "counter.negate",
+            .label = "Negate",
+            .description = "Flip the counter sign",
+            .category = "Counter",
+        }) catch {};
+        reg.register(.{
+            .id = "help.about",
+            .label = "About this demo",
+            .description = "Show what this example illustrates",
+            .category = "Help",
+        }) catch {};
+
+        // Aliases let multiple keys map to the same action.
+        reg.addAlias("counter.inc", .{ .key = .up }) catch {};
+        reg.addAlias("counter.dec", .{ .key = .down }) catch {};
+
+        var palette = zz.CommandPalette.init(ctx.allocator) catch return .quit;
+        palette.placeholder = "Search commands…";
+
+        self.* = .{
+            .registry = reg,
+            .palette = palette,
+            .palette_open = false,
+            .counter = 0,
+            .last_action = "(none yet)",
+        };
+
+        // Push every registered action into the palette.
+        var palette_cmds = std.array_list.Managed(zz.Command).init(ctx.allocator);
+        defer palette_cmds.deinit();
+        for (self.registry.actions.items) |a| {
+            const shortcut = if (a.binding) |b|
+                zz.ActionRegistry.formatKey(ctx.allocator, b) catch ""
+            else
+                "";
+            palette_cmds.append(.{
+                .id = a.id,
+                .label = a.label,
+                .description = a.description,
+                .shortcut = shortcut,
+            }) catch {};
+        }
+        self.palette.setCommands(palette_cmds.items) catch {};
+
+        return .none;
+    }
+
+    pub fn deinit(self: *Model) void {
+        self.registry.deinit();
+        self.palette.deinit();
+    }
+
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .key => |k| {
+                if (self.palette_open) {
+                    const result = self.palette.handleKey(k) catch return .none;
+                    switch (result) {
+                        .accepted => {
+                            if (self.palette.selected()) |cmd| {
+                                _ = self.dispatch(cmd.id);
+                            }
+                            self.palette_open = false;
+                            self.palette.clear() catch {};
+                        },
+                        .cancelled => {
+                            self.palette_open = false;
+                            self.palette.clear() catch {};
+                        },
+                        else => {},
+                    }
+                    return .none;
+                }
+
+                if (self.registry.matchKey(k)) |action| {
+                    return self.dispatchAction(action);
+                }
+
+                if (k.key == .escape) return .quit;
+            },
+        }
+        return .none;
+    }
+
+    fn dispatchAction(self: *Model, action: *const zz.Action) zz.Cmd(Msg) {
+        return self.dispatch(action.id);
+    }
+
+    fn dispatch(self: *Model, id: []const u8) zz.Cmd(Msg) {
+        self.last_action = id;
+        if (std.mem.eql(u8, id, "app.quit")) return .quit;
+        if (std.mem.eql(u8, id, "counter.inc")) self.counter += 1;
+        if (std.mem.eql(u8, id, "counter.dec")) self.counter -= 1;
+        if (std.mem.eql(u8, id, "counter.reset")) self.counter = 0;
+        if (std.mem.eql(u8, id, "counter.times_ten")) self.counter *= 10;
+        if (std.mem.eql(u8, id, "counter.negate")) self.counter = -self.counter;
+        if (std.mem.eql(u8, id, "palette.open")) self.palette_open = true;
+        return .none;
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const alloc = ctx.allocator;
+
+        var title = zz.Style{};
+        title = title.bold(true);
+        title = title.fg(zz.Color.cyan());
+        title = title.inline_style(true);
+        const title_str = title.render(alloc, "ActionRegistry — one source of truth") catch "";
+
+        const body = std.fmt.allocPrint(
+            alloc,
+            \\Counter        {d}
+            \\Last action    {s}
+            \\Footer below auto-renders bindings flagged show_in_footer.
+            \\
+            \\Press ctrl+p to open the palette and search any registered action,
+            \\including ones with no key binding (try "negate" or "ten").
+        ,
+            .{ self.counter, self.last_action },
+        ) catch "";
+
+        var box = zz.Style{};
+        box = box.borderAll(zz.Border.rounded);
+        box = box.borderForeground(zz.Color.gray(8));
+        box = box.paddingAll(1);
+        const boxed = box.render(alloc, body) catch body;
+
+        var footer = zz.ActionFooter.init(&self.registry);
+        footer.setWidth(@intCast(ctx.width));
+        const footer_str = footer.view(alloc) catch "";
+
+        const main_view = std.fmt.allocPrint(
+            alloc,
+            "{s}\n\n{s}\n\n{s}",
+            .{ title_str, boxed, footer_str },
+        ) catch "";
+
+        if (!self.palette_open) return main_view;
+
+        // Overlay the palette centered on top of the main view.
+        const palette_view = self.palette.view(alloc) catch "";
+        return zz.place.placeFloat(
+            alloc,
+            ctx.width,
+            ctx.height,
+            0.5,
+            0.5,
+            palette_view,
+        ) catch main_view;
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -1,0 +1,144 @@
+//! ZigZag BrailleCanvas Example
+//! Animated bouncing ball with a faint grid background.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+const Model = struct {
+    canvas: zz.components.BrailleCanvas,
+    ball_x: f64,
+    ball_y: f64,
+    vx: f64,
+    vy: f64,
+    paused: bool,
+    frame: u64,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+        tick: zz.msg.Tick,
+    };
+
+    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+        const c = zz.components.BrailleCanvas.init(ctx.allocator, 50, 12) catch return .quit;
+        self.* = .{
+            .canvas = c,
+            .ball_x = 10,
+            .ball_y = 10,
+            .vx = 0.9,
+            .vy = 0.6,
+            .paused = false,
+            .frame = 0,
+        };
+        return .{ .every = 33 * std.time.ns_per_ms }; // ~30 fps
+    }
+
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .key => |k| switch (k.key) {
+                .char => |c| switch (c) {
+                    'q' => return .quit,
+                    ' ' => self.paused = !self.paused,
+                    'r' => {
+                        self.ball_x = 10;
+                        self.ball_y = 10;
+                        self.vx = 0.9;
+                        self.vy = 0.6;
+                    },
+                    else => {},
+                },
+                .escape => return .quit,
+                else => {},
+            },
+            .tick => {
+                if (!self.paused) self.advance();
+                self.frame +%= 1;
+            },
+        }
+        return .none;
+    }
+
+    fn advance(self: *Model) void {
+        const max_x: f64 = @floatFromInt(self.canvas.pixelWidth() - 1);
+        const max_y: f64 = @floatFromInt(self.canvas.pixelHeight() - 1);
+
+        self.ball_x += self.vx;
+        self.ball_y += self.vy;
+
+        if (self.ball_x <= 4 or self.ball_x >= max_x - 4) self.vx = -self.vx;
+        if (self.ball_y <= 4 or self.ball_y >= max_y - 4) self.vy = -self.vy;
+        self.ball_x = std.math.clamp(self.ball_x, 4, max_x - 4);
+        self.ball_y = std.math.clamp(self.ball_y, 4, max_y - 4);
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const alloc = ctx.allocator;
+        var c = @constCast(&self.canvas);
+        c.clear();
+
+        // Faint grid: dotted border + crosshair through the centre.
+        var grid_style = zz.Style{};
+        grid_style = grid_style.fg(zz.Color.gray(6));
+        grid_style = grid_style.inline_style(true);
+
+        const w = c.pixelWidth();
+        const h = c.pixelHeight();
+        c.drawRectStyled(0, 0, @intCast(w - 1), @intCast(h - 1), false, grid_style);
+        c.drawLineStyled(@intCast(w / 2), 0, @intCast(w / 2), @intCast(h - 1), grid_style);
+        c.drawLineStyled(0, @intCast(h / 2), @intCast(w - 1), @intCast(h / 2), grid_style);
+
+        // Ball trail.
+        const tx: i32 = @intFromFloat(self.ball_x);
+        const ty: i32 = @intFromFloat(self.ball_y);
+
+        var trail_style = zz.Style{};
+        trail_style = trail_style.fg(zz.Color.cyan());
+        trail_style = trail_style.inline_style(true);
+        c.drawCircleStyled(tx, ty, 3, trail_style);
+
+        var ball_style = zz.Style{};
+        ball_style = ball_style.fg(zz.Color.magenta());
+        ball_style = ball_style.bold(true);
+        ball_style = ball_style.inline_style(true);
+        c.drawCircleStyled(tx, ty, 1, ball_style);
+
+        const canvas_view = c.view(alloc) catch "";
+
+        var title = zz.Style{};
+        title = title.bold(true);
+        title = title.fg(zz.Color.cyan());
+        title = title.inline_style(true);
+        const t = title.render(alloc, "BrailleCanvas — bouncing ball") catch "";
+
+        var box = zz.Style{};
+        box = box.borderAll(zz.Border.rounded);
+        box = box.borderForeground(zz.Color.gray(8));
+        const boxed = box.render(alloc, canvas_view) catch canvas_view;
+
+        var help = zz.Style{};
+        help = help.fg(zz.Color.gray(10));
+        help = help.inline_style(true);
+        const status = if (self.paused) "PAUSED  " else "        ";
+        const help_text = std.fmt.allocPrint(
+            alloc,
+            "{s}space pause  r reset  q quit   |   frame {d}",
+            .{ status, self.frame },
+        ) catch "";
+        const help_str = help.render(alloc, help_text) catch "";
+
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str }) catch "Error";
+    }
+
+    pub fn deinit(self: *Model) void {
+        self.canvas.deinit();
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -1,0 +1,102 @@
+//! ZigZag DataTable Example
+//! Wide table with a frozen first column and cell-level cursor.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+const Model = struct {
+    table: zz.components.DataTable,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+    };
+
+    const headers = [_]zz.components.DataColumn{
+        .{ .header = "id", .width = 4, .@"align" = .right },
+        .{ .header = "name", .width = 12 },
+        .{ .header = "team", .width = 10 },
+        .{ .header = "city", .width = 12 },
+        .{ .header = "role", .width = 14 },
+        .{ .header = "tenure", .width = 8, .@"align" = .right },
+        .{ .header = "rating", .width = 8, .@"align" = .right },
+        .{ .header = "salary", .width = 10, .@"align" = .right },
+    };
+
+    const rows = [_][]const []const u8{
+        &.{ "01", "Alice",   "Platform", "Berlin",     "Engineer",       "5y",  "4.8", "$120k" },
+        &.{ "02", "Bob",     "Growth",   "Lisbon",     "PM",             "3y",  "4.1", "$110k" },
+        &.{ "03", "Carol",   "Platform", "Tokyo",      "Staff Eng",      "9y",  "4.9", "$180k" },
+        &.{ "04", "Dan",     "Infra",    "Berlin",     "SRE",            "2y",  "4.3", "$130k" },
+        &.{ "05", "Eve",     "Growth",   "Lisbon",     "Designer",       "1y",  "4.5", "$95k"  },
+        &.{ "06", "Frank",   "Infra",    "Singapore",  "Eng Manager",    "7y",  "4.6", "$160k" },
+        &.{ "07", "Grace",   "Platform", "Berlin",     "Engineer",       "4y",  "4.7", "$125k" },
+        &.{ "08", "Heidi",   "Sec",      "Tel Aviv",   "Security Eng",   "6y",  "4.4", "$140k" },
+        &.{ "09", "Ivan",    "Growth",   "Lisbon",     "Engineer",       "2y",  "4.0", "$105k" },
+        &.{ "10", "Judy",    "Platform", "Tokyo",      "Engineer",       "3y",  "4.2", "$118k" },
+    };
+
+    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+        var t = zz.components.DataTable.init(ctx.allocator);
+        t.setColumns(&headers) catch return .quit;
+        for (rows) |r| t.addRow(r) catch {};
+        t.setSize(60, 15);
+        t.setFrozenColumns(2); // id + name stay visible while you scroll right.
+        self.* = .{ .table = t };
+        return .none;
+    }
+
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .key => |k| {
+                switch (k.key) {
+                    .char => |c| switch (c) {
+                        'q' => return .quit,
+                        else => self.table.handleKey(k),
+                    },
+                    .escape => return .quit,
+                    else => self.table.handleKey(k),
+                }
+            },
+        }
+        return .none;
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const alloc = ctx.allocator;
+
+        var title_style = zz.Style{};
+        title_style = title_style.bold(true);
+        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.inline_style(true);
+        const title = title_style.render(alloc, "DataTable — frozen columns + cell cursor") catch "";
+
+        var table_mut = @constCast(&self.table);
+        const table_view = table_mut.view(alloc) catch "";
+
+        var help_style = zz.Style{};
+        help_style = help_style.fg(zz.Color.gray(10));
+        help_style = help_style.inline_style(true);
+        const help_text = std.fmt.allocPrint(
+            alloc,
+            "cursor row {d}, col {d}   |   ←→↑↓ / hjkl move   home/end col   g/G row   q quit",
+            .{ self.table.cursor_row, self.table.cursor_col },
+        ) catch "";
+        const help = help_style.render(alloc, help_text) catch "";
+
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ title, table_view, help }) catch "Error";
+    }
+
+    pub fn deinit(self: *Model) void {
+        self.table.deinit();
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -1,0 +1,115 @@
+//! ZigZag DevConsole Example
+//! Streams app log events to dev_console.log AND to TCP port 7878.
+//! In another terminal: `tail -f dev_console.log`  or  `nc localhost 7878`.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+var console: zz.DevConsole = undefined;
+
+const Model = struct {
+    counter: u32,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+        tick: zz.msg.Tick,
+    };
+
+    pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
+        self.* = .{ .counter = 0 };
+        console.info("DevConsole example started — streaming on file + tcp/7878", .{});
+        return .{ .every = 500 * std.time.ns_per_ms };
+    }
+
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .tick => {
+                self.counter += 1;
+                console.debug("tick #{d}", .{self.counter});
+                if (self.counter % 5 == 0) {
+                    console.info("milestone: counter reached {d}", .{self.counter});
+                }
+                if (self.counter == 13) {
+                    console.warn("unlucky number reached: {d}", .{self.counter});
+                }
+                if (self.counter % 17 == 0) {
+                    console.err("simulated failure at counter={d}", .{self.counter});
+                }
+            },
+            .key => |k| switch (k.key) {
+                .char => |c| switch (c) {
+                    'q' => {
+                        console.info("user requested quit at counter={d}", .{self.counter});
+                        return .quit;
+                    },
+                    ' ' => {
+                        console.warn("manual warn from spacebar (counter={d})", .{self.counter});
+                    },
+                    'r' => {
+                        console.info("counter reset by user (was {d})", .{self.counter});
+                        self.counter = 0;
+                    },
+                    else => {},
+                },
+                .escape => return .quit,
+                else => {},
+            },
+        }
+        return .none;
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const alloc = ctx.allocator;
+
+        var title = zz.Style{};
+        title = title.bold(true);
+        title = title.fg(zz.Color.cyan());
+        title = title.inline_style(true);
+        const t = title.render(alloc, "DevConsole — log streamer") catch "";
+
+        const body = std.fmt.allocPrint(
+            alloc,
+            \\Counter: {d}
+            \\
+            \\Two sinks are active:
+            \\  • file ........ ./dev_console.log
+            \\  • tcp .......... 127.0.0.1:7878
+            \\
+            \\Open another terminal and run one of:
+            \\  $ tail -f dev_console.log
+            \\  $ nc localhost 7878
+            \\
+            \\You'll see entries stream in as you press keys here.
+        ,
+            .{self.counter},
+        ) catch "";
+
+        var box = zz.Style{};
+        box = box.borderAll(zz.Border.rounded);
+        box = box.borderForeground(zz.Color.gray(8));
+        box = box.paddingAll(1);
+        const boxed = box.render(alloc, body) catch body;
+
+        var help = zz.Style{};
+        help = help.fg(zz.Color.gray(10));
+        help = help.inline_style(true);
+        const help_str = help.render(alloc, "space warn · r reset · q quit") catch "";
+
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str }) catch "Error";
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    console = zz.DevConsole.init(gpa.allocator());
+    defer console.deinit();
+    try console.addSink(.{ .file = "dev_console.log" });
+    try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -1,0 +1,171 @@
+//! ZigZag RichLog Example
+//! Live log stream with level filtering and search.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+const Model = struct {
+    log: zz.components.RichLog,
+    counter: u32,
+    search_term: std.array_list.Managed(u8),
+    typing_search: bool,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+        tick: zz.msg.Tick,
+    };
+
+    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+        var log = zz.components.RichLog.init(ctx.allocator, 500);
+        log.setSize(80, 14);
+        log.show_timestamps = true;
+
+        // Seed with a few entries.
+        log.append(.info, "RichLog example started") catch {};
+        log.append(.debug, "buffer capacity = 500 entries") catch {};
+        log.append(.info, "follow-mode enabled — new entries scroll into view") catch {};
+        log.append(.warn, "press '/' to filter, 'l' to cycle min level") catch {};
+
+        self.* = .{
+            .log = log,
+            .counter = 0,
+            .search_term = std.array_list.Managed(u8).init(ctx.allocator),
+            .typing_search = false,
+        };
+        return .{ .every = 700 * std.time.ns_per_ms };
+    }
+
+    pub fn deinit(self: *Model) void {
+        self.log.deinit();
+        self.search_term.deinit();
+    }
+
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .tick => {
+                self.counter += 1;
+                self.emit();
+            },
+            .key => |k| {
+                if (self.typing_search) return self.handleSearchKey(k);
+                switch (k.key) {
+                    .char => |c| switch (c) {
+                        'q' => return .quit,
+                        '/' => self.typing_search = true,
+                        'c' => {
+                            self.search_term.clearRetainingCapacity();
+                            self.log.clearSearch();
+                        },
+                        'l' => self.cycleLevel(),
+                        else => self.log.handleKey(k) catch {},
+                    },
+                    .escape => return .quit,
+                    else => self.log.handleKey(k) catch {},
+                }
+            },
+        }
+        return .none;
+    }
+
+    fn handleSearchKey(self: *Model, k: zz.KeyEvent) zz.Cmd(Msg) {
+        switch (k.key) {
+            .escape => {
+                self.typing_search = false;
+                self.search_term.clearRetainingCapacity();
+                self.log.clearSearch();
+            },
+            .enter => {
+                self.typing_search = false;
+                self.log.setSearch(self.search_term.items) catch {};
+            },
+            .backspace => {
+                if (self.search_term.items.len > 0) _ = self.search_term.pop();
+            },
+            .char => |c| {
+                if (c >= 0x20) {
+                    var buf: [4]u8 = undefined;
+                    const n = std.unicode.utf8Encode(c, &buf) catch return .none;
+                    self.search_term.appendSlice(buf[0..n]) catch {};
+                }
+            },
+            else => {},
+        }
+        return .none;
+    }
+
+    fn cycleLevel(self: *Model) void {
+        const next: zz.components.RichLogLevel = switch (self.log.min_level) {
+            .trace => .debug,
+            .debug => .info,
+            .info => .warn,
+            .warn => .err,
+            .err => .trace,
+        };
+        self.log.setMinLevel(next);
+    }
+
+    fn emit(self: *Model) void {
+        // Generate one varied log entry per tick. Format strings must be
+        // comptime, so dispatch in a switch.
+        switch (self.counter % 5) {
+            0 => self.log.appendFmt(.trace, "trace: tick {d} fired", .{self.counter}) catch {},
+            1 => self.log.appendFmt(.debug, "debug: queue depth {d}", .{self.counter}) catch {},
+            2 => self.log.appendFmt(.info, "info: synced {d} records", .{self.counter}) catch {},
+            3 => self.log.appendFmt(.warn, "warn: retry {d} after backoff", .{self.counter}) catch {},
+            else => self.log.appendFmt(.err, "ERROR: timeout on request {d}", .{self.counter}) catch {},
+        }
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const alloc = ctx.allocator;
+        var log_mut = @constCast(&self.log);
+        const log_view = log_mut.view(alloc) catch "";
+
+        var box = zz.Style{};
+        box = box.borderAll(zz.Border.rounded);
+        box = box.borderForeground(zz.Color.gray(8));
+        const boxed = box.render(alloc, log_view) catch log_view;
+
+        var title = zz.Style{};
+        title = title.bold(true);
+        title = title.fg(zz.Color.cyan());
+        title = title.inline_style(true);
+        const t = title.render(alloc, "RichLog — append-only with level filter & search") catch "";
+
+        const status = if (self.typing_search)
+            std.fmt.allocPrint(alloc, "search: {s}_  (enter to apply, esc to cancel)", .{self.search_term.items}) catch ""
+        else
+            std.fmt.allocPrint(
+                alloc,
+                "follow={s}  level≥{s}  search={s}",
+                .{
+                    if (self.log.follow) "ON " else "OFF",
+                    self.log.min_level.label(),
+                    if (self.log.search_term.items.len == 0) "—" else self.log.search_term.items,
+                },
+            ) catch "";
+
+        var status_style = zz.Style{};
+        status_style = status_style.fg(zz.Color.gray(12));
+        status_style = status_style.inline_style(true);
+        const status_str = status_style.render(alloc, status) catch "";
+
+        var help = zz.Style{};
+        help = help.fg(zz.Color.gray(10));
+        help = help.inline_style(true);
+        const help_text = "↑↓ scroll · g/G top/bottom · / search · c clear · l cycle level · q quit";
+        const help_str = help.render(alloc, help_text) catch "";
+
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}\n{s}", .{ t, boxed, status_str, help_str }) catch "Error";
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -1,0 +1,194 @@
+//! ZigZag ScreenStack Example
+//! Three-screen flow: Home → Settings → modal Confirm dialog.
+
+const std = @import("std");
+const zz = @import("zigzag");
+
+// ── Home screen ─────────────────────────────────────────────────────────
+
+const HomeState = struct {
+    counter: u32 = 0,
+
+    fn update(ptr: *anyopaque, _: *zz.Context, key: zz.KeyEvent) zz.ScreenAction {
+        const self: *HomeState = @ptrCast(@alignCast(ptr));
+        switch (key.key) {
+            .char => |c| switch (c) {
+                'q' => return .quit,
+                's' => return .{ .push = settings_screen },
+                '+' => self.counter += 1,
+                '-' => self.counter -|= 1,
+                else => {},
+            },
+            .escape => return .quit,
+            else => {},
+        }
+        return .none;
+    }
+
+    fn view(ptr: *anyopaque, _: *const zz.Context, alloc: std.mem.Allocator) anyerror![]const u8 {
+        const self: *HomeState = @ptrCast(@alignCast(ptr));
+        return std.fmt.allocPrint(
+            alloc,
+            \\┌──────────────────────────────────────────┐
+            \\│  HOME SCREEN                             │
+            \\│                                          │
+            \\│  counter = {d: <30}│
+            \\│                                          │
+            \\│  + / -  adjust counter                   │
+            \\│  s      open Settings                    │
+            \\│  q      quit                             │
+            \\└──────────────────────────────────────────┘
+        ,
+            .{self.counter},
+        );
+    }
+};
+
+var home_state = HomeState{};
+const home_vtable = zz.Screen.VTable{ .update = HomeState.update, .view = HomeState.view };
+const home_screen = zz.Screen{ .ptr = &home_state, .vtable = &home_vtable, .title = "Home" };
+
+// ── Settings screen ─────────────────────────────────────────────────────
+
+const SettingsState = struct {
+    sound_on: bool = true,
+    theme_dark: bool = true,
+
+    fn update(ptr: *anyopaque, _: *zz.Context, key: zz.KeyEvent) zz.ScreenAction {
+        const self: *SettingsState = @ptrCast(@alignCast(ptr));
+        switch (key.key) {
+            .escape => return .pop,
+            .char => |c| switch (c) {
+                's' => self.sound_on = !self.sound_on,
+                't' => self.theme_dark = !self.theme_dark,
+                'r' => return .{ .push = confirm_screen },
+                'q' => return .quit,
+                else => {},
+            },
+            else => {},
+        }
+        return .none;
+    }
+
+    fn view(ptr: *anyopaque, _: *const zz.Context, alloc: std.mem.Allocator) anyerror![]const u8 {
+        const self: *SettingsState = @ptrCast(@alignCast(ptr));
+        return std.fmt.allocPrint(
+            alloc,
+            \\┌──────────────────────────────────────────┐
+            \\│  SETTINGS                                │
+            \\│                                          │
+            \\│  s  sound  [{s}]                         │
+            \\│  t  theme  [{s}]                         │
+            \\│                                          │
+            \\│  r      reset to defaults                │
+            \\│  esc    back                             │
+            \\│  q      quit                             │
+            \\└──────────────────────────────────────────┘
+        ,
+            .{
+                if (self.sound_on) "ON " else "OFF",
+                if (self.theme_dark) "DARK " else "LIGHT",
+            },
+        );
+    }
+};
+
+var settings_state = SettingsState{};
+const settings_vtable = zz.Screen.VTable{ .update = SettingsState.update, .view = SettingsState.view };
+const settings_screen = zz.Screen{ .ptr = &settings_state, .vtable = &settings_vtable, .title = "Settings" };
+
+// ── Modal Confirm screen ────────────────────────────────────────────────
+
+const ConfirmState = struct {
+    fn update(_: *anyopaque, _: *zz.Context, key: zz.KeyEvent) zz.ScreenAction {
+        switch (key.key) {
+            .char => |c| switch (c) {
+                'y', 'Y' => {
+                    settings_state = .{};
+                    return .pop;
+                },
+                'n', 'N' => return .pop,
+                else => {},
+            },
+            .escape => return .pop,
+            else => {},
+        }
+        return .none;
+    }
+
+    fn view(_: *anyopaque, _: *const zz.Context, alloc: std.mem.Allocator) anyerror![]const u8 {
+        return alloc.dupe(u8,
+            \\┌──────────────────┐
+            \\│  Reset settings? │
+            \\│                  │
+            \\│   [y] yes [n] no │
+            \\└──────────────────┘
+        );
+    }
+};
+
+var confirm_state = ConfirmState{};
+const confirm_vtable = zz.Screen.VTable{ .update = ConfirmState.update, .view = ConfirmState.view };
+const confirm_screen = zz.Screen{ .ptr = &confirm_state, .vtable = &confirm_vtable, .title = "Confirm", .modal = true };
+
+// ── Top-level model wrapping the stack ──────────────────────────────────
+
+const Model = struct {
+    stack: zz.ScreenStack,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+    };
+
+    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+        var stack = zz.ScreenStack.init(ctx.allocator);
+        stack.push(home_screen) catch return .quit;
+        self.* = .{ .stack = stack };
+        return .none;
+    }
+
+    pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
+        switch (msg) {
+            .key => |k| {
+                const result = self.stack.handleKey(ctx, k) catch return .none;
+                if (result == .quit) return .quit;
+                if (self.stack.isEmpty()) return .quit;
+            },
+        }
+        return .none;
+    }
+
+    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+        const view_str = self.stack.view(ctx, ctx.allocator) catch "Error";
+
+        var trail = std.array_list.Managed(u8).init(ctx.allocator);
+        defer trail.deinit();
+        const w = trail.writer();
+        w.writeAll("stack: ") catch {};
+        for (self.stack.stack.items, 0..) |s, i| {
+            if (i > 0) w.writeAll(" › ") catch {};
+            w.writeAll(s.title) catch {};
+        }
+
+        var trail_style = zz.Style{};
+        trail_style = trail_style.fg(zz.Color.gray(10));
+        trail_style = trail_style.inline_style(true);
+        const trail_str = trail_style.render(ctx.allocator, trail.items) catch "";
+
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ trail_str, view_str }) catch view_str;
+    }
+
+    pub fn deinit(self: *Model) void {
+        self.stack.deinit();
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var program = try zz.Program(Model).init(gpa.allocator());
+    defer program.deinit();
+
+    try program.run();
+}


### PR DESCRIPTION
## Summary

One runnable example per recently-merged feature, all wired into \`build.zig\` so they show up as \`run-*\` targets:

| Run target | Demonstrates |
|---|---|
| \`zig build run-braille_canvas\` | Animated bouncing ball + crosshair grid via direct pixel drawing |
| \`zig build run-rich_log\` | Live log stream with level filter (\`l\`), search (\`/\`), follow-mode |
| \`zig build run-screen_stack\` | Home → Settings → modal Confirm flow with stack breadcrumb |
| \`zig build run-action_system\` | One ActionRegistry feeding both auto-footer and Ctrl-P palette |
| \`zig build run-data_table\` | Wide table with two frozen columns and cell-level cursor |
| \`zig build run-dev_console\` | Emits log entries to \`dev_console.log\` and \`tcp/7878\` simultaneously |

Each example is a standalone Model so it doubles as a smoke test for the API and a copy-paste starting point.

## Test plan
- [x] \`zig build\` — all 44 examples compile (six new + 38 existing)
- [x] \`zig build test\` — full suite passes
- [x] Run each new example interactively and confirm keys behave