### PR TITLE
CommandPalette owns its command strings

### DIFF
--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -90,24 +90,10 @@ const Model = struct {
             .last_action = "(none yet)",
         };
 
-        // Push every registered action into the palette. Allocate shortcut
-        // strings on the persistent allocator so they survive across frames
-        // (the palette stores them by reference).
-        var palette_cmds = std.array_list.Managed(zz.Command).init(persistent);
-        defer palette_cmds.deinit();
-        for (self.registry.actions.items) |a| {
-            const shortcut: []const u8 = if (a.binding) |b|
-                zz.ActionRegistry.formatKey(persistent, b) catch ""
-            else
-                "";
-            palette_cmds.append(.{
-                .id = a.id,
-                .label = a.label,
-                .description = a.description,
-                .shortcut = shortcut,
-            }) catch {};
-        }
-        self.palette.setCommands(palette_cmds.items) catch {};
+        // One-shot integration: pull every registered action into the
+        // palette, formatting bindings as shortcut hints. The palette owns
+        // the strings, so no lifetime tracking on our side.
+        self.palette.setFromRegistry(&self.registry) catch {};
 
         return .none;
     }

--- a/src/components/command_palette.zig
+++ b/src/components/command_palette.zig
@@ -13,6 +13,8 @@ const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
 const measure = @import("../layout/measure.zig");
 const fuzzy = @import("../core/fuzzy.zig");
+const action_mod = @import("../core/action.zig");
+const ActionRegistry = action_mod.ActionRegistry;
 
 pub const Command = struct {
     id: []const u8,
@@ -122,26 +124,96 @@ pub const CommandPalette = struct {
     }
 
     pub fn deinit(self: *CommandPalette) void {
+        self.freeAllCommandStrings();
         self.commands.deinit();
         self.filtered.deinit();
         self.query.deinit();
     }
 
+    /// Add a command. The palette clones every string in `cmd` (id, label,
+    /// description, shortcut) so the caller is free to pass arena-allocated,
+    /// formatted, or otherwise short-lived strings — no lifetime tracking
+    /// required.
     pub fn addCommand(self: *CommandPalette, cmd: Command) !void {
-        try self.commands.append(cmd);
+        const owned = try self.cloneCommand(cmd);
+        errdefer self.freeCommand(owned);
+        try self.commands.append(owned);
         try self.rebuildFilter();
     }
 
+    /// Replace all commands. Each input command's strings are cloned. Old
+    /// commands are freed.
     pub fn setCommands(self: *CommandPalette, cmds: []const Command) !void {
+        self.freeAllCommandStrings();
         self.commands.clearRetainingCapacity();
-        try self.commands.appendSlice(cmds);
+        for (cmds) |cmd| {
+            const owned = try self.cloneCommand(cmd);
+            errdefer self.freeCommand(owned);
+            try self.commands.append(owned);
+        }
         try self.rebuildFilter();
     }
 
+    /// Convenience: load every enabled action from a registry, formatting its
+    /// binding as the shortcut hint. Cleaner than building Command structs by
+    /// hand and avoids the need to manage shortcut-string lifetimes.
+    pub fn setFromRegistry(self: *CommandPalette, registry: *const ActionRegistry) !void {
+        self.freeAllCommandStrings();
+        self.commands.clearRetainingCapacity();
+        for (registry.actions.items) |a| {
+            if (!a.enabled) continue;
+            const shortcut = if (a.binding) |b|
+                try ActionRegistry.formatKey(self.allocator, b)
+            else
+                try self.allocator.dupe(u8, "");
+            // shortcut is heap-owned; cloneCommand will dup again, so free
+            // the temporary after.
+            defer self.allocator.free(shortcut);
+
+            const owned = try self.cloneCommand(.{
+                .id = a.id,
+                .label = a.label,
+                .description = a.description,
+                .shortcut = shortcut,
+            });
+            errdefer self.freeCommand(owned);
+            try self.commands.append(owned);
+        }
+        try self.rebuildFilter();
+    }
+
+    /// Reset the typed query and cursor without touching the command list.
     pub fn clear(self: *CommandPalette) !void {
         self.query.clearRetainingCapacity();
         self.cursor = 0;
         try self.rebuildFilter();
+    }
+
+    fn cloneCommand(self: *CommandPalette, cmd: Command) !Command {
+        const id = try self.allocator.dupe(u8, cmd.id);
+        errdefer self.allocator.free(id);
+        const label = try self.allocator.dupe(u8, cmd.label);
+        errdefer self.allocator.free(label);
+        const description = try self.allocator.dupe(u8, cmd.description);
+        errdefer self.allocator.free(description);
+        const shortcut = try self.allocator.dupe(u8, cmd.shortcut);
+        return .{
+            .id = id,
+            .label = label,
+            .description = description,
+            .shortcut = shortcut,
+        };
+    }
+
+    fn freeCommand(self: *CommandPalette, cmd: Command) void {
+        self.allocator.free(cmd.id);
+        self.allocator.free(cmd.label);
+        self.allocator.free(cmd.description);
+        self.allocator.free(cmd.shortcut);
+    }
+
+    fn freeAllCommandStrings(self: *CommandPalette) void {
+        for (self.commands.items) |c| self.freeCommand(c);
     }
 
     /// Returns the currently highlighted command, if any.


### PR DESCRIPTION
## Summary

Better fix for the leak that PR #94 patched in user code: solve it in the library so no caller has to think about it.

### The real problem

\`CommandPalette\` stored \`Command\` structs verbatim — \`id\`, \`label\`, \`description\`, and \`shortcut\` were all borrowed slices. That forced every caller to keep the source strings alive for as long as the palette existed, and to free them on shutdown. Easy to get wrong: the \`action_system\` example leaked 8 shortcut strings on exit until PR #94 added a manual ownership tracker on the user side.

That workaround should never have been the caller's job. Other widgets in the codebase (\`Table\`, \`List\`, \`Tree\`) all clone their content; \`CommandPalette\` was the odd one out.

### Library changes

- \`addCommand\` and \`setCommands\` now \`dupe\` every string into the palette's allocator
- \`deinit\` frees them
- New \`setFromRegistry(*const ActionRegistry)\` that wires the registry → palette in one call, formatting bindings as shortcut hints

### Example collapses

\`action_system.zig\` loses ~17 lines of manual \`palette_cmds\` building plus the ownership workaround, replaced by:

\`\`\`zig
self.palette.setFromRegistry(&self.registry) catch {};
\`\`\`

## Test plan
- [x] \`zig build\` passes
- [x] \`zig build test\` — full suite passes
- [x] \`./zig-out/bin/action_system\` then \`q\` — zero \`memory address … leaked\` reports
- [x] Stress test: open palette, run a command, open again, run another, cancel — zero leaks across multiple set/clear cycles