### PR TITLE
Fix example crashes: allocator misuse and integer underflow

### DIFF
--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -16,7 +16,8 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var reg = zz.ActionRegistry.init(ctx.allocator);
+        const persistent = ctx.persistent_allocator;
+        var reg = zz.ActionRegistry.init(persistent);
 
         // Footer-visible actions.
         reg.register(.{
@@ -78,7 +79,7 @@ const Model = struct {
         reg.addAlias("counter.inc", .{ .key = .up }) catch {};
         reg.addAlias("counter.dec", .{ .key = .down }) catch {};
 
-        var palette = zz.CommandPalette.init(ctx.allocator) catch return .quit;
+        var palette = zz.CommandPalette.init(persistent) catch return .quit;
         palette.placeholder = "Search commands…";
 
         self.* = .{
@@ -89,12 +90,14 @@ const Model = struct {
             .last_action = "(none yet)",
         };
 
-        // Push every registered action into the palette.
-        var palette_cmds = std.array_list.Managed(zz.Command).init(ctx.allocator);
+        // Push every registered action into the palette. Allocate shortcut
+        // strings on the persistent allocator so they survive across frames
+        // (the palette stores them by reference).
+        var palette_cmds = std.array_list.Managed(zz.Command).init(persistent);
         defer palette_cmds.deinit();
         for (self.registry.actions.items) |a| {
-            const shortcut = if (a.binding) |b|
-                zz.ActionRegistry.formatKey(ctx.allocator, b) catch ""
+            const shortcut: []const u8 = if (a.binding) |b|
+                zz.ActionRegistry.formatKey(persistent, b) catch ""
             else
                 "";
             palette_cmds.append(.{

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -35,8 +35,11 @@ const Model = struct {
                 .char => |c| switch (c) {
                     'q' => return .quit,
                     's' => {
+                        // Don't relaunch while tasks are still running — that
+                        // confuses the completion counter and can leak threads.
+                        if (self.tasks_launched != 0) return .none;
                         self.status = "Tasks running...";
-                        // Spawn tasks using perform (synchronous simulation)
+                        self.results = .{ "pending...", "pending...", "pending..." };
                         _ = self.async_runner.spawn(&task1);
                         _ = self.async_runner.spawn(&task2);
                         _ = self.async_runner.spawn(&task3);
@@ -56,7 +59,9 @@ const Model = struct {
                         .task_complete => |tr| {
                             if (tr.id < 3) {
                                 self.results[tr.id] = tr.value;
-                                self.tasks_launched -= 1;
+                                // Saturating: if a stray duplicate event
+                                // arrives we don't underflow.
+                                self.tasks_launched -|= 1;
                                 if (self.tasks_launched == 0) {
                                     self.status = "All tasks complete!";
                                 }

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -19,7 +19,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        const c = zz.components.BrailleCanvas.init(ctx.allocator, 50, 12) catch return .quit;
+        const c = zz.components.BrailleCanvas.init(ctx.persistent_allocator, 50, 12) catch return .quit;
         self.* = .{
             .canvas = c,
             .ball_x = 10,

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -36,7 +36,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var t = zz.components.DataTable.init(ctx.allocator);
+        var t = zz.components.DataTable.init(ctx.persistent_allocator);
         t.setColumns(&headers) catch return .quit;
         for (rows) |r| t.addRow(r) catch {};
         t.setSize(60, 15);

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -16,7 +16,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var log = zz.components.RichLog.init(ctx.allocator, 500);
+        var log = zz.components.RichLog.init(ctx.persistent_allocator, 500);
         log.setSize(80, 14);
         log.show_timestamps = true;
 
@@ -29,7 +29,7 @@ const Model = struct {
         self.* = .{
             .log = log,
             .counter = 0,
-            .search_term = std.array_list.Managed(u8).init(ctx.allocator),
+            .search_term = std.array_list.Managed(u8).init(ctx.persistent_allocator),
             .typing_search = false,
         };
         return .{ .every = 700 * std.time.ns_per_ms };

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -141,7 +141,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        var stack = zz.ScreenStack.init(ctx.allocator);
+        var stack = zz.ScreenStack.init(ctx.persistent_allocator);
         stack.push(home_screen) catch return .quit;
         self.* = .{ .stack = stack };
         return .none;


### PR DESCRIPTION
## Summary

Re-apply the fixes from PR #92, which never reached main. (#92 was based on \`feature/examples-batch-7\`; that branch was merged into main before #92 was merged into the feature branch, so the fixes ended up orphaned.)

### Bug 1 — Allocator misuse (5 examples)

Component state was initialized with \`ctx.allocator\` — the per-frame arena that resets every render — instead of \`ctx.persistent_allocator\`. The internal \`array_list\` storage pointed at freed memory after the first \`render()\`, segfaulting on the second frame.

| File | Crash site |
|---|---|
| \`braille_canvas.zig\` | \`braille_canvas.zig:329\` rendering cell style |
| \`data_table.zig\` | \`data_table.zig:284\` reading column width |
| \`rich_log.zig\` | \`rich_log.zig:280\` indexing entries |
| \`screen_stack.zig\` | \`screen_stack.zig:156\` calling vtable.update |
| \`action_system.zig\` | \`action.zig:138\` iterating actions |

Switched all per-component init to \`ctx.persistent_allocator\`, matching the pattern in \`examples/file_browser.zig\`. Also moved the palette \`shortcut\` string allocations to persistent in \`action_system\` since \`CommandPalette\` stores command structs by reference.

### Bug 2 — \`async_tasks\` integer underflow

Pressing \`s\` to relaunch while previous tasks were still in-flight reset \`tasks_launched\` to 3, but the **old** generation's completion events kept arriving and decremented \`tasks_launched\` past zero — \`u8\` underflow panic on the fourth completion.

Two-part fix:
1. Guard against re-launch while \`tasks_launched != 0\` (early return)
2. Saturating subtraction (\`-|=\`) so any stray duplicate event can't underflow

## Test plan
- [x] \`zig build\` passes
- [x] \`zig build test\` — full suite passes
- [x] All six fixed examples run cleanly under random-keystroke smoke tests
- [x] \`async_tasks\` stress-tested with multiple rapid \`s\` presses