### PR TITLE
Form: submit on Ctrl+S (works in every terminal)

### DIFF
--- a/examples/form.zig
+++ b/examples/form.zig
@@ -31,7 +31,7 @@ const Model = struct {
         self.form.addField("Terms", &self.agree_checkbox, .{});
         self.form.initFocus();
 
-        self.status = "Fill out the form and press Ctrl+Enter to submit";
+        self.status = "Fill out the form and press Ctrl+S to submit (Ctrl+Enter also works in capable terminals)";
 
         return .none;
     }

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -8,6 +8,19 @@ const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
 const focus_mod = @import("focus.zig");
 
+/// Universally-supported submit bindings. Ctrl+S works in every terminal
+/// (no encoding ambiguity). Ctrl+Enter is included for terminals that
+/// implement the Kitty keyboard protocol — most don't (notably macOS
+/// Terminal.app, basic xterm), so it's a bonus, not the primary binding.
+const default_submit_keys = [_]keys.KeyEvent{
+    keys.KeyEvent.ctrl('s'),
+    .{ .key = .enter, .modifiers = .{ .ctrl = true } },
+};
+
+const default_cancel_keys = [_]keys.KeyEvent{
+    .{ .key = .escape },
+};
+
 pub fn Form(comptime max_fields: usize) type {
     return struct {
         // Fields
@@ -25,6 +38,17 @@ pub fn Form(comptime max_fields: usize) type {
         label_width: u16,
         spacing: u16,
         show_required_marker: bool,
+
+        // Submit bindings. Multiple keys can submit the form. Default
+        // includes Ctrl+S (works in every terminal) and Ctrl+Enter (only
+        // works in terminals that implement the Kitty keyboard protocol —
+        // Terminal.app and most basic xterms cannot tell Ctrl+Enter from
+        // plain Enter, so we don't rely on it).
+        submit_keys: []const keys.KeyEvent,
+        cancel_keys: []const keys.KeyEvent,
+        /// Human-readable description of submit/cancel bindings shown in the
+        /// footer hint. Override if you change submit_keys/cancel_keys.
+        hint_text: []const u8,
 
         // Styling
         label_style: style_mod.Style,
@@ -59,6 +83,9 @@ pub fn Form(comptime max_fields: usize) type {
                 .label_width = 15,
                 .spacing = 1,
                 .show_required_marker = true,
+                .submit_keys = &default_submit_keys,
+                .cancel_keys = &default_cancel_keys,
+                .hint_text = "Tab: next field | Ctrl+S: submit | Esc: cancel",
                 .label_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
@@ -172,18 +199,22 @@ pub fn Form(comptime max_fields: usize) type {
 
         /// Handle key events.
         pub fn handleKey(self: *Self, key: keys.KeyEvent) bool {
-            // Ctrl+Enter to submit
-            if (key.modifiers.ctrl and key.key == .enter) {
-                if (self.validate()) {
-                    self.submitted = true;
+            // Submit on any configured submit key.
+            for (self.submit_keys) |sk| {
+                if (sk.eql(key)) {
+                    if (self.validate()) {
+                        self.submitted = true;
+                    }
+                    return true;
                 }
-                return true;
             }
 
-            // Escape to cancel
-            if (key.key == .escape) {
-                self.cancelled = true;
-                return true;
+            // Cancel on any configured cancel key.
+            for (self.cancel_keys) |ck| {
+                if (ck.eql(key)) {
+                    self.cancelled = true;
+                    return true;
+                }
             }
 
             // Tab/Shift+Tab for focus cycling
@@ -258,7 +289,7 @@ pub fn Form(comptime max_fields: usize) type {
             var hint_style = style_mod.Style{};
             hint_style = hint_style.fg(Color.gray(12));
             hint_style = hint_style.inline_style(true);
-            const hint = try hint_style.render(allocator, "Tab: next field | Ctrl+Enter: submit | Esc: cancel");
+            const hint = try hint_style.render(allocator, self.hint_text);
             try writer.writeAll(hint);
 
             return result.toOwnedSlice();


### PR DESCRIPTION
## Summary

You reported Ctrl+Enter not submitting the form on macOS. It's not your terminal — it's a fundamental encoding issue. Most terminals (macOS Terminal.app, basic xterm, default VS Code terminal) encode both \`Enter\` and \`Ctrl+Enter\` as the same byte (\`\\r\` / 0x0D). Only terminals that opt into the **Kitty keyboard protocol** can tell them apart. So \`Form\`'s old \`Ctrl+Enter\` binding silently did nothing for most users.

## Library change

\`Form\` gains three new fields with sensible defaults:

| Field | Default | Notes |
|---|---|---|
| \`submit_keys\` | \`{ Ctrl+S, Ctrl+Enter }\` | Ctrl+S works in every terminal; Ctrl+Enter is a bonus for capable ones |
| \`cancel_keys\` | \`{ Escape }\` | unchanged behavior |
| \`hint_text\` | \`"Tab: next field \| Ctrl+S: submit \| Esc: cancel"\` | shown in the footer; override if you change the bindings |

\`handleKey\` now iterates these lists instead of hard-coding the combo, so users can replace either list with their own \`KeyEvent\` slice.

## Audit of the rest of the codebase

I grepped \`src/\` and \`examples/\` for other multi-modifier bindings that would fail in standard terminals. **Form was the only offender.** Everything else uses keys that work universally:

- single-modifier (Ctrl+letter, Alt+letter)
- Tab and Shift+Tab
- arrow keys
- function keys
- plain Enter / Escape / Backspace

## Test plan
- [x] \`zig build\` passes
- [x] \`zig build test\` — full suite passes
- [x] \`zig build run-form\` — type into fields, press Ctrl+S → form submits (verified on macOS Terminal.app)