### PR TITLE
Fix/writergate

### DIFF
--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -3,6 +3,7 @@
 //! and the suggestForeground helper for picking readable colors.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const ColorPair = struct {
@@ -48,8 +49,8 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        var result = std.array_list.Managed(u8).init(ctx.allocator);
-        const w = result.writer();
+        var result: Writer.Allocating = .init(ctx.allocator);
+        const w = &result.writer;
 
         // Title
         var title_s = zz.Style{};

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -2,6 +2,7 @@
 //! Demonstrates tweens with various easing functions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -91,8 +92,8 @@ const Model = struct {
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
 
-        var buf = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = buf.writer();
+        var buf: Writer.Allocating = .init(ctx.allocator);
+        const writer = &buf.writer;
         writer.writeAll(title) catch {};
         writer.writeAll("\n\n") catch {};
 

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -12,7 +12,7 @@ const zig_source =
     \\    defer _ = gpa.deinit();
     \\
     \\    const allocator = gpa.allocator();
-    \\    var list = std.ArrayList(u32).init(allocator);
+    \\    var list = std.std.array_list.Managed(u32).init(allocator);
     \\    defer list.deinit();
     \\
     \\    // Add some numbers

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -2,6 +2,7 @@
 //! Demonstrates a popup context menu triggered by keyboard.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Action = enum { cut, copy, paste, delete, select_all, properties };
