### PR TITLE
Fix segfaults in new examples (use persistent_allocator)

### DIFF
--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -16,7 +16,8 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var reg = zz.ActionRegistry.init(ctx.allocator);
+        const persistent = ctx.persistent_allocator;
+        var reg = zz.ActionRegistry.init(persistent);
 
         // Footer-visible actions.
         reg.register(.{
@@ -78,7 +79,7 @@ const Model = struct {
         reg.addAlias("counter.inc", .{ .key = .up }) catch {};
         reg.addAlias("counter.dec", .{ .key = .down }) catch {};
 
-        var palette = zz.CommandPalette.init(ctx.allocator) catch return .quit;
+        var palette = zz.CommandPalette.init(persistent) catch return .quit;
         palette.placeholder = "Search commands…";
 
         self.* = .{
@@ -89,12 +90,14 @@ const Model = struct {
             .last_action = "(none yet)",
         };
 
-        // Push every registered action into the palette.
-        var palette_cmds = std.array_list.Managed(zz.Command).init(ctx.allocator);
+        // Push every registered action into the palette. Allocate shortcut
+        // strings on the persistent allocator so they survive across frames
+        // (the palette stores them by reference).
+        var palette_cmds = std.array_list.Managed(zz.Command).init(persistent);
         defer palette_cmds.deinit();
         for (self.registry.actions.items) |a| {
-            const shortcut = if (a.binding) |b|
-                zz.ActionRegistry.formatKey(ctx.allocator, b) catch ""
+            const shortcut: []const u8 = if (a.binding) |b|
+                zz.ActionRegistry.formatKey(persistent, b) catch ""
             else
                 "";
             palette_cmds.append(.{

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -19,7 +19,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        const c = zz.components.BrailleCanvas.init(ctx.allocator, 50, 12) catch return .quit;
+        const c = zz.components.BrailleCanvas.init(ctx.persistent_allocator, 50, 12) catch return .quit;
         self.* = .{
             .canvas = c,
             .ball_x = 10,

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -36,7 +36,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var t = zz.components.DataTable.init(ctx.allocator);
+        var t = zz.components.DataTable.init(ctx.persistent_allocator);
         t.setColumns(&headers) catch return .quit;
         for (rows) |r| t.addRow(r) catch {};
         t.setSize(60, 15);

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -16,7 +16,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var log = zz.components.RichLog.init(ctx.allocator, 500);
+        var log = zz.components.RichLog.init(ctx.persistent_allocator, 500);
         log.setSize(80, 14);
         log.show_timestamps = true;
 
@@ -29,7 +29,7 @@ const Model = struct {
         self.* = .{
             .log = log,
             .counter = 0,
-            .search_term = std.array_list.Managed(u8).init(ctx.allocator),
+            .search_term = std.array_list.Managed(u8).init(ctx.persistent_allocator),
             .typing_search = false,
         };
         return .{ .every = 700 * std.time.ns_per_ms };

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -141,7 +141,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var stack = zz.ScreenStack.init(ctx.allocator);
+        var stack = zz.ScreenStack.init(ctx.persistent_allocator);
         stack.push(home_screen) catch return .quit;
         self.* = .{ .stack = stack };
         return .none;


### PR DESCRIPTION
## Summary

Five of the six new examples from #91 crashed after the first frame:

| Example | Crash site |
|---|---|
| \`braille_canvas\` | \`braille_canvas.zig:329\` rendering cell style |
| \`rich_log\` | \`rich_log.zig:280\` indexing entries |
| \`screen_stack\` | \`screen_stack.zig:156\` calling vtable.update |
| \`action_system\` | \`action.zig:138\` iterating actions |
| \`data_table\` | \`data_table.zig:284\` reading column width |

### Root cause

I initialized component state with \`ctx.allocator\` — that's the **per-frame arena** which resets every render. Component internals (array lists of rows, entries, columns, etc.) ended up pointing at freed memory after the first \`render()\`.

### Fix

Switch all long-lived component initialization to \`ctx.persistent_allocator\`, matching the pattern already used by \`examples/file_browser.zig\`. Also allocate the palette \`shortcut\` strings on persistent in \`action_system\` since \`CommandPalette\` stores command structs by reference.

## Base branch

This PR targets \`feature/examples-batch-7\` (#91). Once merged there, #91 will have working examples.

## Test plan
- [x] \`zig build\` passes
- [x] \`zig build test\` — full suite passes
- [x] All six examples run for 3+ seconds and exit cleanly on \`q\` — no crashes