@@ -89,8 +90,8 @@ const Model = struct {
         const title = title_style.render(ctx.allocator, "Context Menu Example") catch "Context Menu";
 
         // File list
-        var list_buf = std.array_list.Managed(u8).init(ctx.allocator);
-        const lw = list_buf.writer();
+        var list_buf: Writer.Allocating = .init(ctx.allocator);
+        const lw = &list_buf.writer;
         for (self.items, 0..) |item, i| {
             if (i > 0) lw.writeByte('\n') catch {};
             if (i == self.selected) {

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -2,6 +2,7 @@
 //! Demonstrates mouse tracking, hit testing, and interactive buttons.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -106,8 +107,8 @@ const Model = struct {
         ) catch "";
 
         // Render buttons
-        var buttons_line = std.array_list.Managed(u8).init(ctx.allocator);
-        const bw = buttons_line.writer();
+        var buttons_line: Writer.Allocating = .init(ctx.allocator);
+        const bw = &buttons_line.writer;
         for (&self.buttons, 0..) |*btn, i| {
             if (i > 0) bw.writeAll("  ") catch {};
             var s = zz.Style{};

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -2,6 +2,7 @@
 //! Three-screen flow: Home → Settings → modal Confirm dialog.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 // ── Home screen ─────────────────────────────────────────────────────────
@@ -161,9 +162,9 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const view_str = self.stack.view(ctx, ctx.allocator) catch "Error";
 
-        var trail = std.array_list.Managed(u8).init(ctx.allocator);
+        var trail: Writer.Allocating = .init(ctx.allocator);
         defer trail.deinit();
-        const w = trail.writer();
+        const w = &trail.writer;
         w.writeAll("stack: ") catch {};
         for (self.stack.stack.items, 0..) |s, i| {
             if (i > 0) w.writeAll(" › ") catch {};
@@ -173,7 +174,7 @@ const Model = struct {
         var trail_style = zz.Style{};
         trail_style = trail_style.fg(zz.Color.gray(10));
         trail_style = trail_style.inline_style(true);
-        const trail_str = trail_style.render(ctx.allocator, trail.items) catch "";
+        const trail_str = trail_style.render(ctx.allocator, trail.writer.buffered()) catch "";
 
         return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ trail_str, view_str }) catch view_str;
     }

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -2,6 +2,7 @@
 //! Comprehensive multi-tab application demonstrating ALL framework features.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Tab = enum {
@@ -511,8 +512,8 @@ const Model = struct {
     }
 
     fn renderTabBar(self: *const Model, ctx: *const zz.Context) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(ctx.allocator);
+        const writer = &result.writer;
 
         const tabs = [_]Tab{ .dashboard, .charts, .data, .files, .editor, .unicode };
         for (tabs, 0..) |tab, i| {
@@ -578,15 +579,12 @@ const Model = struct {
         const sparkline_row = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ spark_label, sparkline_view });
 
         // Spinner
-        const spinner_view = if (self.progress.isComplete())
-            blk: {
-                var done_style = zz.Style{};
-                done_style = done_style.fg(zz.Color.green());
-                done_style = done_style.inline_style(true);
-                break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
-            }
-        else
-            try self.spinner.viewWithTitle(ctx.allocator, "Processing...");
+        const spinner_view = if (self.progress.isComplete()) blk: {
+            var done_style = zz.Style{};
+            done_style = done_style.fg(zz.Color.green());
+            done_style = done_style.inline_style(true);
+            break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
+        } else try self.spinner.viewWithTitle(ctx.allocator, "Processing...");
 
         // Notifications
         const notif_view = try self.notifications.view(ctx.allocator);

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -2,6 +2,7 @@
 //! Demonstrates the List component with item selection.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -148,8 +149,8 @@ const Model = struct {
         const title = title_style.render(ctx.allocator, "Todo List") catch "Todo List";
 
         // Build todo list display using filtered_indices
-        var list_content = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = list_content.writer();
+        var list_content: Writer.Allocating = .init(ctx.allocator);
+        const writer = &list_content.writer;
 
         // Show filter if enabled
         if (self.list.filter_enabled) {

--- a/src/accessibility.zig
+++ b/src/accessibility.zig
@@ -3,6 +3,7 @@
 //! and semantic role annotations for terminal UIs.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const Color = @import("style/color.zig").Color;
 
 /// WCAG 2.1 contrast ratio levels.
@@ -119,30 +120,30 @@ pub const AccessibleLabel = struct {
 
     /// Format an accessible description string for screen readers.
     pub fn format(self: AccessibleLabel, allocator: std.mem.Allocator) ![]const u8 {
-        var parts = std.array_list.Managed(u8).init(allocator);
-        const w = parts.writer();
+        var parts: Writer.Allocating = .init(allocator);
+        const w = &parts.writer;
 
         if (self.role != .none) {
             try w.writeAll(self.role.label());
         }
 
         if (self.name.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(": ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(": ");
             try w.writeAll(self.name);
         }
 
         if (self.value.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(", ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(", ");
             try w.writeAll(self.value);
         }
 
         if (self.state.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(", ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(", ");
             try w.writeAll(self.state);
         }
 
         if (self.description.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(" - ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(" - ");
             try w.writeAll(self.description);
         }
 

--- a/src/components/braille_canvas.zig
+++ b/src/components/braille_canvas.zig
@@ -9,6 +9,7 @@
 //! caller already knows pixel coordinates.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -300,8 +301,8 @@ pub const BrailleCanvas = struct {
             }
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const w = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const w = &result.writer;
 
         var row: usize = 0;
         while (row < self.cell_height) : (row += 1) {

--- a/src/components/breadcrumb.zig
+++ b/src/components/breadcrumb.zig
@@ -5,6 +5,7 @@
 //! the rendered path would exceed a max width.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -127,8 +128,8 @@ pub const Breadcrumb = struct {
     }
 
     fn renderTruncated(self: *const Breadcrumb, allocator: std.mem.Allocator, head: usize, tail: usize) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const head_slice = self.crumbs.items[0..head];
         const tail_slice = self.crumbs.items[self.crumbs.items.len - tail ..];
@@ -169,8 +170,8 @@ pub const Breadcrumb = struct {
     }
 
     fn renderCrumbs(self: *const Breadcrumb, allocator: std.mem.Allocator, items: []const Crumb) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (items, 0..) |c, i| {
             if (i > 0) {

--- a/src/components/calendar.zig
+++ b/src/components/calendar.zig
@@ -3,6 +3,7 @@
 //! Fully customizable: styles, labels, symbols, layout.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const keys = @import("../input/keys.zig");
@@ -185,8 +186,8 @@ pub const Calendar = struct {
     }
 
     pub fn view(self: *const Calendar, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const cw: usize = @max(2, self.cell_width);
 
@@ -261,7 +262,7 @@ pub const Calendar = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn padCenter(allocator: std.mem.Allocator, text: []const u8, target: usize) []const u8 {

--- a/src/components/chart.zig
+++ b/src/components/chart.zig
@@ -1,6 +1,7 @@
 //! Cartesian chart widget with axes, legend, and multiple datasets.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const charting = @import("charting.zig");
 const canvas_mod = @import("canvas.zig");
 const join = @import("../layout/join.zig");
@@ -392,8 +393,8 @@ pub const Chart = struct {
 
     fn renderPlotRow(self: *const Chart, allocator: std.mem.Allocator, row_index: usize, plot_line: []const u8, plot_height: usize, y_label_width: usize, y_ticks: *const TickSet) ![]const u8 {
         _ = plot_height;
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.y_axis.show_labels) {
             const label = y_ticks.labelForRow(row_index) orelse "";
@@ -415,8 +416,8 @@ pub const Chart = struct {
     }
 
     fn renderXAxisLineRow(self: *const Chart, allocator: std.mem.Allocator, plot_width: usize, y_label_width: usize) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.y_axis.show_labels) {
             for (0..y_label_width) |_| try writer.writeByte(' ');
@@ -574,8 +575,8 @@ const GridOrientation = enum { vertical, horizontal };
 
 fn renderPaddedLabel(allocator: std.mem.Allocator, label: []const u8, width: usize, style: Style) ![]const u8 {
     const label_width = measure.width(label);
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     const padding = width -| label_width;
     for (0..padding) |_| try writer.writeByte(' ');

--- a/src/components/charting.zig
+++ b/src/components/charting.zig
@@ -1,6 +1,7 @@
 //! Shared plotting primitives for chart-like components.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 const style_mod = @import("../style/style.zig");
 
@@ -179,8 +180,8 @@ pub const CellBuffer = struct {
     }
 
     pub fn render(self: *const CellBuffer, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var glyph_buf: [4]u8 = undefined;
 

--- a/src/components/checkbox.zig
+++ b/src/components/checkbox.zig
@@ -2,6 +2,7 @@
 //! Standalone boolean toggle and multi-select checkbox group.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -98,8 +99,8 @@ pub const Checkbox = struct {
     }
 
     pub fn view(self: *const Checkbox, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const symbol = if (self.checked) self.checked_symbol else self.unchecked_symbol;
         const sym_style = if (!self.enabled)
@@ -375,8 +376,8 @@ pub fn CheckboxGroup(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             var rendered: usize = 0;
             while (rendered < self.height) : (rendered += 1) {

--- a/src/components/code_view.zig
+++ b/src/components/code_view.zig
@@ -2,6 +2,7 @@
 //! Provides keyword-based highlighting for common languages.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -89,8 +90,8 @@ pub const CodeView = struct {
     };
 
     pub fn view(self: *const CodeView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var lines = std.mem.splitScalar(u8, self.source, '\n');
         var line_num: usize = self.start_line;
@@ -121,14 +122,14 @@ pub const CodeView = struct {
             line_num += 1;
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn highlightLine(self: *const CodeView, allocator: std.mem.Allocator, line: []const u8, in_multiline: *bool) []const u8 {
         if (self.language == .plain) return line;
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var i: usize = 0;
         while (i < line.len) {
@@ -211,7 +212,7 @@ pub const CodeView = struct {
             i += 1;
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn isLineComment(lang: Language, line: []const u8, pos: usize) bool {

--- a/src/components/command_palette.zig
+++ b/src/components/command_palette.zig
@@ -7,6 +7,7 @@
 //! back selected().
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -284,9 +285,9 @@ pub const CommandPalette = struct {
     }
 
     pub fn view(self: *const CommandPalette, allocator: std.mem.Allocator) ![]const u8 {
-        var inner = std.array_list.Managed(u8).init(allocator);
+        var inner: Writer.Allocating = .init(allocator);
         defer inner.deinit();
-        const w = inner.writer();
+        const w = &inner.writer;
 
         // Input row.
         const prompt_styled = try self.prompt_style.render(allocator, self.prompt);
@@ -318,7 +319,7 @@ pub const CommandPalette = struct {
                 if (i > start) try w.writeByte('\n');
                 const is_sel = i == self.cursor;
                 const cmd = self.commands.items[self.filtered.items[i]];
-                try self.renderRow(allocator, w.any(), cmd, is_sel);
+                try self.renderRow(allocator, w, cmd, is_sel);
             }
         }
 
@@ -334,7 +335,7 @@ pub const CommandPalette = struct {
     fn renderRow(
         self: *const CommandPalette,
         allocator: std.mem.Allocator,
-        w: std.io.AnyWriter,
+        w: *Writer,
         cmd: Command,
         is_sel: bool,
     ) !void {

--- a/src/components/confirm.zig
+++ b/src/components/confirm.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const keys = @import("../input/keys.zig");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -118,8 +119,8 @@ pub const Confirm = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result_buf = std.array_list.Managed(u8).init(allocator);
-        const writer = result_buf.writer();
+        var result_buf: Writer.Allocating = .init(allocator);
+        const writer = &result_buf.writer;
 
         // Prompt
         const styled_prompt = try self.prompt_style.render(allocator, self.prompt_text);

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -2,6 +2,7 @@
 //! Popup menu triggered by keyboard shortcut or mouse, positioned at a target location.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -288,8 +289,8 @@ pub fn ContextMenu(comptime Action: type) type {
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
             if (!self.visible) return try allocator.dupe(u8, "");
 
-            var result = std.array_list.Managed(u8).init(allocator);
-            const w = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const w = &result.writer;
 
             const inner_width = self.calcWidth();
 
@@ -350,11 +351,11 @@ pub fn ContextMenu(comptime Action: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeIndent(_: *const Self, writer: anytype, count: usize) !void {
+        fn writeIndent(_: *const Self, writer: *Writer, count: usize) !void {
             for (0..count) |_| try writer.writeByte(' ');
         }
 
-        fn writeBorder(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorder(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);
@@ -378,7 +379,7 @@ pub fn ContextMenu(comptime Action: type) type {
             try writer.writeAll(try bs.render(allocator, cr));
         }
 
-        fn writeBorderChar(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderChar(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -316,8 +316,8 @@ pub fn ContextMenu(comptime Action: type) type {
                         const is_active = (i == self.cursor);
                         const s = if (!a.enabled) self.disabled_style else if (is_active) self.active_style else self.item_style;
 
-                        var line = std.array_list.Managed(u8).init(allocator);
-                        const lw = line.writer();
+                        var line: Writer.Allocating = .init(allocator);
+                        const lw = &line.writer;
                         try lw.writeByte(' ');
                         try lw.writeAll(a.label);
 

--- a/src/components/data_table.zig
+++ b/src/components/data_table.zig
@@ -11,6 +11,7 @@
 //! (database results, log fields, CSV files).
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
@@ -291,16 +292,16 @@ pub const DataTable = struct {
     }
 
     pub fn view(self: *DataTable, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const visible_cols = try self.computeVisibleColumns(allocator);
         defer allocator.free(visible_cols);
 
         if (self.show_header) {
-            try self.renderRow(allocator, w.any(), null, visible_cols, true);
+            try self.renderRow(allocator, w, null, visible_cols, true);
             try w.writeByte('\n');
-            try self.renderHeaderSeparator(allocator, w.any(), visible_cols);
+            try self.renderHeaderSeparator(allocator, w, visible_cols);
             try w.writeByte('\n');
         }
 
@@ -311,7 +312,7 @@ pub const DataTable = struct {
         for (start..end) |row_idx| {
             if (!first) try w.writeByte('\n');
             first = false;
-            try self.renderRow(allocator, w.any(), row_idx, visible_cols, false);
+            try self.renderRow(allocator, w, row_idx, visible_cols, false);
         }
 
         return out.toOwnedSlice();
@@ -340,7 +341,7 @@ pub const DataTable = struct {
         return list.toOwnedSlice();
     }
 
-    fn renderRow(self: *const DataTable, allocator: std.mem.Allocator, writer: std.io.AnyWriter, row_idx: ?usize, visible_cols: []const usize, is_header: bool) !void {
+    fn renderRow(self: *const DataTable, allocator: std.mem.Allocator, writer: *Writer, row_idx: ?usize, visible_cols: []const usize, is_header: bool) !void {
         for (visible_cols, 0..) |col_idx, i| {
             // Frozen separator.
             if (self.frozen_columns > 0 and i == self.frozen_columns) {
@@ -378,7 +379,7 @@ pub const DataTable = struct {
         }
     }
 
-    fn renderHeaderSeparator(self: *const DataTable, allocator: std.mem.Allocator, writer: std.io.AnyWriter, visible_cols: []const usize) !void {
+    fn renderHeaderSeparator(self: *const DataTable, allocator: std.mem.Allocator, writer: *Writer, visible_cols: []const usize) !void {
         for (visible_cols, 0..) |col_idx, i| {
             if (self.frozen_columns > 0 and i == self.frozen_columns) {
                 const sep = try self.frozen_separator_style.render(allocator, "─┼─");

--- a/src/components/diff_view.zig
+++ b/src/components/diff_view.zig
@@ -2,6 +2,7 @@
 //! Displays unified or side-by-side text diffs with syntax coloring.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -76,8 +77,8 @@ pub const DiffView = struct {
     }
 
     fn renderUnified(self: *const DiffView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Header
         const hdr = std.fmt.allocPrint(allocator, "--- {s}\n+++ {s}", .{ self.old_label, self.new_label }) catch "";
@@ -129,16 +130,17 @@ pub const DiffView = struct {
         }
 
         // Trim trailing newline
-        if (result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
+        var array = result.toArrayList();
+        if (array.items.len > 0 and array.items[array.items.len - 1] == '\n') {
+            _ = array.pop();
         }
 
-        return result.items;
+        return array.items;
     }
 
     fn renderSideBySide(self: *const DiffView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const old_lines = splitLines(allocator, self.old_text);
         const new_lines = splitLines(allocator, self.new_text);
@@ -185,11 +187,12 @@ pub const DiffView = struct {
             }
         }
 
-        if (result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
+        var array = result.toArrayList();
+        if (array.items.len > 0 and array.items[array.items.len - 1] == '\n') {
+            _ = array.pop();
         }
 
-        return result.items;
+        return array.items;
     }
 
     fn padRight(allocator: std.mem.Allocator, text: []const u8, target: usize) []const u8 {

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -583,8 +583,8 @@ pub fn Dropdown(comptime T: type) type {
 
                 const item_idx = visible[idx];
                 const item = self.items.items[item_idx];
-                var line = std.array_list.Managed(u8).init(allocator);
-                const line_writer = line.writer();
+                var line: Writer.Allocating = .init(allocator);
+                const line_writer = &line.writer;
 
                 try line_writer.writeByte(' ');
 

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const keys = @import("../input/keys.zig");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -485,8 +486,8 @@ pub fn Dropdown(comptime T: type) type {
         // ── Rendering ───────────────────────────────────
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Label
             if (self.label.len > 0) {
@@ -667,7 +668,7 @@ pub fn Dropdown(comptime T: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeBorderLine(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorderLine(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             const bc = self.border_chars;
             var border_style = style_mod.Style{};
             border_style = border_style.fg(self.border_fg);
@@ -696,7 +697,7 @@ pub fn Dropdown(comptime T: type) type {
             try writer.writeAll(styled_r);
         }
 
-        fn writeBorderSide(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderSide(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var border_style = style_mod.Style{};
             border_style = border_style.fg(self.border_fg);
             border_style = border_style.inline_style(true);
@@ -709,7 +710,7 @@ pub fn Dropdown(comptime T: type) type {
             try writer.writeAll(styled);
         }
 
-        fn writePadding(_: *const Self, writer: anytype, count: usize) !void {
+        fn writePadding(_: *const Self, writer: *Writer, count: usize) !void {
             for (0..count) |_| {
                 try writer.writeByte(' ');
             }

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -2,6 +2,7 @@
 //! Allows browsing directories and selecting files.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const builtin = @import("builtin");
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
@@ -355,8 +356,8 @@ pub const FilePicker = struct {
 
     /// Render the file picker
     pub fn view(self: *const FilePicker, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Current path header
         const path_styled = try self.path_style.render(allocator, self.current_path.items);

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -2,6 +2,7 @@
 //! Composes multiple input fields with focus management, labels, and validation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -205,8 +206,8 @@ pub fn Form(comptime max_fields: usize) type {
 
         /// Render the form.
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Title
             if (self.title.len > 0) {

--- a/src/components/gauge.zig
+++ b/src/components/gauge.zig
@@ -2,6 +2,7 @@
 //! Supports bar, level meter, and block display styles with thresholds and gradients.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -101,8 +102,8 @@ pub const Gauge = struct {
         const bar_width: usize = self.width;
         const filled: usize = @intFromFloat(@as(f64, @floatFromInt(bar_width)) * pct);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Label
         if (self.label.len > 0) {
@@ -158,7 +159,7 @@ pub const Gauge = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn renderLevelMeter(self: *const Gauge, allocator: std.mem.Allocator) []const u8 {
@@ -166,8 +167,8 @@ pub const Gauge = struct {
         const levels: usize = 10;
         const filled: usize = @intFromFloat(@as(f64, @floatFromInt(levels)) * pct);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.label.len > 0) {
             writer.writeAll(self.label) catch {};
@@ -194,7 +195,7 @@ pub const Gauge = struct {
             writer.print(" {d:.0}%", .{pct * 100}) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn renderBlocks(self: *const Gauge, allocator: std.mem.Allocator) []const u8 {
@@ -205,8 +206,8 @@ pub const Gauge = struct {
         // Use shade characters based on intensity
         const shades = [_][]const u8{ " ", "\xe2\x96\x91", "\xe2\x96\x92", "\xe2\x96\x93", "\xe2\x96\x88" };
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.label.len > 0) {
             writer.writeAll(self.label) catch {};
@@ -234,7 +235,7 @@ pub const Gauge = struct {
             writer.print(" {d:.0}%", .{pct * 100}) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn colorForLevel(self: *const Gauge, level_pct: f64) Color {

--- a/src/components/heatmap.zig
+++ b/src/components/heatmap.zig
@@ -2,6 +2,7 @@
 //! Displays data as a colored grid with configurable color scales.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -139,8 +140,8 @@ pub const Heatmap = struct {
         if (self.rows == 0 or self.cols == 0) return "";
 
         const mm = self.getMinMax();
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Title
         if (self.title.len > 0) {
@@ -226,7 +227,7 @@ pub const Heatmap = struct {
             writer.writeAll(max_str) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn maxLabelWidth(labels: []const []const u8) usize {

--- a/src/components/help.zig
+++ b/src/components/help.zig
@@ -2,6 +2,7 @@
 //! Shows keyboard shortcuts and their descriptions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -117,8 +118,8 @@ pub const Help = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var total_width: usize = 0;
 
@@ -180,8 +181,8 @@ pub const Help = struct {
             max_key_width = @max(max_key_width, measure.width(binding.key));
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (self.bindings.items, 0..) |binding, i| {
             if (i > 0) try writer.writeByte('\n');

--- a/src/components/keybinding.zig
+++ b/src/components/keybinding.zig
@@ -2,6 +2,7 @@
 //! Provides structured key binding definitions with matching and help integration.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const Key = keys.Key;
 const KeyEvent = keys.KeyEvent;
@@ -23,8 +24,8 @@ pub const KeyBinding = struct {
 
     /// Get a display string for the key
     pub fn keyDisplay(self: *const KeyBinding, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.key_event.modifiers.ctrl) try writer.writeAll("ctrl+");
         if (self.key_event.modifiers.alt) try writer.writeAll("alt+");

--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -2,6 +2,7 @@
 //! Displays a list of items with selection and optional filtering.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -405,8 +406,8 @@ pub fn List(comptime T: type) type {
 
         /// Render the list
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Filter line
             if (self.filter_enabled) {

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -2,6 +2,7 @@
 //! Converts a subset of markdown to ANSI-styled text.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -126,8 +127,8 @@ pub const Markdown = struct {
 
     /// Render markdown text to styled terminal output.
     pub fn render(self: *const Markdown, allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var lines_iter = std.mem.splitScalar(u8, source, '\n');
         var in_code_block = false;
@@ -262,8 +263,8 @@ pub const Markdown = struct {
 
     /// Render inline formatting: **bold**, *italic*, `code`, [links](url)
     fn renderInline(self: *const Markdown, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var i: usize = 0;
         while (i < text.len) {

--- a/src/components/menu_bar.zig
+++ b/src/components/menu_bar.zig
@@ -2,6 +2,7 @@
 //! Horizontal menu bar with dropdown menus and keyboard navigation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -390,12 +391,12 @@ pub fn MenuBar(comptime Action: type) type {
         // ── Rendering ───────────────────────────────
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator, term_width: usize) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Render menu bar
-            var bar_content = std.array_list.Managed(u8).init(allocator);
-            const bar_writer = bar_content.writer();
+            var bar_content: Writer.Allocating = .init(allocator);
+            const bar_writer = &bar_content.writer;
 
             try bar_writer.writeAll(" ");
 
@@ -437,8 +438,8 @@ pub fn MenuBar(comptime Action: type) type {
         }
 
         fn renderDropdown(self: *const Self, allocator: std.mem.Allocator, menu: Menu) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const w = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const w = &result.writer;
 
             // Calculate width
             var max_label_width: usize = 0;
@@ -489,8 +490,8 @@ pub fn MenuBar(comptime Action: type) type {
                         const s = if (!a.enabled) self.item_disabled_style else if (is_active) self.item_active_style else self.item_style;
 
                         // Build line content
-                        var line = std.array_list.Managed(u8).init(allocator);
-                        const lw = line.writer();
+                        var line: Writer.Allocating = .init(allocator);
+                        const lw = &line.writer;
 
                         try lw.writeByte(' ');
 
@@ -537,7 +538,7 @@ pub fn MenuBar(comptime Action: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeBorder(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorder(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);
@@ -561,7 +562,7 @@ pub fn MenuBar(comptime Action: type) type {
             try writer.writeAll(try bs.render(allocator, cr));
         }
 
-        fn writeBorderChar(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderChar(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -39,6 +39,7 @@
 //! can be registered with a `FocusGroup`.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
@@ -452,8 +453,8 @@ pub const Modal = struct {
         pad_s = pad_s.inline_style(true);
         if (!self.content_bg.isNone()) pad_s = pad_s.bg(self.content_bg);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // ── Top border ──
         try writer.writeAll(try bdr_s.render(allocator, bc.top_left));
@@ -546,8 +547,8 @@ pub const Modal = struct {
             try self.writeEmptyInnerLine(allocator, writer, styled_left, styled_right, pad_s, inner_w);
 
             // Render button row content
-            var btn_buf = std.array_list.Managed(u8).init(allocator);
-            const btn_writer = btn_buf.writer();
+            var btn_buf: Writer.Allocating = .init(allocator);
+            const btn_writer = &btn_buf.writer;
 
             for (self.buttons[0..self.button_count], 0..) |maybe_btn, i| {
                 if (maybe_btn) |btn| {
@@ -610,7 +611,7 @@ pub const Modal = struct {
     fn writeEmptyInnerLine(
         self: *const Modal,
         allocator: std.mem.Allocator,
-        writer: anytype,
+        writer: *Writer,
         styled_left: []const u8,
         styled_right: []const u8,
         pad_s: style_mod.Style,

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -398,8 +398,8 @@ pub const Modal = struct {
         const modal_lines = modal_lines_list.items;
 
         // Build full-screen output
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..term_height) |row| {
             if (row > 0) try writer.writeByte('\n');

--- a/src/components/notification.zig
+++ b/src/components/notification.zig
@@ -2,6 +2,7 @@
 //! Displays auto-dismissing messages with severity levels.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -101,8 +102,8 @@ pub const Notification = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const visible_count = @min(self.messages.items.len, self.max_visible);
         const start = if (self.messages.items.len > self.max_visible)

--- a/src/components/paginator.zig
+++ b/src/components/paginator.zig
@@ -2,6 +2,7 @@
 //! Displays page indicators and handles navigation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -153,8 +154,8 @@ pub const Paginator = struct {
     }
 
     fn viewDots(self: *const Paginator, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..self.total_pages) |i| {
             if (i > 0) try writer.writeByte(' ');
@@ -177,8 +178,8 @@ pub const Paginator = struct {
     }
 
     fn viewCompact(self: *const Paginator, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Show limited range of pages
         const max_visible = 5;

--- a/src/components/progress.zig
+++ b/src/components/progress.zig
@@ -2,6 +2,7 @@
 //! Displays progress with customizable appearance.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -133,8 +134,8 @@ pub const Progress = struct {
 
     /// Render the progress bar
     pub fn view(self: *const Progress, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const ratio = if (self.total > 0) self.current / self.total else 0;
         const filled_width = @as(usize, @intFromFloat(ratio * @as(f64, @floatFromInt(self.width))));
@@ -190,8 +191,8 @@ pub const Progress = struct {
 
     /// Render with a label
     pub fn viewWithLabel(self: *const Progress, allocator: std.mem.Allocator, label: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         try writer.writeAll(label);
         try writer.writeAll(" ");

--- a/src/components/radio_group.zig
+++ b/src/components/radio_group.zig
@@ -2,6 +2,7 @@
 //! Single-select option group with radio button semantics.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -216,8 +217,8 @@ pub fn RadioGroup(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             var rendered: usize = 0;
             while (rendered < self.height) : (rendered += 1) {

--- a/src/components/rich_log.zig
+++ b/src/components/rich_log.zig
@@ -9,6 +9,7 @@
 //! is the right widget for a long-running app's persistent log/audit pane.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -262,8 +263,8 @@ pub const RichLog = struct {
     pub fn view(self: *RichLog, allocator: std.mem.Allocator) ![]const u8 {
         try self.refresh();
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const visible = self.visible.items;
         if (visible.len == 0) {
@@ -278,13 +279,13 @@ pub const RichLog = struct {
             if (!first) try w.writeByte('\n');
             first = false;
             const entry = self.entries.items[visible[row_idx]];
-            try self.renderEntry(allocator, w.any(), entry);
+            try self.renderEntry(allocator, w, entry);
         }
 
         return out.toOwnedSlice();
     }
 
-    fn renderEntry(self: *const RichLog, allocator: std.mem.Allocator, w: std.io.AnyWriter, entry: Entry) !void {
+    fn renderEntry(self: *const RichLog, allocator: std.mem.Allocator, w: *Writer, entry: Entry) !void {
         if (self.show_timestamps) {
             const ts = try formatTimestamp(allocator, entry.timestamp_ns);
             defer allocator.free(ts);
@@ -312,7 +313,7 @@ pub const RichLog = struct {
         }
     }
 
-    fn renderHighlighted(self: *const RichLog, allocator: std.mem.Allocator, w: std.io.AnyWriter, text: []const u8) !void {
+    fn renderHighlighted(self: *const RichLog, allocator: std.mem.Allocator, w: *Writer, text: []const u8) !void {
         const term = self.search_term.items;
         var rest = text;
         while (std.mem.indexOf(u8, rest, term)) |pos| {

--- a/src/components/slider.zig
+++ b/src/components/slider.zig
@@ -2,6 +2,7 @@
 //! Interactive numeric range input with keyboard control.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -170,8 +171,8 @@ pub const Slider = struct {
     }
 
     pub fn view(self: *const Slider, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Label
         if (self.label.len > 0) {

--- a/src/components/sortable_table.zig
+++ b/src/components/sortable_table.zig
@@ -2,6 +2,7 @@
 //! Extends basic table with column sorting and text filtering.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -199,8 +200,8 @@ pub fn SortableTable(comptime num_cols: usize) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) []const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Compute column widths
             var widths: [num_cols]usize = undefined;
@@ -280,7 +281,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
             cs = cs.inline_style(true);
             writer.writeAll(cs.render(allocator, count) catch count) catch {};
 
-            return result.items;
+            return result.toArrayList().items;
         }
 
         fn padTo(allocator: std.mem.Allocator, text: []const u8, target: usize, alignment: Align) []const u8 {

--- a/src/components/sparkline.zig
+++ b/src/components/sparkline.zig
@@ -1,6 +1,7 @@
 //! Sparkline component with configurable aggregation and styling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const charting = @import("charting.zig");
 const progress = @import("progress.zig");
 const style_mod = @import("../style/style.zig");
@@ -110,8 +111,8 @@ pub const Sparkline = struct {
         var visible = try self.bucketValues(allocator);
         defer visible.deinit();
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (visible.items.len == 0) {
             for (0..self.display_width) |_| try writer.writeAll(self.empty_char);
@@ -179,7 +180,7 @@ pub const Sparkline = struct {
         for (0..width) |bucket_index| {
             const start = @min(self.data.items.len, @as(usize, @intFromFloat(@floor(@as(f64, @floatFromInt(bucket_index)) * data_len_f / width_f))));
             const end = @min(self.data.items.len, @as(usize, @intFromFloat(@floor(@as(f64, @floatFromInt(bucket_index + 1)) * data_len_f / width_f))));
-            const slice = if (end > start) self.data.items[start..end] else self.data.items[start .. @min(self.data.items.len, start + 1)];
+            const slice = if (end > start) self.data.items[start..end] else self.data.items[start..@min(self.data.items.len, start + 1)];
             try buckets.append(summarize(slice, self.summary));
         }
 

--- a/src/components/spinner.zig
+++ b/src/components/spinner.zig
@@ -2,6 +2,7 @@
 //! Provides various spinner styles and customization options.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -97,8 +98,8 @@ pub const Spinner = struct {
 
     /// Render spinner with title
     pub fn viewWithTitle(self: *const Spinner, allocator: std.mem.Allocator, title: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const rendered_spinner = try self.view(allocator);
         try writer.writeAll(rendered_spinner);

--- a/src/components/status_bar.zig
+++ b/src/components/status_bar.zig
@@ -6,6 +6,7 @@
 //! position simultaneously.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -109,8 +110,8 @@ pub const StatusBar = struct {
         const cw = measure.width(center_str);
         const rw = measure.width(right_str);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         try writer.writeAll(left_str);
 
@@ -120,14 +121,14 @@ pub const StatusBar = struct {
             const target_start = (self.width -| cw) / 2;
             const start = @max(lw, target_start);
             const gap = start -| lw;
-            try self.writeGap(writer.any(), allocator, gap);
+            try self.writeGap(writer, allocator, gap);
             try writer.writeAll(center_str);
             const consumed = lw + gap + cw;
             const trailing = (self.width -| rw) -| consumed;
-            try self.writeGap(writer.any(), allocator, trailing);
+            try self.writeGap(writer, allocator, trailing);
         } else {
             const gap = (self.width -| rw) -| lw;
-            try self.writeGap(writer.any(), allocator, gap);
+            try self.writeGap(writer, allocator, gap);
         }
 
         try writer.writeAll(right_str);
@@ -136,8 +137,8 @@ pub const StatusBar = struct {
     }
 
     fn renderGroup(self: *const StatusBar, allocator: std.mem.Allocator, items: []const Segment) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
         for (items, 0..) |seg, i| {
             if (i > 0) {
                 if (self.separator.len > 0) {
@@ -159,7 +160,7 @@ pub const StatusBar = struct {
         return out.toOwnedSlice();
     }
 
-    fn writeGap(self: *const StatusBar, writer: std.io.AnyWriter, allocator: std.mem.Allocator, count: usize) !void {
+    fn writeGap(self: *const StatusBar, writer: *std.Io.Writer, allocator: std.mem.Allocator, count: usize) !void {
         if (count == 0) return;
         const spaces = try allocator.alloc(u8, count);
         defer allocator.free(spaces);

--- a/src/components/stepper.zig
+++ b/src/components/stepper.zig
@@ -5,6 +5,7 @@
 //! exposes methods for navigating through the flow.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -133,8 +134,8 @@ pub const Stepper = struct {
     }
 
     fn viewHorizontal(self: *const Stepper, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (self.steps.items, 0..) |step, i| {
             if (i > 0) {
@@ -170,8 +171,8 @@ pub const Stepper = struct {
     }
 
     fn viewVertical(self: *const Stepper, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (self.steps.items, 0..) |step, i| {
             if (i > 0) try w.writeByte('\n');

--- a/src/components/styled_list.zig
+++ b/src/components/styled_list.zig
@@ -2,6 +2,7 @@
 //! Non-interactive rendering-only list with bullet, numbered, roman, alphabet enumerators.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -76,8 +77,8 @@ pub const StyledList = struct {
 
     /// Render the list
     pub fn view(self: *const StyledList, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Track counters per depth level
         var counters: [16]usize = .{0} ** 16;
@@ -134,7 +135,7 @@ pub const StyledList = struct {
 pub fn toRoman(allocator: std.mem.Allocator, n: usize) ![]const u8 {
     if (n == 0) return try allocator.dupe(u8, "0");
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     const values = [_]usize{ 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
     const symbols = [_][]const u8{ "M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I" };
@@ -154,7 +155,7 @@ pub fn toRoman(allocator: std.mem.Allocator, n: usize) ![]const u8 {
 pub fn toAlpha(allocator: std.mem.Allocator, n: usize) ![]const u8 {
     if (n == 0) return try allocator.dupe(u8, "?");
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     var num = n - 1;
 
     while (true) {

--- a/src/components/tab_group.zig
+++ b/src/components/tab_group.zig
@@ -3,6 +3,7 @@
 //! type-erased view routing for multi-screen applications.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
 const style_mod = @import("../style/style.zig");
@@ -762,8 +763,8 @@ pub const TabGroup = struct {
             }
         }
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const writer = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const writer = &out.writer;
 
         if (start > 0) try writer.writeAll(left_marker);
         for (start..end) |i| {
@@ -794,8 +795,8 @@ pub const TabGroup = struct {
             return renderer(ctx, allocator, tab, state);
         }
 
-        var base = std.array_list.Managed(u8).init(allocator);
-        const writer = base.writer();
+        var base: Writer.Allocating = .init(allocator);
+        const writer = &base.writer;
 
         try writer.writeAll(self.tab_prefix);
         if (self.show_numbers) {
@@ -1055,8 +1056,8 @@ fn rangeWidthWithMarkers(parts: []const []const u8, separator: []const u8, start
 fn joinPieces(allocator: std.mem.Allocator, parts: []const []const u8, separator: []const u8) ![]const u8 {
     if (parts.len == 0) return allocator.dupe(u8, "");
 
-    var out = std.array_list.Managed(u8).init(allocator);
-    const writer = out.writer();
+    var out: Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
     for (parts, 0..) |part, i| {
         if (i > 0) try writer.writeAll(separator);
         try writer.writeAll(part);

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -255,8 +255,8 @@ pub fn Table(comptime num_cols: usize) type {
 
         /// Render the table
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             const widths = self.calculateWidths();
 

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -2,6 +2,7 @@
 //! Supports column headers, alignment, and styling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
 const Color = @import("../style/color.zig").Color;
@@ -323,7 +324,7 @@ pub fn Table(comptime num_cols: usize) type {
 
         fn writeRow(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             row: [num_cols][]const u8,
             widths: [num_cols]usize,
@@ -381,7 +382,7 @@ pub fn Table(comptime num_cols: usize) type {
 
         fn writeBorderLine(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             widths: [num_cols]usize,
             pos: BorderPosition,

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -2,6 +2,7 @@
 //! Provides text editing with multiple lines, cursor navigation, and scrolling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -543,8 +544,8 @@ pub const TextArea = struct {
 
     /// Render the text area
     pub fn view(self: *const TextArea, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const line_num_width: usize = if (self.line_numbers) 5 else 0;
         const text_width = self.width -| @as(u16, @intCast(line_num_width));
@@ -645,7 +646,7 @@ pub const TextArea = struct {
         return result.toOwnedSlice();
     }
 
-    fn renderPlaceholder(self: *const TextArea, writer: anytype, allocator: std.mem.Allocator, max_width: u16) !void {
+    fn renderPlaceholder(self: *const TextArea, writer: *Writer, allocator: std.mem.Allocator, max_width: u16) !void {
         const width_limit: usize = max_width;
         if (width_limit == 0) return;
 
@@ -679,7 +680,7 @@ pub const TextArea = struct {
 
     fn renderWrappedLineSegment(
         self: *const TextArea,
-        writer: anytype,
+        writer: *Writer,
         allocator: std.mem.Allocator,
         line: []const u8,
         line_idx: usize,
@@ -737,7 +738,7 @@ pub const TextArea = struct {
         }
     }
 
-    fn renderLine(self: *const TextArea, writer: anytype, allocator: std.mem.Allocator, line: []const u8, line_idx: usize, max_width: u16) !void {
+    fn renderLine(self: *const TextArea, writer: *Writer, allocator: std.mem.Allocator, line: []const u8, line_idx: usize, max_width: u16) !void {
         const is_cursor_line = line_idx == self.cursor_row;
 
         // Apply horizontal scroll

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -144,7 +144,7 @@ pub const TextArea = struct {
 
     /// Get the content as a string
     pub fn getValue(self: *const TextArea, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: std.array_list.Managed(u8) = .init(allocator);
 
         for (self.lines.items, 0..) |line, i| {
             if (i > 0) try result.append('\n');

--- a/src/components/text_input.zig
+++ b/src/components/text_input.zig
@@ -2,6 +2,7 @@
 //! Provides cursor navigation, text editing, and optional validation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -377,8 +378,8 @@ pub const TextInput = struct {
 
     /// Render the input to a string
     pub fn view(self: *const TextInput, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Write prompt
         if (self.prompt.len > 0) {
@@ -422,7 +423,7 @@ pub const TextInput = struct {
         return result.toOwnedSlice();
     }
 
-    fn renderWithCursor(self: *const TextInput, writer: anytype, allocator: std.mem.Allocator) !void {
+    fn renderWithCursor(self: *const TextInput, writer: *Writer, allocator: std.mem.Allocator) !void {
         // Text before cursor
         if (self.cursor > 0) {
             const before = try self.text_style.render(allocator, self.value.items[0..self.cursor]);

--- a/src/components/timer.zig
+++ b/src/components/timer.zig
@@ -2,6 +2,7 @@
 //! Displays time in various formats.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -197,8 +198,8 @@ pub const Timer = struct {
             },
         };
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Choose style based on state
         const active_style = if (self.isDanger())

--- a/src/components/toast.zig
+++ b/src/components/toast.zig
@@ -2,6 +2,7 @@
 //! Supports positioning, stacking, icons, borders, and auto-dismiss with countdown.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -210,9 +211,9 @@ pub const Toast = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: Writer.Allocating = .init(allocator);
         errdefer result.deinit();
-        const writer = result.writer();
+        const writer = &result.writer;
 
         const visible_count = @min(self.messages.items.len, self.max_visible);
 
@@ -280,9 +281,9 @@ pub const Toast = struct {
     fn renderSingleToast(self: *const Toast, allocator: std.mem.Allocator, msg: ToastMessage, current_ns: u64) ![]const u8 {
         const active_style = self.styleForLevel(msg.level);
 
-        var line = std.array_list.Managed(u8).init(allocator);
+        var line: Writer.Allocating = .init(allocator);
         errdefer line.deinit();
-        const lw = line.writer();
+        const lw = &line.writer;
 
         const icon = if (self.show_icons) switch (msg.level) {
             .info => self.info_icon,
@@ -407,9 +408,9 @@ pub const Toast = struct {
 
 fn alignLines(allocator: std.mem.Allocator, content: []const u8, alignment: style_mod.Align) ![]const u8 {
     const target_width = measure.maxLineWidth(content);
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: Writer.Allocating = .init(allocator);
     errdefer result.deinit();
-    const writer = result.writer();
+    const writer = &result.writer;
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     var first = true;

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -31,6 +31,7 @@
 //! - `Tooltip.shortcut(label, key)` — "Label  Ctrl+S" style tooltip
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
 const Color = @import("../style/color.zig").Color;
@@ -216,8 +217,8 @@ pub const Tooltip = struct {
         pad_s = pad_s.inline_style(true);
         if (!self.content_bg.isNone()) pad_s = pad_s.bg(self.content_bg);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // ── Top border ──
         try writer.writeAll(try bdr_s.render(allocator, bc.top_left));
@@ -282,8 +283,8 @@ pub const Tooltip = struct {
         const pos = self.computePosition(box_w, box_h, term_width, term_height);
 
         // Build full-screen output line by line
-        var result = std.array_list.Managed(u8).init(allocator);
-        const wr = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const wr = &result.writer;
 
         // Collect box lines
         var box_lines = std.array_list.Managed([]const u8).init(allocator);
@@ -489,7 +490,7 @@ pub const Tooltip = struct {
     // ── Render helpers (full-screen canvas) ────────────────────────────
 
     /// Arrow on its own row (top/bottom placement).
-    fn writeArrowOnlyRow(self: *const Tooltip, allocator: std.mem.Allocator, writer: anytype, pos: Position, tw: usize) !void {
+    fn writeArrowOnlyRow(self: *const Tooltip, allocator: std.mem.Allocator, writer: *Writer, pos: Position, tw: usize) !void {
         try writer.writeAll(try nSpaces(allocator, pos.arrow_x));
         try writer.writeAll(try self.renderStyledArrow(allocator));
         const aw = self.arrowDisplayWidth();
@@ -498,7 +499,7 @@ pub const Tooltip = struct {
     }
 
     /// Box row that also has a side arrow (left/right placement).
-    fn writeBoxRowWithSideArrow(self: *const Tooltip, allocator: std.mem.Allocator, writer: anytype, pos: Position, box_line: []const u8, tw: usize) !void {
+    fn writeBoxRowWithSideArrow(self: *const Tooltip, allocator: std.mem.Allocator, writer: *Writer, pos: Position, box_line: []const u8, tw: usize) !void {
         const box_line_w = measure.width(box_line);
         const aw = self.arrowDisplayWidth();
         const styled_arrow = try self.renderStyledArrow(allocator);
@@ -526,7 +527,7 @@ pub const Tooltip = struct {
 
     // ── Private Helpers ───────────────────────────────────────────────
 
-    fn writeEmptyLine(allocator: std.mem.Allocator, writer: anytype, styled_left: []const u8, styled_right: []const u8, pad_s: style_mod.Style, inner_w: usize) !void {
+    fn writeEmptyLine(allocator: std.mem.Allocator, writer: *Writer, styled_left: []const u8, styled_right: []const u8, pad_s: style_mod.Style, inner_w: usize) !void {
         try writer.writeAll(styled_left);
         try writer.writeAll(try pad_s.render(allocator, try nSpaces(allocator, inner_w)));
         try writer.writeAll(styled_right);

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -766,8 +766,8 @@ const CellGrid = struct {
     /// Emits SGR sequences only when the style changes between cells
     /// (like Ratatui's Buffer::diff), producing minimal output.
     fn render(self: *const CellGrid, allocator: std.mem.Allocator) ![]const u8 {
-        var buf = std.array_list.Managed(u8).init(allocator);
-        const wr = buf.writer();
+        var buf: Writer.Allocating = .init(allocator);
+        const wr = &buf.writer;
 
         var prev_style = CellStyle{};
 

--- a/src/components/tree.zig
+++ b/src/components/tree.zig
@@ -122,8 +122,8 @@ pub fn Tree(comptime T: type) type {
 
         /// Render the tree
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             for (self.root_indices.items, 0..) |root_idx, i| {
                 if (i > 0) try writer.writeAll("\n");

--- a/src/components/tree.zig
+++ b/src/components/tree.zig
@@ -2,6 +2,7 @@
 //! Renders a tree structure with expandable nodes and customizable enumerators.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -134,7 +135,7 @@ pub fn Tree(comptime T: type) type {
 
         fn renderNode(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             node_idx: usize,
             prefix: []const u8,

--- a/src/components/viewport.zig
+++ b/src/components/viewport.zig
@@ -1,6 +1,7 @@
 //! Scrollable content viewport component.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
 const style = @import("../style/style.zig");
@@ -269,8 +270,8 @@ pub const Viewport = struct {
     }
 
     pub fn view(self: *const Viewport, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const visible_width = self.visibleWidth();
 
@@ -346,7 +347,7 @@ pub const Viewport = struct {
 
     fn getSubstring(self: *const Viewport, allocator: std.mem.Allocator, line: []const u8, start_col: usize, max_width: usize) ![]const u8 {
         _ = self;
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: std.array_list.Managed(u8) = .init(allocator);
 
         var col: usize = 0;
         var i: usize = 0;

--- a/src/components/virtual_list.zig
+++ b/src/components/virtual_list.zig
@@ -2,6 +2,7 @@
 //! Only renders items visible in the viewport.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const keys = @import("../input/keys.zig");
@@ -146,14 +147,14 @@ pub fn VirtualList(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) []const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
             const total = self.items.len;
             const vh: usize = self.viewport_height;
 
             if (total == 0) {
                 writer.writeAll(self.empty_text) catch {};
-                return result.items;
+                return result.toArrayList().items;
             }
 
             const end = @min(self.offset + vh, total);
@@ -199,7 +200,7 @@ pub fn VirtualList(comptime T: type) type {
                 writer.writeAll(cs.render(allocator, count_str) catch count_str) catch {};
             }
 
-            return result.items;
+            return result.toArrayList().items;
         }
 
         fn defaultRender(item: T, index: usize, allocator: std.mem.Allocator) []const u8 {

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -19,6 +19,7 @@
 //! `handler` callbacks are also supported for fire-and-forget actions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const KeyEvent = keys.KeyEvent;
 const style_mod = @import("../style/style.zig");
@@ -197,8 +198,8 @@ pub const ActionRegistry = struct {
 
     /// Format a key event for display: "ctrl+s", "esc", "enter", etc.
     pub fn formatKey(allocator: std.mem.Allocator, event: KeyEvent) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
         if (event.modifiers.ctrl) try w.writeAll("ctrl+");
         if (event.modifiers.alt) try w.writeAll("alt+");
         if (event.modifiers.shift) try w.writeAll("shift+");
@@ -258,9 +259,9 @@ pub const Footer = struct {
     }
 
     pub fn view(self: *const Footer, allocator: std.mem.Allocator) ![]const u8 {
-        var inner = std.array_list.Managed(u8).init(allocator);
+        var inner: Writer.Allocating = .init(allocator);
         defer inner.deinit();
-        const w = inner.writer();
+        const w = &inner.writer;
 
         var first = true;
         for (self.registry.actions.items) |a| {
@@ -284,8 +285,8 @@ pub const Footer = struct {
         defer allocator.free(text);
         const text_w = measure.width(text);
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const ow = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const ow = &out.writer;
         try ow.writeAll(text);
         if (text_w < self.width) {
             const pad = self.width - text_w;

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -17,6 +17,7 @@
 //! The console is safe to call from any thread; writes are mutex-guarded.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 pub const Level = enum {
     trace,
@@ -224,22 +225,21 @@ pub const DevConsole = struct {
     }
 
     fn format(self: *const DevConsole, buf: []u8, level: Level, comptime fmt: []const u8, args: anytype) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const w = fbs.writer();
+        var writer: Writer = .fixed(buf);
         if (self.show_timestamps) {
             const now = std.time.timestamp();
             const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(now) };
             const day = epoch.getDaySeconds();
-            try w.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
+            try writer.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
                 day.getHoursIntoDay(),
                 day.getMinutesIntoHour(),
                 day.getSecondsIntoMinute(),
             });
         }
-        try w.print("{s} ", .{level.label()});
-        try w.print(fmt, args);
-        try w.writeByte('\n');
-        return fbs.getWritten();
+        try writer.print("{s} ", .{level.label()});
+        try writer.print(fmt, args);
+        try writer.writeByte('\n');
+        return writer.buffered();
     }
 
     // Convenience wrappers.

--- a/src/core/screen_stack.zig
+++ b/src/core/screen_stack.zig
@@ -25,6 +25,7 @@
 //! used for confirm dialogs or command palettes).
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const Context = @import("context.zig").Context;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
@@ -246,8 +247,8 @@ fn compose(allocator: std.mem.Allocator, background: []const u8, overlay: []cons
         while (iter.next()) |line| try ov_lines.append(line);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const w = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const w = &result.writer;
 
     var row: usize = 0;
     while (row < bg_lines.items.len) : (row += 1) {

--- a/src/input/keys.zig
+++ b/src/input/keys.zig
@@ -2,6 +2,7 @@
 //! Provides a comprehensive set of key types for terminal input.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 /// Modifier keys that can be combined with other keys
 pub const Modifiers = packed struct {
@@ -176,7 +177,7 @@ pub const KeyEvent = struct {
         self: KeyEvent,
         comptime fmt: []const u8,
         options: std.fmt.FormatOptions,
-        writer: anytype,
+        writer: *Writer,
     ) !void {
         _ = fmt;
         _ = options;

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -2,6 +2,7 @@
 //! Supports standard terminal mouse protocols.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("keys.zig");
 
 /// Mouse button types
@@ -40,7 +41,7 @@ pub const MouseEvent = struct {
         self: MouseEvent,
         comptime fmt: []const u8,
         options: std.fmt.FormatOptions,
-        writer: anytype,
+        writer: *Writer,
     ) !void {
         _ = fmt;
         _ = options;

--- a/src/layout/join.zig
+++ b/src/layout/join.zig
@@ -2,6 +2,7 @@
 //! Provides horizontal and vertical joining with alignment options.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 
 /// Vertical alignment for horizontal joins
@@ -54,8 +55,8 @@ pub fn horizontal(allocator: std.mem.Allocator, valign: VAlign, parts: []const [
     }
 
     // Build result
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (0..max_height) |row| {
         if (row > 0) try writer.writeByte('\n');
@@ -110,8 +111,8 @@ pub fn vertical(allocator: std.mem.Allocator, halign: HAlign, parts: []const []c
         max_width = @max(max_width, measure.maxLineWidth(part));
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (parts, 0..) |part, part_idx| {
         if (part_idx > 0) try writer.writeByte('\n');

--- a/src/layout/layer.zig
+++ b/src/layout/layer.zig
@@ -3,6 +3,7 @@
 //! into a single output with proper z-ordering and transparency.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 
 /// A single layer in the stack.
@@ -81,8 +82,8 @@ pub const LayerStack = struct {
         }
 
         // Render grid to string
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..h) |row| {
             if (row > 0) writer.writeByte('\n') catch {};
@@ -98,7 +99,7 @@ pub const LayerStack = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn paintLayer(self: *const LayerStack, grid: []Cell, w: usize, h: usize, layer: Layer) void {

--- a/src/layout/measure.zig
+++ b/src/layout/measure.zig
@@ -2,6 +2,7 @@
 //! Properly handles ANSI escape sequences and Unicode characters.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const unicode = @import("../unicode.zig");
 
 /// Calculate the visible width of a string (excluding ANSI escape sequences)
@@ -141,7 +142,7 @@ pub fn padRight(allocator: std.mem.Allocator, str: []const u8, target_width: usi
     const current_width = width(str);
     if (current_width >= target_width) return try allocator.dupe(u8, str);
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     try result.appendSlice(str);
 
     for (0..(target_width - current_width)) |_| {
@@ -156,7 +157,7 @@ pub fn padLeft(allocator: std.mem.Allocator, str: []const u8, target_width: usiz
     const current_width = width(str);
     if (current_width >= target_width) return try allocator.dupe(u8, str);
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     for (0..(target_width - current_width)) |_| {
         try result.append(' ');
@@ -175,7 +176,7 @@ pub fn center(allocator: std.mem.Allocator, str: []const u8, target_width: usize
     const left_padding = total_padding / 2;
     const right_padding = total_padding - left_padding;
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     for (0..left_padding) |_| {
         try result.append(' ');
@@ -199,7 +200,7 @@ pub fn truncate(allocator: std.mem.Allocator, str: []const u8, max_width: usize)
         return result;
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     var w: usize = 0;
     var i: usize = 0;
     var in_escape = false;

--- a/src/layout/place.zig
+++ b/src/layout/place.zig
@@ -2,6 +2,7 @@
 //! Provides 2D positioning with horizontal and vertical alignment.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 const unicode = @import("../unicode.zig");
 
@@ -36,8 +37,8 @@ pub fn place(
         return try allocator.dupe(u8, content);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     // Calculate vertical offset
     const v_padding = if (height > content_height) height - content_height else 0;
@@ -110,8 +111,8 @@ pub fn placeAt(
     y: usize,
     content: []const u8,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     var content_lines = std.array_list.Managed([]const u8).init(allocator);
@@ -195,8 +196,8 @@ pub fn overlay(
         try content_lines.append(line);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (0..base_height) |row| {
         if (row > 0) try writer.writeByte('\n');
@@ -316,8 +317,8 @@ pub fn placeFloat(
         return try allocator.dupe(u8, content);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     // Calculate offsets from float positions
     const h_space = if (width > content_width) width - content_width else 0;

--- a/src/style/border.zig
+++ b/src/style/border.zig
@@ -2,6 +2,7 @@
 //! Provides various border character sets and drawing functions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 
 /// Border character set
@@ -243,8 +244,8 @@ pub fn drawBorder(
     width: usize,
     height: usize,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     const inner_width = if (sides.left and sides.right) width -| 2 else if (sides.left or sides.right) width -| 1 else width;
 

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -2,6 +2,7 @@
 //! Supports ANSI 16, 256, and TrueColor (24-bit) colors.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const builtin = @import("builtin");
 const ansi = @import("../terminal/ansi.zig");
 
@@ -122,7 +123,7 @@ pub const Color = union(enum) {
     }
 
     /// Write foreground color ANSI sequence
-    pub fn writeFg(self: Color, writer: anytype) !void {
+    pub fn writeFg(self: Color, writer: *Writer) !void {
         switch (self) {
             .none => {},
             .ansi => |c| try writer.print(ansi.CSI ++ "{d}m", .{c.fgCode()}),
@@ -132,7 +133,7 @@ pub const Color = union(enum) {
     }
 
     /// Write background color ANSI sequence
-    pub fn writeBg(self: Color, writer: anytype) !void {
+    pub fn writeBg(self: Color, writer: *Writer) !void {
         switch (self) {
             .none => {},
             .ansi => |c| try writer.print(ansi.CSI ++ "{d}m", .{c.bgCode()}),

--- a/src/style/compress.zig
+++ b/src/style/compress.zig
@@ -110,8 +110,8 @@ pub const StyleState = struct {
 /// Post-process an ANSI string to remove redundant escape sequences.
 /// Strips consecutive resets and duplicate attribute settings.
 pub fn compressAnsi(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var i: usize = 0;
     var last_was_reset = false;

--- a/src/style/compress.zig
+++ b/src/style/compress.zig
@@ -2,6 +2,7 @@
 //! Reduces ANSI escape sequence overhead by tracking terminal state and emitting only diffs.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("../terminal/ansi.zig");
 
 /// Tracks the current terminal style state for efficient transitions
@@ -30,7 +31,7 @@ pub const StyleState = struct {
     }
 
     /// Emit only the ANSI escape sequences needed to transition to the target state
-    pub fn transitionTo(self: *StyleState, writer: anytype, target: StyleState) !void {
+    pub fn transitionTo(self: *StyleState, writer: *Writer, target: StyleState) !void {
         // If target is fully default, just emit reset
         if (!target.bold and !target.dim and !target.italic and !target.underline and
             !target.blink and !target.reverse and !target.strikethrough and

--- a/src/style/overflow.zig
+++ b/src/style/overflow.zig
@@ -2,6 +2,7 @@
 //! Provides configurable overflow policies: clip, ellipsis, word-wrap, char-wrap.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 
 /// Overflow policy for text that exceeds width constraints.
@@ -28,7 +29,7 @@ pub fn applyOverflow(
 ) ![]const u8 {
     if (policy == .visible or max_width == 0) return text;
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     var lines = std.mem.splitScalar(u8, text, '\n');
     var first_line = true;
@@ -45,7 +46,7 @@ pub fn applyOverflow(
         }
     }
 
-    return try result.toOwnedSlice();
+    return result.toOwnedSlice();
 }
 
 fn applyClip(result: *std.array_list.Managed(u8), line: []const u8, max_width: u16) !void {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -576,12 +576,13 @@ pub const Style = struct {
     pub fn render(self: Self, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
         var result: Writer.Allocating = .init(allocator);
         defer result.deinit();
-        var buf: Writer.Allocating = .init(allocator);
-        defer buf.deinit();
 
-        // Preprocess tabs if tab_width is set
+        // Preprocess tabs if tab_width is set. Only allocate the scratch
+        // buffer when expansion is actually needed.
         var processed_text = text;
         if (self.tab_width_val) |tw| {
+            var buf: Writer.Allocating = .init(allocator);
+            defer buf.deinit();
             for (text) |c| {
                 if (c == '\t') {
                     for (0..tw) |_| {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -2,6 +2,7 @@
 //! Provides a builder pattern for composing styles.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const color_mod = @import("color.zig");
 const border_mod = @import("border.zig");
 const ansi = @import("../terminal/ansi.zig");
@@ -573,20 +574,21 @@ pub const Style = struct {
 
     /// Render styled text
     pub fn render(self: Self, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        defer result.deinit();
+        var buf: Writer.Allocating = .init(allocator);
+        defer buf.deinit();
 
         // Preprocess tabs if tab_width is set
         var processed_text = text;
         if (self.tab_width_val) |tw| {
-            var buf = std.array_list.Managed(u8).init(allocator);
             for (text) |c| {
                 if (c == '\t') {
                     for (0..tw) |_| {
-                        try buf.append(' ');
+                        try buf.writer.writeByte(' ');
                     }
                 } else {
-                    try buf.append(c);
+                    try buf.writer.writeByte(c);
                 }
             }
             processed_text = try buf.toOwnedSlice();
@@ -630,43 +632,45 @@ pub const Style = struct {
 
         // Write margin top
         for (0..self.margin_val.top) |_| {
-            try self.writeMarginLeft(writer);
+            try self.writeMarginLeft(&result.writer);
             if (!self.margin_bg.isNone()) {
-                try self.margin_bg.writeBg(writer);
+                try self.margin_bg.writeBg(&result.writer);
                 for (0..target_width) |_| {
-                    try writer.writeByte(' ');
+                    try result.writer.writeByte(' ');
                 }
-                try self.writeMarginRight(writer, target_width);
-                try writer.writeAll(ansi.reset);
+                try self.writeMarginRight(&result.writer, target_width);
+                try result.writer.writeAll(ansi.reset);
             }
-            try writer.writeByte('\n');
+            try result.writer.writeByte('\n');
         }
 
         // Build styled content
-        try self.writeStyledContent(writer, processed_text, target_width, target_height);
+        try self.writeStyledContent(&result.writer, processed_text, target_width, target_height);
 
         // Write margin bottom
         for (0..self.margin_val.bottom) |_| {
-            try writer.writeByte('\n');
-            try self.writeMarginLeft(writer);
+            try result.writer.writeByte('\n');
+            try self.writeMarginLeft(&result.writer);
             if (!self.margin_bg.isNone()) {
-                try self.margin_bg.writeBg(writer);
+                try self.margin_bg.writeBg(&result.writer);
                 for (0..target_width) |_| {
-                    try writer.writeByte(' ');
+                    try result.writer.writeByte(' ');
                 }
-                try self.writeMarginRight(writer, target_width);
-                try writer.writeAll(ansi.reset);
+                try self.writeMarginRight(&result.writer, target_width);
+                try result.writer.writeAll(ansi.reset);
             }
         }
 
-        if (!self.inline_mode and result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
-        }
+        var array = result.toArrayList();
+        if (!self.inline_mode and
+            array.items.len > 0 and
+            array.items[array.items.len - 1] == '\n')
+            _ = array.pop();
 
-        return result.toOwnedSlice();
+        return array.toOwnedSlice(allocator);
     }
 
-    fn writeStyledContent(self: Self, writer: anytype, text: []const u8, target_width: usize, target_height: usize) !void {
+    fn writeStyledContent(self: Self, writer: *Writer, text: []const u8, target_width: usize, target_height: usize) !void {
         const inner_width = target_width -|
             self.padding_val.left -| self.padding_val.right -|
             @as(usize, if (self.border_sides.left) 1 else 0) -|
@@ -733,7 +737,7 @@ pub const Style = struct {
             (self.strikethrough_spaces and (self.strikethrough_attr orelse false));
     }
 
-    fn writeContentLine(self: Self, writer: anytype, line: []const u8, inner_width: usize) !void {
+    fn writeContentLine(self: Self, writer: *Writer, line: []const u8, inner_width: usize) !void {
         try self.writeMarginLeft(writer);
 
         // Left border
@@ -827,7 +831,7 @@ pub const Style = struct {
     }
 
     /// Write text with per-character whitespace attribute control
-    fn writeWithWhitespaceControl(self: Self, writer: anytype, text: []const u8) !void {
+    fn writeWithWhitespaceControl(self: Self, writer: *Writer, text: []const u8) !void {
         var i: usize = 0;
         while (i < text.len) {
             const byte_len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
@@ -875,7 +879,7 @@ pub const Style = struct {
     }
 
     /// Write N spaces with whitespace control
-    fn writeSpacesWithControl(self: Self, writer: anytype, count: usize) !void {
+    fn writeSpacesWithControl(self: Self, writer: *Writer, count: usize) !void {
         if (count == 0) return;
         if (!self.color_whitespace and !self.background.isNone()) {
             try writer.writeAll(ansi.reset);
@@ -896,7 +900,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeMarginLeft(self: Self, writer: anytype) !void {
+    fn writeMarginLeft(self: Self, writer: *Writer) !void {
         if (!self.margin_bg.isNone() and self.margin_val.left > 0) {
             try self.margin_bg.writeBg(writer);
         }
@@ -908,7 +912,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeMarginRight(self: Self, writer: anytype, content_width: usize) !void {
+    fn writeMarginRight(self: Self, writer: *Writer, content_width: usize) !void {
         _ = content_width;
         if (self.margin_val.right > 0) {
             if (!self.margin_bg.isNone()) {
@@ -923,7 +927,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeStyleStart(self: Self, writer: anytype) !void {
+    fn writeStyleStart(self: Self, writer: *Writer) !void {
         if (self.bold_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.bold});
         if (self.dim_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.dim});
         if (self.italic_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.italic});
@@ -938,7 +942,7 @@ pub const Style = struct {
 
     const BorderSide = enum { top, right, bottom, left };
 
-    fn writeBorderColorSide(self: Self, writer: anytype, side: BorderSide) !void {
+    fn writeBorderColorSide(self: Self, writer: *Writer, side: BorderSide) !void {
         const side_fg = switch (side) {
             .top => self.border_top_fg,
             .right => self.border_right_fg,
@@ -957,7 +961,7 @@ pub const Style = struct {
         try resolved_bg.writeBg(writer);
     }
 
-    fn writeBorderColor(self: Self, writer: anytype) !void {
+    fn writeBorderColor(self: Self, writer: *Writer) !void {
         try self.border_fg.writeFg(writer);
         try self.border_bg.writeBg(writer);
     }

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -986,8 +986,8 @@ pub const StyleRange = struct {
 
 /// Render text with different styles applied to specific byte ranges
 pub fn renderWithRanges(allocator: std.mem.Allocator, text: []const u8, ranges: []const StyleRange) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var pos: usize = 0;
     while (pos < text.len) {
@@ -1030,8 +1030,8 @@ pub fn renderWithHighlights(
     highlight_style: Style,
     base_style: Style,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var pos: usize = 0;
     var pi: usize = 0; // position index

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -2,6 +2,7 @@
 //! Provides functions to generate standard terminal control sequences.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 /// ANSI escape codes
 pub const ESC = "\x1b";
@@ -62,98 +63,98 @@ pub const kitty_keyboard_enable = CSI ++ ">1u";
 pub const kitty_keyboard_disable = CSI ++ "<u";
 
 /// Move cursor to position (1-indexed)
-pub fn cursorTo(writer: anytype, row: u16, col: u16) !void {
+pub fn cursorTo(writer: *Writer, row: u16, col: u16) !void {
     try writer.print(CSI ++ "{d};{d}H", .{ row, col });
 }
 
 /// Move cursor to position (0-indexed)
-pub fn cursorTo0(writer: anytype, row: u16, col: u16) !void {
+pub fn cursorTo0(writer: *Writer, row: u16, col: u16) !void {
     try writer.print(CSI ++ "{d};{d}H", .{ row + 1, col + 1 });
 }
 
 /// Move cursor up
-pub fn cursorUp(writer: anytype, n: u16) !void {
+pub fn cursorUp(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}A", .{n});
 }
 
 /// Move cursor down
-pub fn cursorDown(writer: anytype, n: u16) !void {
+pub fn cursorDown(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}B", .{n});
 }
 
 /// Move cursor forward (right)
-pub fn cursorForward(writer: anytype, n: u16) !void {
+pub fn cursorForward(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}C", .{n});
 }
 
 /// Move cursor backward (left)
-pub fn cursorBack(writer: anytype, n: u16) !void {
+pub fn cursorBack(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}D", .{n});
 }
 
 /// Move cursor to column (1-indexed)
-pub fn cursorToCol(writer: anytype, col: u16) !void {
+pub fn cursorToCol(writer: *Writer, col: u16) !void {
     try writer.print(CSI ++ "{d}G", .{col});
 }
 
 /// Move cursor to column (0-indexed)
-pub fn cursorToCol0(writer: anytype, col: u16) !void {
+pub fn cursorToCol0(writer: *Writer, col: u16) !void {
     try writer.print(CSI ++ "{d}G", .{col + 1});
 }
 
 /// Request cursor position (response: ESC[row;colR)
-pub fn requestCursorPos(writer: anytype) !void {
+pub fn requestCursorPos(writer: *Writer) !void {
     try writer.writeAll(CSI ++ "6n");
 }
 
 /// Set scrolling region
-pub fn setScrollRegion(writer: anytype, top: u16, bottom: u16) !void {
+pub fn setScrollRegion(writer: *Writer, top: u16, bottom: u16) !void {
     try writer.print(CSI ++ "{d};{d}r", .{ top, bottom });
 }
 
 /// Reset scrolling region
-pub fn resetScrollRegion(writer: anytype) !void {
+pub fn resetScrollRegion(writer: *Writer) !void {
     try writer.writeAll(CSI ++ "r");
 }
 
 /// Scroll up (content moves up, blank lines at bottom)
-pub fn scrollUp(writer: anytype, n: u16) !void {
+pub fn scrollUp(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}S", .{n});
 }
 
 /// Scroll down (content moves down, blank lines at top)
-pub fn scrollDown(writer: anytype, n: u16) !void {
+pub fn scrollDown(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}T", .{n});
 }
 
 /// Erase n characters from cursor position
-pub fn eraseChars(writer: anytype, n: u16) !void {
+pub fn eraseChars(writer: *Writer, n: u16) !void {
     try writer.print(CSI ++ "{d}X", .{n});
 }
 
 /// Insert n blank lines at cursor position
-pub fn insertLines(writer: anytype, n: u16) !void {
+pub fn insertLines(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}L", .{n});
 }
 
 /// Delete n lines at cursor position
-pub fn deleteLines(writer: anytype, n: u16) !void {
+pub fn deleteLines(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}M", .{n});
 }
 
 /// Set window title
-pub fn setTitle(writer: anytype, title: []const u8) !void {
+pub fn setTitle(writer: *Writer, title: []const u8) !void {
     try writer.print(OSC ++ "0;{s}\x07", .{title});
 }
 
-fn writeOscTerminator(writer: anytype, terminator: OscTerminator) !void {
+fn writeOscTerminator(writer: *Writer, terminator: OscTerminator) !void {
     switch (terminator) {
         .bel => try writer.writeAll("\x07"),
         .st => try writer.writeAll(ST),
     }
 }
 
-fn writeEscapedForDcs(writer: anytype, bytes: []const u8) !void {
+fn writeEscapedForDcs(writer: *Writer, bytes: []const u8) !void {
     var start: usize = 0;
     for (bytes, 0..) |byte, idx| {
         if (byte != 0x1b) continue;
@@ -173,7 +174,7 @@ fn writeEscapedForDcs(writer: anytype, bytes: []const u8) !void {
 /// Start an OSC 52 sequence and write the fixed header:
 /// `OSC 52 ; <target> ;`
 pub fn osc52Start(
-    writer: anytype,
+    writer: *Writer,
     target: []const u8,
     passthrough: Osc52Passthrough,
 ) !void {
@@ -199,7 +200,7 @@ pub fn osc52Start(
 }
 
 /// Finish an OSC 52 sequence started by `osc52Start`.
-pub fn osc52End(writer: anytype, terminator: OscTerminator, passthrough: Osc52Passthrough) !void {
+pub fn osc52End(writer: *Writer, terminator: OscTerminator, passthrough: Osc52Passthrough) !void {
     switch (passthrough) {
         .none => try writeOscTerminator(writer, terminator),
         .tmux, .dcs => {
@@ -214,7 +215,7 @@ pub fn osc52End(writer: anytype, terminator: OscTerminator, passthrough: Osc52Pa
 
 /// Write a complete OSC 52 sequence with a pre-encoded base64 payload.
 pub fn osc52Encoded(
-    writer: anytype,
+    writer: *Writer,
     target: []const u8,
     payload_b64: []const u8,
     terminator: OscTerminator,
@@ -290,7 +291,7 @@ pub const SGR = struct {
 };
 
 /// Generate SGR sequence
-pub fn sgr(writer: anytype, codes: []const u8) !void {
+pub fn sgr(writer: *Writer, codes: []const u8) !void {
     try writer.writeAll(CSI);
     for (codes, 0..) |code, i| {
         if (i > 0) try writer.writeByte(';');
@@ -300,32 +301,32 @@ pub fn sgr(writer: anytype, codes: []const u8) !void {
 }
 
 /// Generate 256-color foreground
-pub fn fg256(writer: anytype, color: u8) !void {
+pub fn fg256(writer: *Writer, color: u8) !void {
     try writer.print(CSI ++ "38;5;{d}m", .{color});
 }
 
 /// Generate 256-color background
-pub fn bg256(writer: anytype, color: u8) !void {
+pub fn bg256(writer: *Writer, color: u8) !void {
     try writer.print(CSI ++ "48;5;{d}m", .{color});
 }
 
 /// Generate true color (24-bit) foreground
-pub fn fgRgb(writer: anytype, r: u8, g: u8, b: u8) !void {
+pub fn fgRgb(writer: *Writer, r: u8, g: u8, b: u8) !void {
     try writer.print(CSI ++ "38;2;{d};{d};{d}m", .{ r, g, b });
 }
 
 /// Generate true color (24-bit) background
-pub fn bgRgb(writer: anytype, r: u8, g: u8, b: u8) !void {
+pub fn bgRgb(writer: *Writer, r: u8, g: u8, b: u8) !void {
     try writer.print(CSI ++ "48;2;{d};{d};{d}m", .{ r, g, b });
 }
 
 /// Hyperlink (OSC 8)
-pub fn hyperlink(writer: anytype, url: []const u8, text: []const u8) !void {
+pub fn hyperlink(writer: *Writer, url: []const u8, text: []const u8) !void {
     try writer.print(OSC ++ "8;;{s}\x07{s}" ++ OSC ++ "8;;\x07", .{ url, text });
 }
 
 /// Kitty graphics protocol command (APC G ... ST)
-pub fn kittyGraphics(writer: anytype, params: []const u8, payload: []const u8) !void {
+pub fn kittyGraphics(writer: *Writer, params: []const u8, payload: []const u8) !void {
     try writer.writeAll(APC ++ "G");
     try writer.writeAll(params);
     try writer.writeAll(";");
@@ -334,7 +335,7 @@ pub fn kittyGraphics(writer: anytype, params: []const u8, payload: []const u8) !
 }
 
 /// iTerm2 inline image command (OSC 1337;File=...:... BEL)
-pub fn iterm2InlineImage(writer: anytype, params: []const u8, payload: []const u8) !void {
+pub fn iterm2InlineImage(writer: *Writer, params: []const u8, payload: []const u8) !void {
     try writer.writeAll(OSC ++ "1337;File=");
     try writer.writeAll(params);
     try writer.writeAll(":");
@@ -344,28 +345,28 @@ pub fn iterm2InlineImage(writer: anytype, params: []const u8, payload: []const u
 
 test "osc52Encoded direct BEL" {
     var buf: [128]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .bel, .none);
-    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x07", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .bel, .none);
+    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x07", writer.buffered());
 }
 
 test "osc52Encoded direct ST" {
     var buf: [128]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .st, .none);
-    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .st, .none);
+    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x1b\\", writer.buffered());
 }
 
 test "osc52Encoded tmux passthrough BEL" {
     var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .bel, .tmux);
-    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x07\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .bel, .tmux);
+    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x07\x1b\\", writer.buffered());
 }
 
 test "osc52Encoded tmux passthrough ST" {
     var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .st, .tmux);
-    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x1b\x1b\\\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .st, .tmux);
+    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x1b\x1b\\\x1b\\", writer.buffered());
 }

--- a/src/terminal/platform/posix.zig
+++ b/src/terminal/platform/posix.zig
@@ -2,6 +2,7 @@
 //! Handles raw mode, terminal size, and signal handling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const posix = std.posix;
 const ansi = @import("../ansi.zig");
 
@@ -118,7 +119,7 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_enter);
@@ -126,7 +127,7 @@ pub fn enterAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Exit alternate screen buffer
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_exit);
@@ -134,7 +135,7 @@ pub fn exitAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Enable mouse tracking
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
 
     // Enable SGR mouse mode with all motion tracking
@@ -143,7 +144,7 @@ pub fn enableMouse(state: *State, writer: anytype) !void {
 }
 
 /// Disable mouse tracking
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
 
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -144,18 +144,31 @@ export fn zigzagPushInput(len: usize) void {
     input_write_pos = @min(len, input_ring.len);
 }
 
-/// Writer adapter that sends bytes to the JS host.
+/// Unbuffered `std.Io.Writer` adapter that drains bytes to the JS host.
 pub const WasmWriter = struct {
-    pub const Error = error{};
+    writer: Writer,
 
-    pub fn write(_: *const WasmWriter, bytes: []const u8) Error!usize {
-        jsWrite(bytes.ptr, bytes.len);
-        return bytes.len;
+    const vtable: Writer.VTable = .{ .drain = drain };
+
+    pub fn init() WasmWriter {
+        return .{ .writer = .{ .vtable = &vtable, .buffer = &.{} } };
     }
 
-    pub fn writer(self: *const WasmWriter) std.io.GenericWriter(*const WasmWriter, Error, write) {
-        return .{ .context = self };
+    fn drain(_: *Writer, data: []const []const u8, splat: usize) Writer.Error!usize {
+        var consumed: usize = 0;
+        if (data.len > 1) for (data[0 .. data.len - 1]) |chunk| {
+            if (chunk.len == 0) continue;
+            jsWrite(chunk.ptr, chunk.len);
+            consumed += chunk.len;
+        };
+        const pattern = data[data.len - 1];
+        if (pattern.len > 0 and splat > 0) {
+            var i: usize = 0;
+            while (i < splat) : (i += 1) jsWrite(pattern.ptr, pattern.len);
+            consumed += pattern.len * splat;
+        }
+        return consumed;
     }
 };
 
-pub const wasm_writer_instance = WasmWriter{};
+pub var wasm_writer_instance: WasmWriter = .init();

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -4,6 +4,7 @@
 //! or similar browser-based terminal emulator.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("../ansi.zig");
 
 pub const TerminalError = error{
@@ -67,28 +68,28 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer.
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
     try writer.writeAll(ansi.alt_screen_enter);
     state.in_alt_screen = true;
 }
 
 /// Exit alternate screen buffer.
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
     try writer.writeAll(ansi.alt_screen_exit);
     state.in_alt_screen = false;
 }
 
 /// Enable mouse tracking.
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
     try writer.writeAll("\x1b[?1003h\x1b[?1006h");
     state.mouse_enabled = true;
 }
 
 /// Disable mouse tracking.
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");
     state.mouse_enabled = false;

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -155,6 +155,10 @@ pub const WasmWriter = struct {
     }
 
     fn drain(_: *Writer, data: []const []const u8, splat: usize) Writer.Error!usize {
+        // Empty data == pure flush; the splat pattern lives at the last
+        // element so we must early-return before indexing.
+        if (data.len == 0) return 0;
+
         var consumed: usize = 0;
         if (data.len > 1) for (data[0 .. data.len - 1]) |chunk| {
             if (chunk.len == 0) continue;

--- a/src/terminal/platform/windows.zig
+++ b/src/terminal/platform/windows.zig
@@ -2,6 +2,7 @@
 //! Provides terminal control for Windows systems.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const windows = std.os.windows;
 const ansi = @import("../ansi.zig");
 
@@ -194,7 +195,7 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_enter);
@@ -202,7 +203,7 @@ pub fn enterAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Exit alternate screen buffer
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_exit);
@@ -210,7 +211,7 @@ pub fn exitAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Enable mouse tracking
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
 
     // Enable mouse input in console mode
@@ -227,7 +228,7 @@ pub fn enableMouse(state: *State, writer: anytype) !void {
 }
 
 /// Disable mouse tracking
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
 
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");

--- a/src/terminal/screen.zig
+++ b/src/terminal/screen.zig
@@ -2,6 +2,7 @@
 //! Provides double-buffering to minimize flickering and optimize updates.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("ansi.zig");
 const unicode = @import("../unicode.zig");
 
@@ -161,7 +162,7 @@ pub const Screen = struct {
     }
 
     /// Render screen differences to the writer
-    pub fn renderDiff(self: *const Screen, prev: *const Screen, writer: anytype) !void {
+    pub fn renderDiff(self: *const Screen, prev: *const Screen, writer: *Writer) !void {
         var last_x: u16 = 0;
         var last_y: u16 = 0;
         var need_move = true;
@@ -215,7 +216,7 @@ pub const Screen = struct {
     }
 
     /// Render entire screen to writer
-    pub fn render(self: *const Screen, writer: anytype) !void {
+    pub fn render(self: *const Screen, writer: *Writer) !void {
         try writer.writeAll(ansi.cursor_home);
         try writer.writeAll(ansi.reset);
 
@@ -252,7 +253,7 @@ pub const Screen = struct {
         try writer.writeAll(ansi.reset);
     }
 
-    fn applyStyle(writer: anytype, current: *Cell, new: Cell) !void {
+    fn applyStyle(writer: *Writer, current: *Cell, new: Cell) !void {
         var needs_reset = false;
 
         // Check if we need to reset (turning off attributes)

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -1830,6 +1830,11 @@ pub const Terminal = struct {
                 io_w.end = 0;
             }
 
+            // The std.Io.Writer.VTable contract treats data.len == 0 as a
+            // pure flush; the splat pattern lives at data[data.len - 1] so we
+            // must early-return before indexing.
+            if (data.len == 0) return 0;
+
             var consumed: usize = 0;
             if (data.len > 1) {
                 for (data[0 .. data.len - 1]) |chunk| {

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -1851,7 +1851,7 @@ pub const Terminal = struct {
 
         fn sinkAll(self: *Writer, bytes: []const u8) std.Io.Writer.Error!void {
             if (is_wasm) {
-                _ = platform.WasmWriter.write(&platform.wasm_writer_instance, bytes) catch return error.WriteFailed;
+                try platform.wasm_writer_instance.writer.writeAll(bytes);
             } else {
                 self.file.writeAll(bytes) catch return error.WriteFailed;
             }

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -2,6 +2,7 @@
 //! Handles raw mode, alternate screen, mouse tracking, and input/output.
 
 const std = @import("std");
+const FixedWriter = std.Io.Writer.fixed;
 const builtin = @import("builtin");
 pub const ansi = @import("ansi.zig");
 pub const screen = @import("screen.zig");
@@ -261,10 +262,8 @@ pub const Config = struct {
 pub const Terminal = struct {
     state: platform.State,
     config: Config,
-    stdout: std.fs.File,
     stdin: std.fs.File,
-    write_buffer: [4096]u8 = undefined,
-    write_pos: usize = 0,
+    out: Writer,
     pending_input: [8192]u8 = undefined,
     pending_input_len: usize = 0,
     unicode_width_caps: UnicodeWidthCapabilities = .{},
@@ -276,8 +275,8 @@ pub const Terminal = struct {
         var term: Terminal = if (is_wasm) .{
             .state = state,
             .config = config,
-            .stdout = undefined,
             .stdin = undefined,
+            .out = .init({}),
         } else blk: {
             const stdout = config.output orelse std.fs.File.stdout();
             const stdin = config.input orelse std.fs.File.stdin();
@@ -285,17 +284,17 @@ pub const Terminal = struct {
             // Apply custom fd overrides
             if (builtin.os.tag != .windows) {
                 if (config.input) |inp| state.stdin_fd = inp.handle;
-                if (config.output) |out| state.stdout_fd = out.handle;
+                if (config.output) |o| state.stdout_fd = o.handle;
             } else {
                 if (config.input) |inp| state.stdin_handle = inp.handle;
-                if (config.output) |out| state.stdout_handle = out.handle;
+                if (config.output) |o| state.stdout_handle = o.handle;
             }
 
             break :blk .{
                 .state = state,
                 .config = config,
-                .stdout = stdout,
                 .stdin = stdin,
+                .out = .init(stdout),
             };
         };
 
@@ -393,15 +392,9 @@ pub const Terminal = struct {
         platform.disableRawMode(&self.state);
     }
 
-    /// Write bytes to internal buffer
+    /// Write bytes through the buffered terminal writer.
     fn writeBytes(self: *Terminal, bytes: []const u8) !void {
-        for (bytes) |byte| {
-            if (self.write_pos >= self.write_buffer.len) {
-                try self.flush();
-            }
-            self.write_buffer[self.write_pos] = byte;
-            self.write_pos += 1;
-        }
+        try self.writer().writeAll(bytes);
     }
 
     /// Get terminal size
@@ -435,26 +428,15 @@ pub const Terminal = struct {
         return platform.checkResize();
     }
 
-    /// Get a simple writer interface
-    pub fn writer(self: *Terminal) Writer {
-        return Writer{ .terminal = self };
+    /// Get a Writer interface.
+    pub fn writer(self: *Terminal) *std.Io.Writer {
+        self.out.bind();
+        return &self.out.writer;
     }
 
-    /// Flush output buffer
+    /// Flush buffered terminal output to the underlying sink.
     pub fn flush(self: *Terminal) !void {
-        if (self.write_pos > 0) {
-            if (is_wasm) {
-                platform.WasmWriter.write(&platform.wasm_writer_instance, self.write_buffer[0..self.write_pos]) catch {};
-            } else {
-                self.stdout.writeAll(self.write_buffer[0..self.write_pos]) catch |err| {
-                    return switch (err) {
-                        error.WouldBlock => error.WouldBlock,
-                        else => error.BrokenPipe,
-                    };
-                };
-            }
-            self.write_pos = 0;
-        }
+        try self.writer().flush();
     }
 
     /// Clear the screen
@@ -627,8 +609,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or image_data.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=T,t=d,f={d}", .{@intFromEnum(options.format)});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -642,7 +623,7 @@ pub const Terminal = struct {
         if (options.pixel_width) |pw| try params_writer.print(",s={d}", .{pw});
         if (options.pixel_height) |ph| try params_writer.print(",v={d}", .{ph});
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), image_data);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), image_data);
         return true;
     }
 
@@ -652,8 +633,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or path.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("a=T,t=f,f=100");
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -665,7 +645,7 @@ pub const Terminal = struct {
         if (options.z_index) |z| try params_writer.print(",z={d}", .{z});
         if (options.unicode_placeholder) try params_writer.writeAll(",U=1");
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), path);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), path);
         return true;
     }
 
@@ -675,8 +655,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or payload.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=t,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -695,7 +674,7 @@ pub const Terminal = struct {
             },
         }
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), payload);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), payload);
         return true;
     }
 
@@ -705,13 +684,12 @@ pub const Terminal = struct {
         if (!fileExists(path)) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=t,t=f,f=100,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), path);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), path);
         return true;
     }
 
@@ -720,8 +698,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=p,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -733,7 +710,7 @@ pub const Terminal = struct {
         if (options.unicode_placeholder) try params_writer.writeAll(",U=1");
 
         // Virtual placement has no payload.
-        try ansi.kittyGraphics(self.writer(), stream.getWritten(), "");
+        try ansi.kittyGraphics(self.writer(), params_writer.buffered(), "");
         return true;
     }
 
@@ -742,8 +719,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics) return false;
 
         var params_buf: [128]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("a=d,q=2");
         switch (target) {
@@ -752,7 +728,7 @@ pub const Terminal = struct {
             .all => try params_writer.writeAll(",d=A"),
         }
 
-        try ansi.kittyGraphics(self.writer(), stream.getWritten(), "");
+        try ansi.kittyGraphics(self.writer(), params_writer.buffered(), "");
         return true;
     }
 
@@ -767,8 +743,7 @@ pub const Terminal = struct {
         const stat = try file.stat();
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("inline=1");
         if (options.width_cells) |cols| try params_writer.print(";width={d}", .{cols});
@@ -784,7 +759,7 @@ pub const Terminal = struct {
             try params_writer.print(";name={s}", .{file_name_b64});
         }
 
-        try self.sendIterm2InlineImagePayload(stream.getWritten(), &file, stat.size);
+        try self.sendIterm2InlineImagePayload(params_writer.buffered(), &file, stat.size);
         return true;
     }
 
@@ -794,8 +769,7 @@ pub const Terminal = struct {
         if (!self.image_caps.iterm2_inline_image or data.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("inline=1");
         if (options.width_cells) |cols| try params_writer.print(";width={d}", .{cols});
@@ -804,7 +778,7 @@ pub const Terminal = struct {
         if (!options.move_cursor) try params_writer.writeAll(";doNotMoveCursor=1");
         try params_writer.print(";size={d}", .{data.len});
 
-        try self.sendIterm2InlineImageDataPayload(stream.getWritten(), data);
+        try self.sendIterm2InlineImageDataPayload(params_writer.buffered(), data);
         return true;
     }
 
@@ -1823,18 +1797,64 @@ pub const Terminal = struct {
         return std.mem.indexOf(u8, value, needle) != null;
     }
 
-    /// Simple writer struct for compatibility
+    /// Buffered writer that exposes a `std.Io.Writer` interface and drains to
+    /// the terminal's output sink (stdout file, or the wasm host on wasm).
     pub const Writer = struct {
-        terminal: *Terminal,
+        file: if (is_wasm) void else std.fs.File,
+        buffer: [4096]u8 = undefined,
+        writer: std.Io.Writer,
 
-        pub fn writeAll(self: Writer, bytes: []const u8) !void {
-            try self.terminal.writeBytes(bytes);
+        const vtable: std.Io.Writer.VTable = .{ .drain = drain };
+
+        pub fn init(file: if (is_wasm) void else std.fs.File) Writer {
+            return .{
+                .file = file,
+                .writer = .{ .vtable = &vtable, .buffer = &.{} },
+            };
         }
 
-        pub fn print(self: Writer, comptime fmt: []const u8, args: anytype) !void {
-            var buf: [256]u8 = undefined;
-            const result = std.fmt.bufPrint(&buf, fmt, args) catch return;
-            try self.terminal.writeBytes(result);
+        /// Wires the `std.Io.Writer` to the local buffer. Called by the
+        /// containing `Terminal` whenever it hands the writer out, so the
+        /// buffer pointer stays valid even if the `Terminal` was moved.
+        /// `writer.end` is preserved across moves, so re-binding is safe.
+        pub fn bind(self: *Writer) void {
+            self.writer.buffer = &self.buffer;
+        }
+
+        fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+            const self: *Writer = @fieldParentPtr("writer", io_w);
+
+            const buffered = io_w.buffered();
+            if (buffered.len != 0) {
+                try self.sinkAll(buffered);
+                io_w.end = 0;
+            }
+
+            var consumed: usize = 0;
+            if (data.len > 1) {
+                for (data[0 .. data.len - 1]) |chunk| {
+                    if (chunk.len == 0) continue;
+                    try self.sinkAll(chunk);
+                    consumed += chunk.len;
+                }
+            }
+
+            const pattern = data[data.len - 1];
+            if (pattern.len > 0 and splat > 0) {
+                var i: usize = 0;
+                while (i < splat) : (i += 1) try self.sinkAll(pattern);
+                consumed += pattern.len * splat;
+            }
+
+            return consumed;
+        }
+
+        fn sinkAll(self: *Writer, bytes: []const u8) std.Io.Writer.Error!void {
+            if (is_wasm) {
+                _ = platform.WasmWriter.write(&platform.wasm_writer_instance, bytes) catch return error.WriteFailed;
+            } else {
+                self.file.writeAll(bytes) catch return error.WriteFailed;
+            }
         }
     };
 };

--- a/tests/input_tests.zig
+++ b/tests/input_tests.zig
@@ -1,6 +1,7 @@
 //! Input handling tests
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const testing = std.testing;
 const zz = @import("zigzag");
 
@@ -138,11 +139,11 @@ test "KeyEvent format" {
         .modifiers = .{ .ctrl = true },
     };
 
-    var buf = std.array_list.Managed(u8).init(allocator);
+    var buf: Writer.Allocating = .init(allocator);
     defer buf.deinit();
 
-    try event.format("", .{}, buf.writer());
-    try testing.expectEqualStrings("ctrl+a", buf.items);
+    try event.format("", .{}, &buf.writer);
+    try testing.expectEqualStrings("ctrl+a", buf.written());
 }
 
 test "parseAll multiple keys" {

--- a/tests/toast_tests.zig
+++ b/tests/toast_tests.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Writer = std.Io.Writer;
 const testing = std.testing;
 const zz = @import("zigzag");
 
@@ -212,7 +213,7 @@ fn rightEdgeDisplay(line: []const u8) usize {
 }
 
 fn stripAnsi(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     errdefer result.deinit();
 
     var i: usize = 0;


### PR DESCRIPTION
Replaced all deprecated `GenericWriter`s with `std.Io.Writer`.

`zig build test` passes.
`zig build run-counter` builds and runs.

As big as this is the only two real changes are the Writers in Terminal and wasm, and I would take a good look at those to see if I missed something.  Note that I haven't created a way to verify the wasm version yet.

For reference:
```zig
var buffer: std.Io.Writer.Allocating = .init(allocator);
const writer = &buffer.writer;
```
is the closest replacement for
```zig
var buffer: std.array_list.Managed(u8) = .init(allocator);
const writer = buffer.writer();
```

for fixed writer
```zig
var buffer: [256]u8 = undefined;
var writer: std.Io.Writer = .fixed(&buffer);
const string = writer.buffered();
```