### PR TITLE
Feat/comptime render

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A delightful TUI framework for Zig, inspired by [Bubble Tea](https://github.com/
 
 Add ZigZag to your `build.zig.zon`:
 ```sh
-zig fetch --save https://github.com/meszmate/zigzag/
+zig fetch --save git+https://github.com/meszmate/zigzag#main
 ```
 
 Then in your `build.zig`:

--- a/README.md
+++ b/README.md
@@ -29,16 +29,8 @@ A delightful TUI framework for Zig, inspired by [Bubble Tea](https://github.com/
 ## Installation
 
 Add ZigZag to your `build.zig.zon`:
-
-```zig
-.dependencies = .{
-    .zigzag = .{
-        .url = "https://github.com/meszmate/zigzag/archive/refs/heads/main.tar.gz",
-        .hash = "...",
-    },
-},
-// To pin a specific version instead:
-// .url = "https://github.com/meszmate/zigzag/archive/refs/tags/v0.1.0.tar.gz",
+```sh
+zig fetch --save https://github.com/meszmate/zigzag/
 ```
 
 Then in your `build.zig`:
@@ -82,14 +74,14 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const style = (zz.Style{}).bold(true).fg(zz.Color.cyan());
+        const style = zz.newStyle().bold(true).fg(.cyan);
         const text = std.fmt.allocPrint(ctx.allocator, "Count: {d}\n\nPress q to quit", .{self.count}) catch "Error";
         return style.render(ctx.allocator, text) catch text;
     }
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
     defer _ = gpa.deinit();
 
     var program = try zz.Program(Model).init(gpa.allocator());
@@ -168,18 +160,18 @@ return .{ .delete_image = .all };              // Free all cached images
 The styling system is inspired by Lipgloss:
 
 ```zig
-const style = (zz.Style{})
+const style = zz.newStyle()
     .bold(true)
     .italic(true)
-    .fg(zz.Color.cyan())
-    .bg(zz.Color.black())
+    .fg(.cyan)
+    .bg(.black)
     .paddingAll(1)
     .marginAll(2)
-    .marginBackground(zz.Color.gray(3))
-    .borderAll(zz.Border.rounded)
-    .borderForeground(zz.Color.magenta())
-    .borderTopForeground(zz.Color.cyan())    // Per-side border colors
-    .borderBottomForeground(zz.Color.green())
+    .marginBackground(.gray(3))
+    .borderAll(.rounded)
+    .borderForeground(.magenta)
+    .borderTopForeground(.cyan)    // Per-side border colors
+    .borderBottomForeground(.green)
     .tabWidth(4)
     .width(40)
     .alignH(.center);
@@ -188,14 +180,14 @@ const output = try style.render(allocator, "Hello, World!");
 // render() does not append an implicit trailing '\n'
 
 // Text transforms
-const upper_style = (zz.Style{}).transform(zz.transforms.uppercase);
+const upper_style = zz.newStyle().transform(.uppercase);
 const shouting = try upper_style.render(allocator, "hello"); // "HELLO"
 
 // Inline mode is useful when embedding block-styled output in a single line
-const inline = (zz.Style{}).fg(zz.Color.cyan()).inline_style(true);
+const inline = zz.newStyle().fg(.cyan).inline_style(true);
 
 // Whitespace formatting controls
-const ws_style = (zz.Style{})
+const ws_style = zz.newStyle()
     .underline(true)
     .setUnderlineSpaces(true)      // Underline extends through spaces
     .setColorWhitespace(false);     // Don't apply bg color to whitespace
@@ -204,11 +196,11 @@ const ws_style = (zz.Style{})
 const derived = style.unsetBold().unsetPadding().unsetBorder();
 
 // Style inheritance (unset values inherit from parent)
-const child = (zz.Style{}).fg(zz.Color.red()).inherit(style);
+const child = zz.newStyle().fg(.red).inherit(style);
 
 // Style ranges - apply different styles to byte ranges
 const ranges = &[_]zz.StyleRange{
-    .{ .start = 0, .end = 5, .s = (zz.Style{}).bold(true) },
+    .{ .start = 0, .end = 5, .s = zz.newStyle().bold(true) },
 };
 const ranged = try zz.renderWithRanges(allocator, "Hello World", ranges);
 
@@ -220,9 +212,9 @@ const highlighted = try zz.renderWithHighlights(allocator, "hello", &.{0, 2}, hi
 
 ```zig
 // Basic ANSI colors
-zz.Color.red()
-zz.Color.cyan()
-zz.Color.brightGreen()
+zz.Color.red
+zz.Color.cyan
+zz.Color.brightGreen
 
 // 256-color palette
 zz.Color.color256(123)
@@ -234,9 +226,9 @@ zz.Color.hex("#FF8040")
 
 // Adaptive colors (change based on terminal capabilities)
 const adaptive = zz.AdaptiveColor{
-    .true_color = zz.Color.hex("#FF8040"),
-    .color_256 = zz.Color.color256(208),
-    .ansi = zz.Color.red(),
+    .true_color = .hex("#FF8040"),
+    .color_256 = .color256(208),
+    .ansi = .red,
 };
 const resolved = adaptive.resolve(ctx.true_color, ctx.color_256);
 
@@ -245,7 +237,7 @@ const resolved = adaptive.resolve(ctx.true_color, ctx.color_256);
 // ctx.is_dark_background: bool
 
 // Color interpolation (for gradients)
-const mid = zz.interpolateColor(zz.Color.red(), zz.Color.green(), 0.5);
+const mid = zz.interpolateColor(.red, .green, 0.5);
 ```
 
 ### Borders
@@ -314,8 +306,8 @@ try viewport.setContent(long_text);
 viewport.setWrap(true);
 viewport.setScrollbarChars("·", "█");
 viewport.setScrollbarStyle(
-    (zz.Style{}).fg(zz.Color.gray(8)).inline_style(true),
-    (zz.Style{}).fg(zz.Color.cyan()).inline_style(true),
+    zz.newStyle().fg(.gray(8)).inline_style(true),
+    zz.newStyle().fg(.cyan).inline_style(true),
 );
 viewport.handleKey(key_event);  // Supports j/k, Page Up/Down, etc.
 ```
@@ -327,7 +319,7 @@ Progress bar with optional color gradients:
 ```zig
 var progress = zz.Progress.init();
 progress.setWidth(40);
-progress.setGradient(zz.Color.hex("#FF6B6B"), zz.Color.hex("#4ECDC4"));
+progress.setGradient(.hex("#FF6B6B"), .hex("#4ECDC4"));
 progress.setPercent(75);
 const bar = try progress.view(allocator);
 ```
@@ -398,7 +390,7 @@ Mini chart using Unicode block elements with configurable bucketing, ranges, and
 var spark = zz.Sparkline.init(allocator);
 spark.setWidth(20);
 spark.setSummary(.average);
-spark.setGradient(zz.Color.hex("#F97316"), zz.Color.hex("#22C55E"));
+spark.setGradient(.hex("#F97316"), .hex("#22C55E"));
 try spark.push(10.0);
 try spark.push(25.0);
 try spark.push(15.0);
@@ -421,7 +413,7 @@ chart.x_axis = .{ .title = "Time", .tick_count = 5, .show_grid = true };
 chart.y_axis = .{ .title = "CPU", .tick_count = 5, .show_grid = true };
 
 var dataset = try zz.ChartDataset.init(allocator, "load");
-dataset.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+dataset.setStyle(zz.newStyle().fg(.cyan).bold(true));
 dataset.setShowPoints(true);
 dataset.setInterpolation(.monotone_cubic);
 dataset.setInterpolationSteps(10);
@@ -443,8 +435,8 @@ Vertical or horizontal bar chart with labels, values, and positive/negative base
 var bars = zz.BarChart.init(allocator);
 bars.setOrientation(.horizontal);
 bars.show_values = true;
-try bars.addBar(try zz.Bar.init(allocator, "api", 31));
-try bars.addBar(try zz.Bar.init(allocator, "db", -12));
+try bars.addBar(try .init(allocator, "api", 31));
+try bars.addBar(try .init(allocator, "db", -12));
 const view = try bars.view(allocator);
 ```
 
@@ -459,8 +451,8 @@ defer canvas.deinit();
 canvas.setSize(24, 10);
 canvas.setMarker(.braille);
 canvas.setRanges(.{ .min = -1, .max = 1 }, .{ .min = -1, .max = 1 });
-try canvas.drawLineStyled(-1, -1, 1, 1, (zz.Style{}).fg(zz.Color.yellow()), null);
-try canvas.drawPointStyled(0.25, 0.7, (zz.Style{}).fg(zz.Color.cyan()), null);
+try canvas.drawLineStyled(-1, -1, 1, 1, zz.newStyle().fg(.yellow), null);
+try canvas.drawPointStyled(0.25, 0.7, zz.newStyle().fg(.cyan), null);
 const view = try canvas.view(allocator);
 ```
 
@@ -578,8 +570,8 @@ gauge.label = "CPU";
 gauge.full_char = "\xe2\x96\x88";   // Customizable fill character
 gauge.empty_char = "\xe2\x96\x91";  // Customizable empty character
 gauge.thresholds = &.{
-    .{ .value = 80, .color = zz.Color.yellow() },
-    .{ .value = 90, .color = zz.Color.red() },
+    .{ .value = 80, .color = .yellow },
+    .{ .value = 90, .color = .red },
 };
 const output = gauge.view(allocator);
 ```
@@ -615,7 +607,7 @@ cal.week_start_monday = true;
 cal.day_headers_mon = .{ "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su" }; // Customizable
 cal.month_names = .{ "Jan", "Feb", ... };  // Customizable
 cal.prev_symbol = "\xe2\x97\x80"; // Customizable nav symbols
-cal.addMarkedDate(25, zz.Color.red());
+cal.addMarkedDate(25, .red);
 cal.update(key_event);             // Arrows, Enter, PgUp/PgDn, Shift+L/R
 const output = cal.view(allocator);
 ```
@@ -883,9 +875,9 @@ var fg: zz.FocusGroup(3) = .{ .wrap = false };
 
 // Custom focus ring colors
 const fs = zz.FocusStyle{
-    .focused_border_fg = zz.Color.green(),
-    .blurred_border_fg = zz.Color.gray(8),
-    .border_chars = zz.Border.double,
+    .focused_border_fg = .green,
+    .blurred_border_fg = .gray(8),
+    .border_chars = .double,
 };
 ```
 

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -3,6 +3,7 @@
 //! and the suggestForeground helper for picking readable colors.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const ColorPair = struct {
@@ -48,8 +49,8 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        var result = std.array_list.Managed(u8).init(ctx.allocator);
-        const w = result.writer();
+        var result: Writer.Allocating = .init(ctx.allocator);
+        const w = &result.writer;
 
         // Title
         var title_s = zz.Style{};

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -21,14 +21,14 @@ const Model = struct {
 
     pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
         self.pairs = .{
-            .{ .name = "White on Black", .fg = zz.Color.white(), .bg = zz.Color.black() },
-            .{ .name = "Black on White", .fg = zz.Color.black(), .bg = zz.Color.white() },
-            .{ .name = "Cyan on Dark", .fg = zz.Color.cyan(), .bg = zz.Color.fromRgb(30, 30, 46) },
-            .{ .name = "Gray on Gray", .fg = zz.Color.fromRgb(120, 120, 120), .bg = zz.Color.fromRgb(140, 140, 140) },
-            .{ .name = "Yellow on White", .fg = zz.Color.yellow(), .bg = zz.Color.white() },
-            .{ .name = "Green on Black", .fg = zz.Color.green(), .bg = zz.Color.black() },
-            .{ .name = "Red on Dark Red", .fg = zz.Color.red(), .bg = zz.Color.fromRgb(60, 10, 10) },
-            .{ .name = "Blue on Blue", .fg = zz.Color.fromRgb(100, 100, 200), .bg = zz.Color.fromRgb(80, 80, 180) },
+            .{ .name = "White on Black", .fg = .white, .bg = .black },
+            .{ .name = "Black on White", .fg = .black, .bg = .white },
+            .{ .name = "Cyan on Dark", .fg = .cyan, .bg = .fromRgb(30, 30, 46) },
+            .{ .name = "Gray on Gray", .fg = .fromRgb(120, 120, 120), .bg = .fromRgb(140, 140, 140) },
+            .{ .name = "Yellow on White", .fg = .yellow, .bg = .white },
+            .{ .name = "Green on Black", .fg = .green, .bg = .black },
+            .{ .name = "Red on Dark Red", .fg = .red, .bg = .fromRgb(60, 10, 10) },
+            .{ .name = "Blue on Blue", .fg = .fromRgb(100, 100, 200), .bg = .fromRgb(80, 80, 180) },
         };
         self.selected = 0;
         return .none;
@@ -54,7 +54,7 @@ const Model = struct {
         // Title
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.white());
+        title_s = title_s.fg(.white);
         title_s = title_s.inline_style(true);
         const title = title_s.render(ctx.allocator, "Accessibility: WCAG Contrast Checker") catch "A11y Demo";
         w.print("{s}\n\n", .{title}) catch {};
@@ -77,10 +77,10 @@ const Model = struct {
 
             // Level badge color
             const level_color: zz.Color = switch (level) {
-                .aaa => zz.Color.green(),
-                .aa => zz.Color.cyan(),
-                .aa_large => zz.Color.yellow(),
-                .fail => zz.Color.red(),
+                .aaa => .green,
+                .aa => .cyan,
+                .aa_large => .yellow,
+                .fail => .red,
             };
 
             // Row indicator
@@ -138,20 +138,20 @@ const Model = struct {
         };
         const label_text = a11y_label.format(ctx.allocator) catch "?";
         var label_s = zz.Style{};
-        label_s = label_s.fg(zz.Color.gray(14));
+        label_s = label_s.fg(.gray(14));
         label_s = label_s.inline_style(true);
         const label_rendered = label_s.render(ctx.allocator, label_text) catch label_text;
         w.print("Screen reader: {s}\n", .{label_rendered}) catch {};
 
         // Suggested foreground
         const suggested = zz.a11y.suggestForeground(pair.bg);
-        const sugg_name: []const u8 = if (std.meta.eql(suggested, zz.Color.white())) "white" else "black";
+        const sugg_name: []const u8 = if (std.meta.eql(suggested, .white)) "white" else "black";
         w.print("Suggested foreground for this bg: {s}\n", .{sugg_name}) catch {};
 
         // Help
         w.writeAll("\n") catch {};
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(12));
+        help_s = help_s.fg(.gray(12));
         help_s = help_s.inline_style(true);
         const help = help_s.render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";
         w.writeAll(help) catch {};

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -3,6 +3,7 @@
 //! and the suggestForeground helper for picking readable colors.
 
 const std = @import("std");
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
 const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
@@ -53,11 +54,11 @@ const Model = struct {
         const w = &result.writer;
 
         // Title
-        var title_s = zz.Style{};
-        title_s = title_s.bold(true);
-        title_s = title_s.fg(.white);
-        title_s = title_s.inline_style(true);
-        const title = title_s.render(ctx.allocator, "Accessibility: WCAG Contrast Checker") catch "A11y Demo";
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.white)
+            .inline_style(true)
+            .renderComptime("Accessibility: WCAG Contrast Checker");
         w.print("{s}\n\n", .{title}) catch {};
 
         // Table header
@@ -99,11 +100,11 @@ const Model = struct {
             w.print("{d:.1}:1   ", .{ratio}) catch {};
 
             // Level badge
-            var badge_s = zz.Style{};
-            badge_s = badge_s.fg(level_color);
-            badge_s = badge_s.bold(true);
-            badge_s = badge_s.inline_style(true);
-            const badge = badge_s.render(ctx.allocator, level_name) catch level_name;
+            const badge = zz.newStyle()
+                .fg(level_color)
+                .bold(true)
+                .inline_style(true)
+                .render(ctx.allocator, level_name) catch "";
             w.print("{s}", .{badge}) catch {};
             const badge_len = level_name.len;
             if (badge_len < 10) {
@@ -111,11 +112,11 @@ const Model = struct {
             }
 
             // Sample text with the actual colors
-            var sample_s = zz.Style{};
-            sample_s = sample_s.fg(pair.fg);
-            sample_s = sample_s.bg(pair.bg);
-            sample_s = sample_s.inline_style(true);
-            const sample = sample_s.render(ctx.allocator, " Sample Text ") catch "Sample";
+            const sample = zz.newStyle()
+                .fg(pair.fg)
+                .bg(pair.bg)
+                .inline_style(true)
+                .render(ctx.allocator, " Sample Text ") catch "Sample";
             w.print("{s}", .{sample}) catch {};
 
             w.writeByte('\n') catch {};
@@ -138,10 +139,10 @@ const Model = struct {
             },
         };
         const label_text = a11y_label.format(ctx.allocator) catch "?";
-        var label_s = zz.Style{};
-        label_s = label_s.fg(.gray(14));
-        label_s = label_s.inline_style(true);
-        const label_rendered = label_s.render(ctx.allocator, label_text) catch label_text;
+        const label_rendered = zz.newStyle()
+            .fg(.gray(14))
+            .inline_style(true)
+            .render(ctx.allocator, label_text) catch label_text;
         w.print("Screen reader: {s}\n", .{label_rendered}) catch {};
 
         // Suggested foreground
@@ -151,10 +152,10 @@ const Model = struct {
 
         // Help
         w.writeAll("\n") catch {};
-        var help_s = zz.Style{};
-        help_s = help_s.fg(.gray(12));
-        help_s = help_s.inline_style(true);
-        const help = help_s.render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";
+        const help = comptime zz.newStyle()
+            .fg(.gray(12))
+            .inline_style(true)
+            .renderComptime("Up/Down: select pair | q: quit");
         w.writeAll(help) catch {};
 
         return result.toOwnedSlice() catch "Error";
@@ -162,8 +163,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: GeneralPurposeAllocator = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -156,7 +156,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(.cyan);
         title = title.inline_style(true);
         const title_str = title.render(alloc, "ActionRegistry — one source of truth") catch "";
 
@@ -173,8 +173,8 @@ const Model = struct {
         ) catch "";
 
         var box = zz.Style{};
-        box = box.borderAll(zz.Border.rounded);
-        box = box.borderForeground(zz.Color.gray(8));
+        box = box.borderAll(.rounded);
+        box = box.borderForeground(.gray(8));
         box = box.paddingAll(1);
         const boxed = box.render(alloc, body) catch body;
 

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -2,6 +2,7 @@
 //! One registry feeding both an auto-rendered footer and a fuzzy command palette.
 
 const std = @import("std");
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -154,11 +155,11 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const alloc = ctx.allocator;
 
-        var title = zz.Style{};
-        title = title.bold(true);
-        title = title.fg(.cyan);
-        title = title.inline_style(true);
-        const title_str = title.render(alloc, "ActionRegistry — one source of truth") catch "";
+        const title_str = comptime zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true)
+            .renderComptime("ActionRegistry — one source of truth");
 
         const body = std.fmt.allocPrint(
             alloc,
@@ -172,11 +173,11 @@ const Model = struct {
             .{ self.counter, self.last_action },
         ) catch "";
 
-        var box = zz.Style{};
-        box = box.borderAll(.rounded);
-        box = box.borderForeground(.gray(8));
-        box = box.paddingAll(1);
-        const boxed = box.render(alloc, body) catch body;
+        const boxed = zz.newStyle()
+            .borderAll(.rounded)
+            .borderForeground(.gray(8))
+            .paddingAll(1)
+            .render(alloc, body) catch body;
 
         var footer = zz.ActionFooter.init(&self.registry);
         footer.setWidth(@intCast(ctx.width));
@@ -204,8 +205,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: GeneralPurposeAllocator = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -2,6 +2,7 @@
 //! Demonstrates tweens with various easing functions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -91,8 +92,8 @@ const Model = struct {
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
 
-        var buf = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = buf.writer();
+        var buf: Writer.Allocating = .init(ctx.allocator);
+        const writer = &buf.writer;
         writer.writeAll(title) catch {};
         writer.writeAll("\n\n") catch {};
 

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -2,6 +2,7 @@
 //! Demonstrates tweens with various easing functions.
 
 const std = @import("std");
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
 const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
@@ -86,11 +87,11 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        var title_style = zz.Style{};
-        title_style = title_style.bold(true);
-        title_style = title_style.fg(.magenta);
-        title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.magenta)
+            .inline_style(true)
+            .renderComptime("Animation & Easing Demo");
 
         var buf: Writer.Allocating = .init(ctx.allocator);
         const writer = &buf.writer;
@@ -100,28 +101,28 @@ const Model = struct {
         // Render each tween as a bar
         for (&self.tweens, self.easing_names) |*tw, name| {
             // Label
-            var label_style = zz.Style{};
-            label_style = label_style.fg(.cyan);
-            label_style = label_style.inline_style(true);
-            const label = std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name}) catch "";
-            const styled_label = label_style.render(ctx.allocator, label) catch label;
-            writer.writeAll(styled_label) catch {};
+            const label_text = std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name}) catch "";
+            const label = zz.newStyle()
+                .fg(.cyan)
+                .inline_style(true)
+                .render(ctx.allocator, label_text) catch label_text;
+            writer.writeAll(label) catch {};
 
             // Bar
             const pos = @as(usize, @intFromFloat(@max(0, tw.value())));
             for (0..30) |i| {
                 if (i == pos) {
-                    var dot_style = zz.Style{};
-                    dot_style = dot_style.fg(.green);
-                    dot_style = dot_style.bold(true);
-                    dot_style = dot_style.inline_style(true);
-                    const dot = dot_style.render(ctx.allocator, "●") catch "o";
+                    const dot = comptime zz.newStyle()
+                        .fg(.green)
+                        .bold(true)
+                        .inline_style(true)
+                        .renderComptime("●");
                     writer.writeAll(dot) catch {};
                 } else {
-                    var track_style = zz.Style{};
-                    track_style = track_style.fg(.gray(6));
-                    track_style = track_style.inline_style(true);
-                    const track = track_style.render(ctx.allocator, "─") catch "-";
+                    const track = comptime zz.newStyle()
+                        .fg(.gray(6))
+                        .inline_style(true)
+                        .renderComptime("─");
                     writer.writeAll(track) catch {};
                 }
             }
@@ -130,27 +131,27 @@ const Model = struct {
 
         // Color tween demo
         writer.writeAll("\n") catch {};
-        var color_label_style = zz.Style{};
-        color_label_style = color_label_style.fg(.cyan);
-        color_label_style = color_label_style.inline_style(true);
-        const color_label = color_label_style.render(ctx.allocator, "     Color tween: ") catch "";
+        const color_label = comptime zz.newStyle()
+            .fg(.cyan)
+            .inline_style(true)
+            .renderComptime("     Color tween: ");
         writer.writeAll(color_label) catch {};
 
         const ct = self.color_tween.value();
         const color = zz.tweenColor(.red, .cyan, ct);
-        var cs = zz.Style{};
-        cs = cs.fg(color);
-        cs = cs.bold(true);
-        cs = cs.inline_style(true);
-        const color_block = cs.render(ctx.allocator, "████████████████████████████████") catch "";
+        const color_block = zz.newStyle()
+            .fg(color)
+            .bold(true)
+            .inline_style(true)
+            .render(ctx.allocator, "████████████████████████████████") catch "";
         writer.writeAll(color_block) catch {};
 
         // Help
         writer.writeAll("\n\n") catch {};
-        var help_style = zz.Style{};
-        help_style = help_style.fg(.gray(12));
-        help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "r: restart animations | q: quit") catch "";
+        const help = comptime zz.newStyle()
+            .fg(.gray(12))
+            .inline_style(true)
+            .renderComptime("r: restart animations | q: quit");
         writer.writeAll(help) catch {};
 
         return buf.toOwnedSlice() catch "Error";
@@ -158,8 +159,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: GeneralPurposeAllocator = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -87,7 +87,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
 
@@ -100,7 +100,7 @@ const Model = struct {
         for (&self.tweens, self.easing_names) |*tw, name| {
             // Label
             var label_style = zz.Style{};
-            label_style = label_style.fg(zz.Color.cyan());
+            label_style = label_style.fg(.cyan);
             label_style = label_style.inline_style(true);
             const label = std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name}) catch "";
             const styled_label = label_style.render(ctx.allocator, label) catch label;
@@ -111,14 +111,14 @@ const Model = struct {
             for (0..30) |i| {
                 if (i == pos) {
                     var dot_style = zz.Style{};
-                    dot_style = dot_style.fg(zz.Color.green());
+                    dot_style = dot_style.fg(.green);
                     dot_style = dot_style.bold(true);
                     dot_style = dot_style.inline_style(true);
                     const dot = dot_style.render(ctx.allocator, "●") catch "o";
                     writer.writeAll(dot) catch {};
                 } else {
                     var track_style = zz.Style{};
-                    track_style = track_style.fg(zz.Color.gray(6));
+                    track_style = track_style.fg(.gray(6));
                     track_style = track_style.inline_style(true);
                     const track = track_style.render(ctx.allocator, "─") catch "-";
                     writer.writeAll(track) catch {};
@@ -130,13 +130,13 @@ const Model = struct {
         // Color tween demo
         writer.writeAll("\n") catch {};
         var color_label_style = zz.Style{};
-        color_label_style = color_label_style.fg(zz.Color.cyan());
+        color_label_style = color_label_style.fg(.cyan);
         color_label_style = color_label_style.inline_style(true);
         const color_label = color_label_style.render(ctx.allocator, "     Color tween: ") catch "";
         writer.writeAll(color_label) catch {};
 
         const ct = self.color_tween.value();
-        const color = zz.tweenColor(zz.Color.red(), zz.Color.cyan(), ct);
+        const color = zz.tweenColor(.red, .cyan, ct);
         var cs = zz.Style{};
         cs = cs.fg(color);
         cs = cs.bold(true);
@@ -147,7 +147,7 @@ const Model = struct {
         // Help
         writer.writeAll("\n\n") catch {};
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator, "r: restart animations | q: quit") catch "";
         writer.writeAll(help) catch {};

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -100,16 +100,16 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var status_s = zz.Style{};
-        status_s = status_s.fg(zz.Color.yellow());
+        status_s = status_s.fg(.yellow);
         status_s = status_s.inline_style(true);
 
         var box_s = zz.Style{};
-        box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderAll(.rounded);
+        box_s = box_s.borderForeground(.cyan);
         box_s = box_s.paddingAll(1);
         box_s = box_s.width(45);
 
@@ -119,7 +119,7 @@ const Model = struct {
         ) catch "";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -2,6 +2,7 @@
 //! Demonstrates spawning background tasks that report results.
 
 const std = @import("std");
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -98,37 +99,41 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const alloc = ctx.allocator;
 
-        var title_s = zz.Style{};
-        title_s = title_s.bold(true);
-        title_s = title_s.fg(.cyan);
-        title_s = title_s.inline_style(true);
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true)
+            .renderComptime("Async Tasks Demo");
 
-        var status_s = zz.Style{};
-        status_s = status_s.fg(.yellow);
-        status_s = status_s.inline_style(true);
+        var status_s = zz.newStyle()
+            .fg(.yellow)
+            .inline_style(true);
 
-        var box_s = zz.Style{};
-        box_s = box_s.borderAll(.rounded);
-        box_s = box_s.borderForeground(.cyan);
-        box_s = box_s.paddingAll(1);
-        box_s = box_s.width(45);
+        var box_s = zz.newStyle()
+            .borderAll(.rounded)
+            .borderForeground(.cyan)
+            .paddingAll(1)
+            .width(45);
 
-        const results_text = std.fmt.allocPrint(alloc,
+        const results_text = std.fmt.allocPrint(
+            alloc,
             "1: {s}\n2: {s}\n3: {s}",
             .{ self.results[0], self.results[1], self.results[2] },
         ) catch "";
 
-        var help_s = zz.Style{};
-        help_s = help_s.fg(.gray(10));
-        help_s = help_s.inline_style(true);
+        const help = comptime zz.newStyle()
+            .fg(.gray(10))
+            .inline_style(true)
+            .renderComptime("s: start tasks  q: quit");
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, "Async Tasks Demo") catch "Async Tasks",
+                title,
                 status_s.render(alloc, self.status) catch self.status,
                 box_s.render(alloc, results_text) catch results_text,
-                help_s.render(alloc, "s: start tasks  q: quit") catch "",
+                help,
             },
         ) catch "Error";
 
@@ -137,8 +142,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: GeneralPurposeAllocator = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -77,7 +77,7 @@ const Model = struct {
 
         // Faint grid: dotted border + crosshair through the centre.
         var grid_style = zz.Style{};
-        grid_style = grid_style.fg(zz.Color.gray(6));
+        grid_style = grid_style.fg(.gray(6));
         grid_style = grid_style.inline_style(true);
 
         const w = c.pixelWidth();
@@ -91,12 +91,12 @@ const Model = struct {
         const ty: i32 = @intFromFloat(self.ball_y);
 
         var trail_style = zz.Style{};
-        trail_style = trail_style.fg(zz.Color.cyan());
+        trail_style = trail_style.fg(.cyan);
         trail_style = trail_style.inline_style(true);
         c.drawCircleStyled(tx, ty, 3, trail_style);
 
         var ball_style = zz.Style{};
-        ball_style = ball_style.fg(zz.Color.magenta());
+        ball_style = ball_style.fg(.magenta);
         ball_style = ball_style.bold(true);
         ball_style = ball_style.inline_style(true);
         c.drawCircleStyled(tx, ty, 1, ball_style);
@@ -105,17 +105,17 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "BrailleCanvas — bouncing ball") catch "";
 
         var box = zz.Style{};
-        box = box.borderAll(zz.Border.rounded);
-        box = box.borderForeground(zz.Color.gray(8));
+        box = box.borderAll(.rounded);
+        box = box.borderForeground(.gray(8));
         const boxed = box.render(alloc, canvas_view) catch canvas_view;
 
         var help = zz.Style{};
-        help = help.fg(zz.Color.gray(10));
+        help = help.fg(.gray(10));
         help = help.inline_style(true);
         const status = if (self.paused) "PAUSED  " else "        ";
         const help_text = std.fmt.allocPrint(

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -2,6 +2,7 @@
 //! Animated bouncing ball with a faint grid background.
 
 const std = @import("std");
+const GeneralPurposeAllocator = std.heap.GeneralPurposeAllocator(.{});
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -76,9 +77,9 @@ const Model = struct {
         c.clear();
 
         // Faint grid: dotted border + crosshair through the centre.
-        var grid_style = zz.Style{};
-        grid_style = grid_style.fg(.gray(6));
-        grid_style = grid_style.inline_style(true);
+        const grid_style = zz.newStyle()
+            .fg(.gray(6))
+            .inline_style(true);
 
         const w = c.pixelWidth();
         const h = c.pixelHeight();
@@ -90,42 +91,43 @@ const Model = struct {
         const tx: i32 = @intFromFloat(self.ball_x);
         const ty: i32 = @intFromFloat(self.ball_y);
 
-        var trail_style = zz.Style{};
-        trail_style = trail_style.fg(.cyan);
-        trail_style = trail_style.inline_style(true);
+        const trail_style = zz.newStyle()
+            .fg(.cyan)
+            .inline_style(true);
         c.drawCircleStyled(tx, ty, 3, trail_style);
 
-        var ball_style = zz.Style{};
-        ball_style = ball_style.fg(.magenta);
-        ball_style = ball_style.bold(true);
-        ball_style = ball_style.inline_style(true);
+        const ball_style = zz.newStyle()
+            .fg(.magenta)
+            .bold(true)
+            .inline_style(true);
         c.drawCircleStyled(tx, ty, 1, ball_style);
 
         const canvas_view = c.view(alloc) catch "";
 
-        var title = zz.Style{};
-        title = title.bold(true);
-        title = title.fg(.cyan);
-        title = title.inline_style(true);
-        const t = title.render(alloc, "BrailleCanvas — bouncing ball") catch "";
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true)
+            .renderComptime("BrailleCanvas — bouncing ball");
 
-        var box = zz.Style{};
-        box = box.borderAll(.rounded);
-        box = box.borderForeground(.gray(8));
-        const boxed = box.render(alloc, canvas_view) catch canvas_view;
+        const boxed = zz.newStyle()
+            .borderAll(.rounded)
+            .borderForeground(.gray(8))
+            .render(alloc, canvas_view) catch canvas_view;
 
-        var help = zz.Style{};
-        help = help.fg(.gray(10));
-        help = help.inline_style(true);
         const status = if (self.paused) "PAUSED  " else "        ";
         const help_text = std.fmt.allocPrint(
             alloc,
             "{s}space pause  r reset  q quit   |   frame {d}",
             .{ status, self.frame },
         ) catch "";
-        const help_str = help.render(alloc, help_text) catch "";
 
-        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str }) catch "Error";
+        const help = zz.newStyle()
+            .fg(.gray(10))
+            .inline_style(true)
+            .render(alloc, help_text) catch "";
+
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ title, boxed, help }) catch "Error";
     }
 
     pub fn deinit(self: *Model) void {
@@ -134,8 +136,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: GeneralPurposeAllocator = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -45,35 +45,34 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const alloc = ctx.allocator;
 
-        var title_s = zz.Style{};
-        title_s = title_s.bold(true);
-        title_s = title_s.fg(.cyan);
-        title_s = title_s.inline_style(true);
-
-        var box_style = zz.Style{};
-        box_style = box_style.borderAll(.rounded);
-        box_style = box_style.borderForeground(.cyan);
-        box_style = box_style.paddingAll(1);
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true)
+            .renderComptime("Calendar Demo");
 
         const cal_view = self.cal.view(alloc);
-        const boxed = box_style.render(alloc, cal_view) catch cal_view;
+        const boxed = zz.newStyle()
+            .borderAll(.rounded)
+            .borderForeground(.cyan)
+            .paddingAll(1)
+            .render(alloc, cal_view) catch cal_view;
 
         const selected_str = std.fmt.allocPrint(alloc, "Selected: {d}/{d}/{d}", .{
-            self.cal.selected_day, self.cal.month, self.cal.year,
+            self.cal.selected_day,
+            self.cal.month,
+            self.cal.year,
         }) catch "";
 
-        var help_s = zz.Style{};
-        help_s = help_s.fg(.gray(10));
-        help_s = help_s.inline_style(true);
+        const help = comptime zz.newStyle()
+            .fg(.gray(10))
+            .inline_style(true)
+            .renderComptime("Arrows: navigate  Enter: select  Shift+L/R: month  PgUp/Dn: month  q: quit");
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
-            .{
-                title_s.render(alloc, "Calendar Demo") catch "Calendar",
-                boxed,
-                selected_str,
-                help_s.render(alloc, "Arrows: navigate  Enter: select  Shift+L/R: month  PgUp/Dn: month  q: quit") catch "",
-            },
+            .{ title, boxed, selected_str, help },
         ) catch "Error";
 
         return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -22,9 +22,9 @@ const Model = struct {
             .today_year = 2026,
         };
         // Mark some dates
-        self.cal.addMarkedDate(25, zz.Color.red());
-        self.cal.addMarkedDate(1, zz.Color.green());
-        self.cal.addMarkedDate(14, zz.Color.magenta());
+        self.cal.addMarkedDate(25, .red);
+        self.cal.addMarkedDate(1, .green);
+        self.cal.addMarkedDate(14, .magenta);
         return .none;
     }
 
@@ -47,12 +47,12 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.cyan);
         box_style = box_style.paddingAll(1);
 
         const cal_view = self.cal.view(alloc);
@@ -63,7 +63,7 @@ const Model = struct {
         }) catch "";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -33,18 +33,18 @@ const Model = struct {
         };
 
         var cpu = zz.ChartDataset.init(ctx.persistent_allocator, "CPU") catch unreachable;
-        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+        cpu.setStyle((zz.Style{}).fg(.cyan).bold(true));
         cpu.setShowPoints(true);
         cpu.setInterpolation(.monotone_cubic);
         cpu.setInterpolationSteps(10);
 
         var mem = zz.ChartDataset.init(ctx.persistent_allocator, "Memory") catch unreachable;
-        mem.setStyle((zz.Style{}).fg(zz.Color.magenta()));
+        mem.setStyle((zz.Style{}).fg(.magenta));
         mem.setInterpolation(.catmull_rom);
         mem.setInterpolationSteps(10);
 
         var backlog = zz.ChartDataset.init(ctx.persistent_allocator, "Backlog") catch unreachable;
-        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow()));
+        backlog.setStyle((zz.Style{}).fg(.yellow));
         backlog.setGraphType(.area);
         backlog.setInterpolation(.step_center);
         backlog.setFillBaseline(18.0);
@@ -65,10 +65,10 @@ const Model = struct {
         self.bars.setBarWidth(1);
         self.bars.setGap(0);
         self.bars.show_values = false;
-        self.bars.label_style = (zz.Style{}).fg(zz.Color.gray(18)).inline_style(true);
-        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green()).inline_style(true);
-        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red()).inline_style(true);
-        self.bars.axis_style = (zz.Style{}).fg(zz.Color.gray(10)).inline_style(true);
+        self.bars.label_style = (zz.Style{}).fg(.gray(18)).inline_style(true);
+        self.bars.positive_style = (zz.Style{}).fg(.green).inline_style(true);
+        self.bars.negative_style = (zz.Style{}).fg(.red).inline_style(true);
+        self.bars.axis_style = (zz.Style{}).fg(.gray(10)).inline_style(true);
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "api", 31) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "db", -12) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "queue", 22) catch unreachable) catch unreachable;
@@ -78,7 +78,7 @@ const Model = struct {
         self.spark.setWidth(22);
         self.spark.setSummary(.average);
         self.spark.setRetentionLimit(120);
-        self.spark.setGradient(zz.Color.hex("#F97316"), zz.Color.hex("#22C55E"));
+        self.spark.setGradient(.hex("#F97316"), .hex("#22C55E"));
 
         for (0..60) |i| {
             const x = @as(f64, @floatFromInt(i));
@@ -225,7 +225,7 @@ const Model = struct {
         canvas.setRanges(.{ .min = -1.2, .max = 1.2 }, .{ .min = -1.2, .max = 1.2 });
 
         var point_style = zz.Style{};
-        point_style = point_style.fg(zz.Color.yellow());
+        point_style = point_style.fg(.yellow);
         point_style = point_style.inline_style(true);
 
         for (0..64) |i| {
@@ -251,7 +251,7 @@ const Model = struct {
         chart.y_axis = .{ .title = if (compact) "" else "Revenue", .tick_count = if (ultra) 3 else 4, .show_grid = !ultra };
 
         var actual = try zz.ChartDataset.init(ctx.allocator, "Actual");
-        actual.setStyle((zz.Style{}).fg(zz.Color.hex("#22C55E")).bold(true));
+        actual.setStyle((zz.Style{}).fg(.hex("#22C55E")).bold(true));
         actual.setInterpolation(.monotone_cubic);
         actual.setInterpolationSteps(10);
         actual.setShowPoints(true);
@@ -263,7 +263,7 @@ const Model = struct {
         });
 
         var forecast = try zz.ChartDataset.init(ctx.allocator, "Forecast");
-        forecast.setStyle((zz.Style{}).fg(zz.Color.hex("#38BDF8")));
+        forecast.setStyle((zz.Style{}).fg(.hex("#38BDF8")));
         forecast.setInterpolation(.step_end);
         try forecast.setPoints(&.{
             .{ .x = 1, .y = 16 },
@@ -280,13 +280,13 @@ const Model = struct {
 
 fn box(ctx: *const zz.Context, title: []const u8, body: []const u8) ![]const u8 {
     var style = zz.Style{};
-    style = style.borderAll(zz.Border.rounded);
-    style = style.borderForeground(zz.Color.gray(12));
+    style = style.borderAll(.rounded);
+    style = style.borderForeground(.gray(12));
     style = style.paddingLeft(1).paddingRight(1);
 
     var header_style = zz.Style{};
     header_style = header_style.bold(true);
-    header_style = header_style.fg(zz.Color.cyan());
+    header_style = header_style.fg(.cyan);
     header_style = header_style.inline_style(true);
     const header = try header_style.render(ctx.allocator, title);
 
@@ -296,13 +296,13 @@ fn box(ctx: *const zz.Context, title: []const u8, body: []const u8) ![]const u8 
 
 fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]const u8 {
     var label_style = zz.Style{};
-    label_style = label_style.fg(zz.Color.gray(15));
+    label_style = label_style.fg(.gray(15));
     label_style = label_style.inline_style(true);
     const rendered_label = try label_style.render(ctx.allocator, label);
 
     var value_style = zz.Style{};
     value_style = value_style.bold(true);
-    value_style = value_style.fg(zz.Color.white());
+    value_style = value_style.fg(.white);
     value_style = value_style.inline_style(true);
     const rendered_value = try value_style.render(ctx.allocator, value);
 

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -83,12 +83,12 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
 
         var section_style = zz.Style{};
         section_style = section_style.bold(true);
-        section_style = section_style.fg(zz.Color.cyan());
+        section_style = section_style.fg(.cyan);
         section_style = section_style.inline_style(true);
 
         const title = title_style.render(ctx.allocator, "Checkbox & Radio Example") catch "Title";
@@ -112,7 +112,7 @@ const Model = struct {
             "None selected";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator, "Tab: switch focus | Space/Enter: toggle/select | q: quit") catch "";
 

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -153,15 +153,15 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
 
         var info_style = zz.Style{};
-        info_style = info_style.fg(zz.Color.gray(16));
+        info_style = info_style.fg(.gray(16));
         info_style = info_style.inline_style(true);
 
         var hint_style = zz.Style{};
-        hint_style = hint_style.fg(zz.Color.gray(12));
+        hint_style = hint_style.fg(.gray(12));
         hint_style = hint_style.inline_style(true);
 
         const title = title_style.render(ctx.allocator, "OSC 52 Clipboard Demo") catch "OSC 52 Clipboard Demo";

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -12,7 +12,7 @@ const zig_source =
     \\    defer _ = gpa.deinit();
     \\
     \\    const allocator = gpa.allocator();
-    \\    var list = std.ArrayList(u32).init(allocator);
+    \\    var list = std.std.array_list.Managed(u32).init(allocator);
     \\    defer list.deinit();
     \\
     \\    // Add some numbers

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -75,7 +75,7 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var cv = zz.components.code_view.CodeView{};
@@ -91,15 +91,15 @@ const Model = struct {
         }
 
         var box_s = zz.Style{};
-        box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.gray(10));
+        box_s = box_s.borderAll(.rounded);
+        box_s = box_s.borderForeground(.gray(10));
         box_s = box_s.paddingAll(1);
 
         const code_output = cv.view(alloc);
         const boxed = box_s.render(alloc, code_output) catch code_output;
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const header = std.fmt.allocPrint(alloc, "{s}  [{s}]", .{

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -2,6 +2,7 @@
 //! Demonstrates a popup context menu triggered by keyboard.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Action = enum { cut, copy, paste, delete, select_all, properties };
@@ -89,8 +90,8 @@ const Model = struct {
         const title = title_style.render(ctx.allocator, "Context Menu Example") catch "Context Menu";
 
         // File list
-        var list_buf = std.array_list.Managed(u8).init(ctx.allocator);
-        const lw = list_buf.writer();
+        var list_buf: Writer.Allocating = .init(ctx.allocator);
+        const lw = &list_buf.writer;
         for (self.items, 0..) |item, i| {
             if (i > 0) lw.writeByte('\n') catch {};
             if (i == self.selected) {

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -84,7 +84,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Context Menu Example") catch "Context Menu";
 
@@ -96,7 +96,7 @@ const Model = struct {
             if (i == self.selected) {
                 var sel_style = zz.Style{};
                 sel_style = sel_style.bold(true);
-                sel_style = sel_style.fg(zz.Color.cyan());
+                sel_style = sel_style.fg(.cyan);
                 sel_style = sel_style.inline_style(true);
                 const line = std.fmt.allocPrint(ctx.allocator, "  > {s}", .{item}) catch "";
                 const styled = sel_style.render(ctx.allocator, line) catch line;
@@ -110,7 +110,7 @@ const Model = struct {
 
         // Status
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.green());
+        status_style = status_style.fg(.green);
         status_style = status_style.inline_style(true);
         const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;
 
@@ -118,7 +118,7 @@ const Model = struct {
         const menu_view = self.menu.view(ctx.allocator) catch "";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator, "Up/Down: navigate | Space/Enter: context menu | Esc: close | q: quit") catch "";
 

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -41,7 +41,7 @@ const Model = struct {
         // Title style
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
 
         // Counter value style - changes color based on value
@@ -49,16 +49,16 @@ const Model = struct {
         counter_style = counter_style.bold(true);
         counter_style = counter_style.inline_style(true);
         counter_style = counter_style.fg(if (self.count > 0)
-            zz.Color.green()
+            .green
         else if (self.count < 0)
-            zz.Color.red()
+            .red
         else
-            zz.Color.white());
+            .white);
 
         // Border style
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.cyan);
         box_style = box_style.paddingAll(1);
         box_style = box_style.alignH(.center);
 
@@ -75,7 +75,7 @@ const Model = struct {
         const boxed = box_style.render(ctx.allocator, content) catch content;
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -85,7 +85,7 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.hex("#FF6B6B"));
+        title_style = title_style.fg(.hex("#FF6B6B"));
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Dashboard") catch "Dashboard";
 
@@ -104,7 +104,7 @@ const Model = struct {
 
         // Help
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,
@@ -141,23 +141,23 @@ const Model = struct {
 
     fn renderStats(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.cyan);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(25);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.cyan());
+        header_style = header_style.fg(.cyan);
         header_style = header_style.inline_style(true);
 
         var value_style = zz.Style{};
         value_style = value_style.bold(true);
-        value_style = value_style.fg(zz.Color.white());
+        value_style = value_style.fg(.white);
         value_style = value_style.inline_style(true);
 
         var label_style = zz.Style{};
-        label_style = label_style.fg(zz.Color.gray(15));
+        label_style = label_style.fg(.gray(15));
         label_style = label_style.inline_style(true);
 
         const header = try header_style.render(ctx.allocator, "Statistics");
@@ -182,28 +182,28 @@ const Model = struct {
 
     fn renderProgress(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.magenta());
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.magenta);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(40);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.magenta());
+        header_style = header_style.fg(.magenta);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Progress");
 
         const progress_bar = try self.progress.view(ctx.allocator);
 
         var timer_label_style = zz.Style{};
-        timer_label_style = timer_label_style.fg(zz.Color.gray(15));
+        timer_label_style = timer_label_style.fg(.gray(15));
         timer_label_style = timer_label_style.inline_style(true);
         const timer_label = timer_label_style.render(ctx.allocator, "Elapsed: ") catch "";
         const timer_view = try self.timer.view(ctx.allocator);
 
         // Show paused indicator
         var paused_style = zz.Style{};
-        paused_style = paused_style.fg(zz.Color.yellow());
+        paused_style = paused_style.fg(.yellow);
         paused_style = paused_style.inline_style(true);
         const paused_indicator = if (!self.timer.running)
             paused_style.render(ctx.allocator, " (PAUSED)") catch ""
@@ -221,22 +221,22 @@ const Model = struct {
 
     fn renderActivity(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.green());
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.green);
         box_style = box_style.paddingAll(1);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.green());
+        header_style = header_style.fg(.green);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Activity");
 
         var complete_style = zz.Style{};
-        complete_style = complete_style.fg(zz.Color.green());
+        complete_style = complete_style.fg(.green);
         complete_style = complete_style.inline_style(true);
 
         var progress_style = zz.Style{};
-        progress_style = progress_style.fg(zz.Color.yellow());
+        progress_style = progress_style.fg(.yellow);
         progress_style = progress_style.inline_style(true);
 
         const is_complete = self.task_progress >= 100;

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -66,7 +66,7 @@ const Model = struct {
 
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(alloc, "DataTable — frozen columns + cell cursor") catch "";
 
@@ -74,7 +74,7 @@ const Model = struct {
         const table_view = table_mut.view(alloc) catch "";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(10));
+        help_style = help_style.fg(.gray(10));
         help_style = help_style.inline_style(true);
         const help_text = std.fmt.allocPrint(
             alloc,

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -63,7 +63,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "DevConsole — log streamer") catch "";
 
@@ -85,13 +85,13 @@ const Model = struct {
         ) catch "";
 
         var box = zz.Style{};
-        box = box.borderAll(zz.Border.rounded);
-        box = box.borderForeground(zz.Color.gray(8));
+        box = box.borderAll(.rounded);
+        box = box.borderForeground(.gray(8));
         box = box.paddingAll(1);
         const boxed = box.render(alloc, body) catch body;
 
         var help = zz.Style{};
-        help = help.fg(zz.Color.gray(10));
+        help = help.fg(.gray(10));
         help = help.inline_style(true);
         const help_str = help.render(alloc, "space warn · r reset · q quit") catch "";
 

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -63,7 +63,7 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var dv = zz.components.diff_view.DiffView{};
@@ -74,8 +74,8 @@ const Model = struct {
         dv.mode = if (self.side_by_side) .side_by_side else .unified;
 
         var box_s = zz.Style{};
-        box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.gray(10));
+        box_s = box_s.borderAll(.rounded);
+        box_s = box_s.borderForeground(.gray(10));
         box_s = box_s.paddingAll(1);
 
         const diff_output = dv.view(alloc);
@@ -84,7 +84,7 @@ const Model = struct {
         const mode_label: []const u8 = if (self.side_by_side) "side-by-side" else "unified";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         return std.fmt.allocPrint(alloc, "{s}  [{s}]\n\n{s}\n\n{s}", .{

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -82,7 +82,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Dropdown Example") catch "Dropdown Example";
 
@@ -99,7 +99,7 @@ const Model = struct {
         const topping_info = std.fmt.allocPrint(ctx.allocator, "Selected toppings: {d}", .{topping_count}) catch "?";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -88,7 +88,7 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "File Browser") catch "File Browser";
 
@@ -99,13 +99,13 @@ const Model = struct {
         var preview_section: []const u8 = "";
         if (self.file_picker.getSelected()) |path| {
             var path_style = zz.Style{};
-            path_style = path_style.fg(zz.Color.green());
+            path_style = path_style.fg(.green);
             path_style = path_style.inline_style(true);
             const path_display = path_style.render(ctx.allocator, path) catch path;
 
             var preview_style = zz.Style{};
-            preview_style = preview_style.borderAll(zz.Border.normal);
-            preview_style = preview_style.borderForeground(zz.Color.gray(12));
+            preview_style = preview_style.borderAll(.normal);
+            preview_style = preview_style.borderForeground(.gray(12));
 
             const preview_content = if (self.preview.items.len > 0)
                 self.preview.items
@@ -125,7 +125,7 @@ const Model = struct {
 
         // Help
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -58,14 +58,14 @@ const Model = struct {
         // -- Render each panel into styled boxes --
 
         // Header
-        const header = renderPanel(alloc, "Dashboard", rows[0].width, rows[0].height, zz.Color.cyan(), true);
+        const header = renderPanel(alloc, "Dashboard", rows[0].width, rows[0].height, .cyan, true);
 
         // Sidebar
         const sidebar_items =
             "  [1] Overview\n" ++
             "  [2] Metrics\n" ++
             "  [3] Settings";
-        const sidebar = renderPanel(alloc, sidebar_items, cols[0].width, cols[0].height, zz.Color.magenta(), self.selected_panel == 0);
+        const sidebar = renderPanel(alloc, sidebar_items, cols[0].width, cols[0].height, .magenta, self.selected_panel == 0);
 
         // Main content area
         const main_text = switch (self.selected_panel) {
@@ -74,14 +74,14 @@ const Model = struct {
             2 => "Theme: Dark\nRefresh: 5s\nNotifications: On",
             else => "",
         };
-        const main_panel = renderPanel(alloc, main_text, cols[1].width, cols[1].height, zz.Color.green(), self.selected_panel == 1);
+        const main_panel = renderPanel(alloc, main_text, cols[1].width, cols[1].height, .green, self.selected_panel == 1);
 
         // Footer
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const footer_text = help_style.render(alloc, "Tab: cycle panels  1/2/3: select panel  q: quit") catch "Tab: cycle  q: quit";
-        const footer = renderPanel(alloc, footer_text, rows[2].width, rows[2].height, zz.Color.gray(8), false);
+        const footer = renderPanel(alloc, footer_text, rows[2].width, rows[2].height, .gray(8), false);
 
         // Compose the body row: sidebar | main
         const body = zz.join.horizontal(alloc, .top, &.{ sidebar, main_panel }) catch main_panel;
@@ -92,11 +92,11 @@ const Model = struct {
 
     fn renderPanel(alloc: std.mem.Allocator, content: []const u8, w: u16, h: u16, border_color: zz.Color, highlight: bool) []const u8 {
         var s = zz.Style{};
-        s = s.borderAll(zz.Border.rounded);
+        s = s.borderAll(.rounded);
         if (highlight) {
             s = s.borderForeground(border_color);
         } else {
-            s = s.borderForeground(zz.Color.gray(6));
+            s = s.borderForeground(.gray(6));
         }
         // Account for border (2 cells each side)
         const inner_w: u16 = if (w > 4) w - 4 else 1;

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -83,24 +83,26 @@ const Model = struct {
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         // Title
-        var title_style = zz.Style{};
-        title_style = title_style.bold(true);
-        title_style = title_style.fg(.hex("#FF6B6B"));
-        title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Contact Form") catch "Contact Form";
+        const title = comptime zz.newStyle()
+            .bold(true)
+            .fg(.hex("#FF6B6B"))
+            .inline_style(true)
+            .renderComptime("Contact Form");
 
         // Subtitle
-        var sub_style = zz.Style{};
-        sub_style = sub_style.fg(.gray(15));
-        sub_style = sub_style.inline_style(true);
+        var sub_style = zz.newStyle()
+            .fg(.gray(15))
+            .inline_style(true);
+        // sub_style = sub_style.fg(.gray(15));
+        // sub_style = sub_style.inline_style(true);
         const subtitle = sub_style.render(ctx.allocator, "Tab/Shift+Tab to navigate • Enter to submit • Esc to quit") catch "";
 
         // Field labels
-        var label_style = zz.Style{};
+        var label_style = zz.newStyle();
         label_style = label_style.bold(true);
         label_style = label_style.inline_style(true);
 
-        var focused_label = zz.Style{};
+        var focused_label = zz.newStyle();
         focused_label = focused_label.bold(true);
         focused_label = focused_label.fg(.cyan);
         focused_label = focused_label.inline_style(true);
@@ -133,7 +135,7 @@ const Model = struct {
 
         // Status line
         const status = if (self.submitted) blk: {
-            var success_style = zz.Style{};
+            var success_style = zz.newStyle();
             success_style = success_style.bold(true);
             success_style = success_style.fg(.green);
             success_style = success_style.inline_style(true);
@@ -153,7 +155,7 @@ const Model = struct {
             ) catch "✓ Submitted!";
             break :blk success_style.render(ctx.allocator, text) catch text;
         } else blk: {
-            var hint_style = zz.Style{};
+            var hint_style = zz.newStyle();
             hint_style = hint_style.fg(.gray(12));
             hint_style = hint_style.inline_style(true);
             const field_name = switch (self.focus_group.focused()) {
@@ -200,7 +202,7 @@ const Model = struct {
 
     fn renderField(self: *const Model, ctx: *const zz.Context, label: []const u8, input_view: []const u8, index: usize) []const u8 {
         const content = std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ label, input_view }) catch input_view;
-        var box = zz.Style{};
+        var box = zz.newStyle();
         box = box.paddingLeft(1);
         box = box.paddingRight(1);
         box = box.width(40);

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -85,13 +85,13 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.hex("#FF6B6B"));
+        title_style = title_style.fg(.hex("#FF6B6B"));
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Contact Form") catch "Contact Form";
 
         // Subtitle
         var sub_style = zz.Style{};
-        sub_style = sub_style.fg(zz.Color.gray(15));
+        sub_style = sub_style.fg(.gray(15));
         sub_style = sub_style.inline_style(true);
         const subtitle = sub_style.render(ctx.allocator, "Tab/Shift+Tab to navigate • Enter to submit • Esc to quit") catch "";
 
@@ -102,7 +102,7 @@ const Model = struct {
 
         var focused_label = zz.Style{};
         focused_label = focused_label.bold(true);
-        focused_label = focused_label.fg(zz.Color.cyan());
+        focused_label = focused_label.fg(.cyan);
         focused_label = focused_label.inline_style(true);
 
         // Render each field with focus indicator
@@ -135,7 +135,7 @@ const Model = struct {
         const status = if (self.submitted) blk: {
             var success_style = zz.Style{};
             success_style = success_style.bold(true);
-            success_style = success_style.fg(zz.Color.green());
+            success_style = success_style.fg(.green);
             success_style = success_style.inline_style(true);
 
             const name_val = self.name_input.getValue();
@@ -154,7 +154,7 @@ const Model = struct {
             break :blk success_style.render(ctx.allocator, text) catch text;
         } else blk: {
             var hint_style = zz.Style{};
-            hint_style = hint_style.fg(zz.Color.gray(12));
+            hint_style = hint_style.fg(.gray(12));
             hint_style = hint_style.inline_style(true);
             const field_name = switch (self.focus_group.focused()) {
                 0 => "Name",

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -31,7 +31,7 @@ const Model = struct {
         self.form.addField("Terms", &self.agree_checkbox, .{});
         self.form.initFocus();
 
-        self.status = "Fill out the form and press Ctrl+Enter to submit";
+        self.status = "Fill out the form and press Ctrl+S to submit (Ctrl+Enter also works in capable terminals)";
 
         return .none;
     }

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -60,7 +60,7 @@ const Model = struct {
         const form_view = self.form.view(ctx.allocator) catch "error";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.green());
+        status_style = status_style.fg(.green);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
         const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -48,13 +48,13 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
         const title = title_s.render(alloc, "Gauge Component Demo") catch "Gauge Demo";
 
         const thresholds = &[_]zz.Gauge.Threshold{
-            .{ .value = 70, .color = zz.Color.yellow() },
-            .{ .value = 90, .color = zz.Color.red() },
+            .{ .value = 70, .color = .yellow },
+            .{ .value = 90, .color = .red },
         };
 
         // Bar gauge
@@ -83,11 +83,11 @@ const Model = struct {
         blocks.display_style = .blocks;
         blocks.show_percent = true;
         blocks.label = "DSK";
-        blocks.base_color = zz.Color.blue();
+        blocks.base_color = .blue;
         const blocks_view = blocks.view(alloc);
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -66,7 +66,7 @@ const Model = struct {
         const load_view = load.view(alloc);
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc, "{s}\n\n\n{s}\n\n{s}", .{

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -203,20 +203,20 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
 
         var subtitle_style = zz.Style{};
-        subtitle_style = subtitle_style.fg(zz.Color.gray(18));
+        subtitle_style = subtitle_style.fg(.gray(18));
         subtitle_style = subtitle_style.inline_style(true);
 
         var hint_style = zz.Style{};
         hint_style = hint_style.italic(true);
-        hint_style = hint_style.fg(zz.Color.gray(12));
+        hint_style = hint_style.fg(.gray(12));
         hint_style = hint_style.inline_style(true);
 
         var image_hint_style = zz.Style{};
-        image_hint_style = image_hint_style.fg(zz.Color.gray(16));
+        image_hint_style = image_hint_style.fg(.gray(16));
         image_hint_style = image_hint_style.inline_style(true);
 
         const title = title_style.render(ctx.allocator, "Hello, ZigZag!") catch "Hello, ZigZag!";

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -51,7 +51,7 @@ const Model = struct {
 
         // Background layer (z=0)
         var bg_style = zz.Style{};
-        bg_style = bg_style.fg(zz.Color.gray(8));
+        bg_style = bg_style.fg(.gray(8));
         bg_style = bg_style.inline_style(true);
 
         var bg_content = std.array_list.Managed(u8).init(alloc);
@@ -66,8 +66,8 @@ const Model = struct {
 
         // Main info panel (z=1)
         var info_style = zz.Style{};
-        info_style = info_style.borderAll(zz.Border.rounded);
-        info_style = info_style.borderForeground(zz.Color.cyan());
+        info_style = info_style.borderAll(.rounded);
+        info_style = info_style.borderForeground(.cyan);
         info_style = info_style.paddingAll(1);
         info_style = info_style.width(40);
         info_style = info_style.height(8);
@@ -79,8 +79,8 @@ const Model = struct {
         // Popup (z=10)
         if (self.show_popup) {
             var popup_style = zz.Style{};
-            popup_style = popup_style.borderAll(zz.Border.double);
-            popup_style = popup_style.borderForeground(zz.Color.yellow());
+            popup_style = popup_style.borderAll(.double);
+            popup_style = popup_style.borderForeground(.yellow);
             popup_style = popup_style.paddingAll(1);
             popup_style = popup_style.width(30);
             popup_style = popup_style.height(5);
@@ -95,8 +95,8 @@ const Model = struct {
         // Tooltip (z=20)
         if (self.show_tooltip) {
             var tt_style = zz.Style{};
-            tt_style = tt_style.borderAll(zz.Border.normal);
-            tt_style = tt_style.borderForeground(zz.Color.green());
+            tt_style = tt_style.borderAll(.normal);
+            tt_style = tt_style.borderForeground(.green);
             tt_style = tt_style.width(20);
 
             const tt = tt_style.render(alloc, "Tooltip z=20") catch "tooltip";

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -77,7 +77,7 @@ const Model = struct {
         const content = self.viewport.view(ctx.allocator) catch "error";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator, "j/k or Up/Down: scroll | q: quit") catch "";
 

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -127,7 +127,7 @@ const Model = struct {
         const menu_view = self.menu.view(ctx.allocator, ctx.width) catch "error";
 
         var content_style = zz.Style{};
-        content_style = content_style.fg(zz.Color.gray(16));
+        content_style = content_style.fg(.gray(16));
         content_style = content_style.inline_style(true);
 
         const content = content_style.render(
@@ -136,14 +136,14 @@ const Model = struct {
         ) catch "";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.cyan());
+        status_style = status_style.fg(.cyan);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
         const status = std.fmt.allocPrint(ctx.allocator, "Status: {s}", .{self.status}) catch "?";
         const styled_status = status_style.render(ctx.allocator, status) catch status;
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator, "F9: activate menu | Alt+letter: open menu | q/Esc: quit") catch "";
 

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -126,7 +126,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const menu_view = self.menu.view(ctx.allocator, ctx.width) catch "error";
 
-        var content_style = zz.Style{};
+        var content_style = zz.newStyle();
         content_style = content_style.fg(.gray(16));
         content_style = content_style.inline_style(true);
 
@@ -135,16 +135,16 @@ const Model = struct {
             "Press F9 or Alt+F/E/V/H to open menus\nUse arrow keys to navigate, Enter to select",
         ) catch "";
 
-        var status_style = zz.Style{};
-        status_style = status_style.fg(.cyan);
-        status_style = status_style.bold(true);
-        status_style = status_style.inline_style(true);
+        var status_style = zz.newStyle()
+            .fg(.cyan)
+            .bold(true)
+            .inline_style(true);
         const status = std.fmt.allocPrint(ctx.allocator, "Status: {s}", .{self.status}) catch "?";
         const styled_status = status_style.render(ctx.allocator, status) catch status;
 
-        var help_style = zz.Style{};
-        help_style = help_style.fg(.gray(12));
-        help_style = help_style.inline_style(true);
+        var help_style = zz.newStyle()
+            .fg(.gray(12))
+            .inline_style(true);
         const help = help_style.render(ctx.allocator, "F9: activate menu | Alt+letter: open menu | q/Esc: quit") catch "";
 
         return std.fmt.allocPrint(
@@ -156,7 +156,7 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
     defer _ = gpa.deinit();
 
     var program = try zz.Program(Model).init(gpa.allocator());

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -85,14 +85,14 @@ const Model = struct {
                             self.modal.body = "This is a fully customized modal.\nWith multiple lines of content.\nAnd custom buttons below.";
                             self.modal.footer = "Use Tab/arrows to navigate, Enter to select";
                             self.modal.width = .{ .fixed = 50 };
-                            self.modal.border_chars = zz.Border.double;
-                            self.modal.border_fg = zz.Color.magenta();
+                            self.modal.border_chars = .double;
+                            self.modal.border_fg = .magenta;
                             self.modal.title_style = blk: {
                                 var s = zz.Style{};
-                                s = s.bold(true).fg(zz.Color.magenta()).inline_style(true);
+                                s = s.bold(true).fg(.magenta).inline_style(true);
                                 break :blk s;
                             };
-                            self.modal.content_bg = zz.Color.gray(2);
+                            self.modal.content_bg = .gray(2);
                             self.modal.backdrop = .{};
                             self.modal.addButton("Save", .{ .char = 's' });
                             self.modal.addButton("Discard", .{ .char = 'd' });
@@ -120,16 +120,16 @@ const Model = struct {
 
         // Main view
         var title_s = zz.Style{};
-        title_s = title_s.bold(true).fg(zz.Color.hex("#FF6B6B")).inline_style(true);
+        title_s = title_s.bold(true).fg(.hex("#FF6B6B")).inline_style(true);
 
         var hint_s = zz.Style{};
-        hint_s = hint_s.fg(zz.Color.gray(14)).inline_style(true);
+        hint_s = hint_s.fg(.gray(14)).inline_style(true);
 
         var result_s = zz.Style{};
-        result_s = result_s.fg(zz.Color.cyan()).inline_style(true);
+        result_s = result_s.fg(.cyan).inline_style(true);
 
         var status_s = zz.Style{};
-        status_s = status_s.fg(zz.Color.gray(12)).inline_style(true);
+        status_s = status_s.fg(.gray(12)).inline_style(true);
 
         const title = title_s.render(alloc, "Modal Component Demo") catch "Modal Component Demo";
         const hint = hint_s.render(alloc, "1: Info  2: Confirm  3: Warning  4: Error  5: Custom  q: Quit") catch "";

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -2,6 +2,7 @@
 //! Demonstrates mouse tracking, hit testing, and interactive buttons.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -106,8 +107,8 @@ const Model = struct {
         ) catch "";
 
         // Render buttons
-        var buttons_line = std.array_list.Managed(u8).init(ctx.allocator);
-        const bw = buttons_line.writer();
+        var buttons_line: Writer.Allocating = .init(ctx.allocator);
+        const bw = &buttons_line.writer;
         for (&self.buttons, 0..) |*btn, i| {
             if (i > 0) bw.writeAll("  ") catch {};
             var s = zz.Style{};

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -24,9 +24,9 @@ const Model = struct {
 
     pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
         self.buttons = .{
-            .{ .label = "  Click Me  ", .color = zz.Color.cyan(), .mouse = .{} },
-            .{ .label = "  Count++   ", .color = zz.Color.green(), .mouse = .{} },
-            .{ .label = "   Reset    ", .color = zz.Color.red(), .mouse = .{} },
+            .{ .label = "  Click Me  ", .color = .cyan, .mouse = .{} },
+            .{ .label = "  Count++   ", .color = .green, .mouse = .{} },
+            .{ .label = "   Reset    ", .color = .red, .mouse = .{} },
         };
         self.click_count = 0;
         self.last_event = "Move the mouse or click a button";
@@ -89,7 +89,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.white());
+        title_style = title_style.fg(.white);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Mouse Demo") catch "Mouse Demo";
 
@@ -111,9 +111,9 @@ const Model = struct {
         for (&self.buttons, 0..) |*btn, i| {
             if (i > 0) bw.writeAll("  ") catch {};
             var s = zz.Style{};
-            s = s.borderAll(zz.Border.rounded);
+            s = s.borderAll(.rounded);
             if (btn.mouse.hover) {
-                s = s.borderForeground(zz.Color.white());
+                s = s.borderForeground(.white);
                 s = s.bold(true);
             } else {
                 s = s.borderForeground(btn.color);
@@ -126,7 +126,7 @@ const Model = struct {
         const buttons = buttons_line.toOwnedSlice() catch "";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(12));
+        help_s = help_s.fg(.gray(12));
         help_s = help_s.inline_style(true);
         const help = help_s.render(ctx.allocator, "Click the buttons above | q: quit") catch "";
 

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -122,13 +122,13 @@ const Model = struct {
         const log_view = log_mut.view(alloc) catch "";
 
         var box = zz.Style{};
-        box = box.borderAll(zz.Border.rounded);
-        box = box.borderForeground(zz.Color.gray(8));
+        box = box.borderAll(.rounded);
+        box = box.borderForeground(.gray(8));
         const boxed = box.render(alloc, log_view) catch log_view;
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "RichLog — append-only with level filter & search") catch "";
 
@@ -146,12 +146,12 @@ const Model = struct {
             ) catch "";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.gray(12));
+        status_style = status_style.fg(.gray(12));
         status_style = status_style.inline_style(true);
         const status_str = status_style.render(alloc, status) catch "";
 
         var help = zz.Style{};
-        help = help.fg(zz.Color.gray(10));
+        help = help.fg(.gray(10));
         help = help.inline_style(true);
         const help_text = "↑↓ scroll · g/G top/bottom · / search · c clear · l cycle level · q quit";
         const help_str = help.render(alloc, help_text) catch "";

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -171,7 +171,7 @@ const Model = struct {
         }
 
         var trail_style = zz.Style{};
-        trail_style = trail_style.fg(zz.Color.gray(10));
+        trail_style = trail_style.fg(.gray(10));
         trail_style = trail_style.inline_style(true);
         const trail_str = trail_style.render(ctx.allocator, trail.items) catch "";
 

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -2,6 +2,7 @@
 //! Three-screen flow: Home → Settings → modal Confirm dialog.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 // ── Home screen ─────────────────────────────────────────────────────────
@@ -161,9 +162,9 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         const view_str = self.stack.view(ctx, ctx.allocator) catch "Error";
 
-        var trail = std.array_list.Managed(u8).init(ctx.allocator);
+        var trail: Writer.Allocating = .init(ctx.allocator);
         defer trail.deinit();
-        const w = trail.writer();
+        const w = &trail.writer;
         w.writeAll("stack: ") catch {};
         for (self.stack.stack.items, 0..) |s, i| {
             if (i > 0) w.writeAll(" › ") catch {};
@@ -173,7 +174,7 @@ const Model = struct {
         var trail_style = zz.Style{};
         trail_style = trail_style.fg(.gray(10));
         trail_style = trail_style.inline_style(true);
-        const trail_str = trail_style.render(ctx.allocator, trail.items) catch "";
+        const trail_str = trail_style.render(ctx.allocator, trail.writer.buffered()) catch "";
 
         return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ trail_str, view_str }) catch view_str;
     }

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -2,6 +2,7 @@
 //! Comprehensive multi-tab application demonstrating ALL framework features.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Tab = enum {
@@ -511,8 +512,8 @@ const Model = struct {
     }
 
     fn renderTabBar(self: *const Model, ctx: *const zz.Context) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(ctx.allocator);
+        const writer = &result.writer;
 
         const tabs = [_]Tab{ .dashboard, .charts, .data, .files, .editor, .unicode };
         for (tabs, 0..) |tab, i| {
@@ -578,15 +579,12 @@ const Model = struct {
         const sparkline_row = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ spark_label, sparkline_view });
 
         // Spinner
-        const spinner_view = if (self.progress.isComplete())
-            blk: {
-                var done_style = zz.Style{};
-                done_style = done_style.fg(.green);
-                done_style = done_style.inline_style(true);
-                break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
-            }
-        else
-            try self.spinner.viewWithTitle(ctx.allocator, "Processing...");
+        const spinner_view = if (self.progress.isComplete()) blk: {
+            var done_style = zz.Style{};
+            done_style = done_style.fg(.green);
+            done_style = done_style.inline_style(true);
+            break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
+        } else try self.spinner.viewWithTitle(ctx.allocator, "Processing...");
 
         // Notifications
         const notif_view = try self.notifications.view(ctx.allocator);

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -78,14 +78,14 @@ const Model = struct {
 
         self.progress = zz.Progress.init();
         self.progress.setWidth(30);
-        self.progress.setGradient(zz.Color.hex("#FF6B6B"), zz.Color.hex("#4ECDC4"));
+        self.progress.setGradient(.hex("#FF6B6B"), .hex("#4ECDC4"));
 
         self.timer = zz.components.Timer.stopwatch();
         self.timer.start();
 
         self.sparkline = zz.Sparkline.init(ctx.persistent_allocator);
         self.sparkline.setWidth(30);
-        self.sparkline.setGradient(zz.Color.hex("#F97316"), zz.Color.hex("#22C55E"));
+        self.sparkline.setGradient(.hex("#F97316"), .hex("#22C55E"));
 
         self.chart = zz.Chart.init(ctx.persistent_allocator);
         self.chart.setSize(42, 13);
@@ -103,18 +103,18 @@ const Model = struct {
         };
 
         var cpu = zz.ChartDataset.init(ctx.persistent_allocator, "CPU") catch unreachable;
-        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+        cpu.setStyle((zz.Style{}).fg(.cyan).bold(true));
         cpu.setShowPoints(true);
         cpu.setInterpolation(.monotone_cubic);
         cpu.setInterpolationSteps(10);
 
         var mem = zz.ChartDataset.init(ctx.persistent_allocator, "Memory") catch unreachable;
-        mem.setStyle((zz.Style{}).fg(zz.Color.magenta()));
+        mem.setStyle((zz.Style{}).fg(.magenta));
         mem.setInterpolation(.catmull_rom);
         mem.setInterpolationSteps(10);
 
         var backlog = zz.ChartDataset.init(ctx.persistent_allocator, "Backlog") catch unreachable;
-        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow()));
+        backlog.setStyle((zz.Style{}).fg(.yellow));
         backlog.setGraphType(.area);
         backlog.setInterpolation(.step_center);
         backlog.setFillBaseline(18.0);
@@ -134,10 +134,10 @@ const Model = struct {
         self.bars.setSize(28, 8);
         self.bars.setOrientation(.horizontal);
         self.bars.show_values = true;
-        self.bars.label_style = (zz.Style{}).fg(zz.Color.gray(18)).inline_style(true);
-        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green()).inline_style(true);
-        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red()).inline_style(true);
-        self.bars.axis_style = (zz.Style{}).fg(zz.Color.gray(10)).inline_style(true);
+        self.bars.label_style = (zz.Style{}).fg(.gray(18)).inline_style(true);
+        self.bars.positive_style = (zz.Style{}).fg(.green).inline_style(true);
+        self.bars.negative_style = (zz.Style{}).fg(.red).inline_style(true);
+        self.bars.axis_style = (zz.Style{}).fg(.gray(10)).inline_style(true);
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "api", 22) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "db", -10) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "queue", 15) catch unreachable) catch unreachable;
@@ -153,9 +153,9 @@ const Model = struct {
         // Data tab
         self.table = zz.Table(4).init(ctx.persistent_allocator);
         self.table.setHeaders(.{ "Server", "Status", "Uptime", "Load" });
-        self.table.setBorder(zz.Border.rounded);
+        self.table.setBorder(.rounded);
         var alt_style = zz.Style{};
-        alt_style = alt_style.fg(zz.Color.gray(18));
+        alt_style = alt_style.fg(.gray(18));
         alt_style = alt_style.inline_style(true);
         self.table.alt_row_style = alt_style;
         self.table.visible_rows = 8;
@@ -521,7 +521,7 @@ const Model = struct {
             if (tab == self.active_tab) {
                 var active_style = zz.Style{};
                 active_style = active_style.bold(true);
-                active_style = active_style.fg(zz.Color.hex("#4ECDC4"));
+                active_style = active_style.fg(.hex("#4ECDC4"));
                 active_style = active_style.underline(true);
                 active_style = active_style.inline_style(true);
                 const label = try std.fmt.allocPrint(ctx.allocator, "{d}:{s}", .{ i + 1, tab.name() });
@@ -529,7 +529,7 @@ const Model = struct {
                 try writer.writeAll(styled);
             } else {
                 var tab_style = zz.Style{};
-                tab_style = tab_style.fg(zz.Color.gray(12));
+                tab_style = tab_style.fg(.gray(12));
                 tab_style = tab_style.inline_style(true);
                 const label = try std.fmt.allocPrint(ctx.allocator, "{d}:{s}", .{ i + 1, tab.name() });
                 const styled = try tab_style.render(ctx.allocator, label);
@@ -540,8 +540,8 @@ const Model = struct {
         // Wrap in border
         const bar_content = try result.toOwnedSlice();
         var bar_style = zz.Style{};
-        bar_style = bar_style.borderAll(zz.Border.rounded);
-        bar_style = bar_style.borderForeground(zz.Color.gray(8));
+        bar_style = bar_style.borderAll(.rounded);
+        bar_style = bar_style.borderForeground(.gray(8));
         bar_style = bar_style.paddingLeft(1).paddingRight(1);
         bar_style = bar_style.width(@min(ctx.width -| 2, 60));
 
@@ -572,7 +572,7 @@ const Model = struct {
         // Bottom: Sparkline
         const sparkline_view = try self.sparkline.view(ctx.allocator);
         var spark_label_style = zz.Style{};
-        spark_label_style = spark_label_style.fg(zz.Color.gray(15));
+        spark_label_style = spark_label_style.fg(.gray(15));
         spark_label_style = spark_label_style.inline_style(true);
         const spark_label = try spark_label_style.render(ctx.allocator, "FPS: ");
         const sparkline_row = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ spark_label, sparkline_view });
@@ -581,7 +581,7 @@ const Model = struct {
         const spinner_view = if (self.progress.isComplete())
             blk: {
                 var done_style = zz.Style{};
-                done_style = done_style.fg(zz.Color.green());
+                done_style = done_style.fg(.green);
                 done_style = done_style.inline_style(true);
                 break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
             }
@@ -594,8 +594,8 @@ const Model = struct {
 
         // Bottom box
         var bottom_style = zz.Style{};
-        bottom_style = bottom_style.borderAll(zz.Border.rounded);
-        bottom_style = bottom_style.borderForeground(zz.Color.green());
+        bottom_style = bottom_style.borderAll(.rounded);
+        bottom_style = bottom_style.borderForeground(.green);
         bottom_style = bottom_style.paddingAll(1);
 
         const bottom_content = if (has_notifs)
@@ -610,24 +610,24 @@ const Model = struct {
 
     fn renderDashboardStats(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
-        box_style = box_style.borderTopForeground(zz.Color.hex("#4ECDC4"));
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.cyan);
+        box_style = box_style.borderTopForeground(.hex("#4ECDC4"));
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(25);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.cyan());
+        header_style = header_style.fg(.cyan);
         header_style = header_style.inline_style(true);
 
         var value_style = zz.Style{};
         value_style = value_style.bold(true);
-        value_style = value_style.fg(zz.Color.white());
+        value_style = value_style.fg(.white);
         value_style = value_style.inline_style(true);
 
         var label_style = zz.Style{};
-        label_style = label_style.fg(zz.Color.gray(15));
+        label_style = label_style.fg(.gray(15));
         label_style = label_style.inline_style(true);
 
         const header = try header_style.render(ctx.allocator, "Statistics");
@@ -637,13 +637,13 @@ const Model = struct {
         const fps_label = try label_style.render(ctx.allocator, " FPS");
 
         var paused_style = zz.Style{};
-        paused_style = paused_style.fg(zz.Color.yellow());
+        paused_style = paused_style.fg(.yellow);
         paused_style = paused_style.inline_style(true);
         const status = if (self.paused)
             try paused_style.render(ctx.allocator, "PAUSED")
         else blk: {
             var run_style = zz.Style{};
-            run_style = run_style.fg(zz.Color.green());
+            run_style = run_style.fg(.green);
             run_style = run_style.inline_style(true);
             break :blk try run_style.render(ctx.allocator, "RUNNING");
         };
@@ -657,21 +657,21 @@ const Model = struct {
 
     fn renderDashboardProgress(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.double);
-        box_style = box_style.borderForeground(zz.Color.magenta());
+        box_style = box_style.borderAll(.double);
+        box_style = box_style.borderForeground(.magenta);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(35);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.magenta());
+        header_style = header_style.fg(.magenta);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Progress");
 
         const progress_bar = try self.progress.view(ctx.allocator);
 
         var timer_label_style = zz.Style{};
-        timer_label_style = timer_label_style.fg(zz.Color.gray(15));
+        timer_label_style = timer_label_style.fg(.gray(15));
         timer_label_style = timer_label_style.inline_style(true);
         const timer_label = try timer_label_style.render(ctx.allocator, "Elapsed: ");
         const timer_view = try self.timer.view(ctx.allocator);
@@ -687,11 +687,11 @@ const Model = struct {
         // Left: Interactive table
         const table_view = try self.table.view(ctx.allocator);
         var table_box_style = zz.Style{};
-        table_box_style = table_box_style.borderAll(zz.Border.normal);
+        table_box_style = table_box_style.borderAll(.normal);
         if (self.data_focus == .table_focus) {
-            table_box_style = table_box_style.borderForeground(zz.Color.cyan());
+            table_box_style = table_box_style.borderForeground(.cyan);
         } else {
-            table_box_style = table_box_style.borderForeground(zz.Color.gray(8));
+            table_box_style = table_box_style.borderForeground(.gray(8));
         }
         table_box_style = table_box_style.paddingAll(0);
         const table_boxed = try table_box_style.render(ctx.allocator, table_view);
@@ -699,17 +699,17 @@ const Model = struct {
         // Right top: Tree
         const tree_view = try self.tree.view(ctx.allocator);
         var tree_box_style = zz.Style{};
-        tree_box_style = tree_box_style.borderAll(zz.Border.rounded);
+        tree_box_style = tree_box_style.borderAll(.rounded);
         if (self.data_focus == .tree_focus) {
-            tree_box_style = tree_box_style.borderForeground(zz.Color.cyan());
+            tree_box_style = tree_box_style.borderForeground(.cyan);
         } else {
-            tree_box_style = tree_box_style.borderForeground(zz.Color.gray(8));
+            tree_box_style = tree_box_style.borderForeground(.gray(8));
         }
         tree_box_style = tree_box_style.paddingLeft(1).paddingRight(1);
 
         var tree_header_style = zz.Style{};
         tree_header_style = tree_header_style.bold(true);
-        tree_header_style = tree_header_style.fg(zz.Color.yellow());
+        tree_header_style = tree_header_style.fg(.yellow);
         tree_header_style = tree_header_style.inline_style(true);
         const tree_header = try tree_header_style.render(ctx.allocator, "Project Structure");
         const tree_content = try std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ tree_header, tree_view });
@@ -718,13 +718,13 @@ const Model = struct {
         // Right bottom: Styled list
         const list_view = try self.styled_list.view(ctx.allocator);
         var list_box_style = zz.Style{};
-        list_box_style = list_box_style.borderAll(zz.Border.rounded);
-        list_box_style = list_box_style.borderForeground(zz.Color.gray(8));
+        list_box_style = list_box_style.borderAll(.rounded);
+        list_box_style = list_box_style.borderForeground(.gray(8));
         list_box_style = list_box_style.paddingLeft(1).paddingRight(1);
 
         var list_header_style = zz.Style{};
         list_header_style = list_header_style.bold(true);
-        list_header_style = list_header_style.fg(zz.Color.green());
+        list_header_style = list_header_style.fg(.green);
         list_header_style = list_header_style.inline_style(true);
         const list_header = try list_header_style.render(ctx.allocator, "TODO Items");
         const list_content = try std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ list_header, list_view });
@@ -735,7 +735,7 @@ const Model = struct {
 
         // Data tab hint
         var hint_style = zz.Style{};
-        hint_style = hint_style.fg(zz.Color.gray(10));
+        hint_style = hint_style.fg(.gray(10));
         hint_style = hint_style.italic(true);
         hint_style = hint_style.inline_style(true);
         const focus_hint = if (self.data_focus == .table_focus)
@@ -757,18 +757,18 @@ const Model = struct {
         const canvas_view = try self.renderChartCanvas(ctx);
 
         var trend_style = zz.Style{};
-        trend_style = trend_style.borderAll(zz.Border.rounded);
-        trend_style = trend_style.borderForeground(zz.Color.cyan());
+        trend_style = trend_style.borderAll(.rounded);
+        trend_style = trend_style.borderForeground(.cyan);
         trend_style = trend_style.paddingLeft(1).paddingRight(1);
 
         var bars_style = zz.Style{};
-        bars_style = bars_style.borderAll(zz.Border.rounded);
-        bars_style = bars_style.borderForeground(zz.Color.green());
+        bars_style = bars_style.borderAll(.rounded);
+        bars_style = bars_style.borderForeground(.green);
         bars_style = bars_style.paddingLeft(1).paddingRight(1);
 
         var aux_style = zz.Style{};
-        aux_style = aux_style.borderAll(zz.Border.rounded);
-        aux_style = aux_style.borderForeground(zz.Color.yellow());
+        aux_style = aux_style.borderAll(.rounded);
+        aux_style = aux_style.borderForeground(.yellow);
         aux_style = aux_style.paddingLeft(1).paddingRight(1);
 
         const trend_box = try trend_style.render(ctx.allocator, try self.section(ctx, "Interpolated Lines + Area", trend_view));
@@ -792,13 +792,13 @@ const Model = struct {
         const viewport_view = try self.file_viewport.view(ctx.allocator);
 
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.thick);
-        box_style = box_style.borderForeground(zz.Color.blue());
+        box_style = box_style.borderAll(.thick);
+        box_style = box_style.borderForeground(.blue);
         box_style = box_style.paddingAll(1);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.blue());
+        header_style = header_style.fg(.blue);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "File Browser");
 
@@ -819,7 +819,7 @@ const Model = struct {
         canvas.setRanges(.{ .min = -1.2, .max = 1.2 }, .{ .min = -1.2, .max = 1.2 });
 
         var style = zz.Style{};
-        style = style.fg(zz.Color.yellow());
+        style = style.fg(.yellow);
         style = style.inline_style(true);
 
         for (0..64) |i| {
@@ -843,7 +843,7 @@ const Model = struct {
         chart.y_axis = .{ .title = if (compact) "" else "Score", .tick_count = if (ultra) 3 else 4, .show_grid = !ultra };
 
         var actual = try zz.ChartDataset.init(ctx.allocator, "A");
-        actual.setStyle((zz.Style{}).fg(zz.Color.hex("#22C55E")).bold(true));
+        actual.setStyle((zz.Style{}).fg(.hex("#22C55E")).bold(true));
         actual.setInterpolation(.monotone_cubic);
         actual.setInterpolationSteps(10);
         try actual.setPoints(&.{
@@ -854,7 +854,7 @@ const Model = struct {
         });
 
         var target = try zz.ChartDataset.init(ctx.allocator, "T");
-        target.setStyle((zz.Style{}).fg(zz.Color.hex("#38BDF8")));
+        target.setStyle((zz.Style{}).fg(.hex("#38BDF8")));
         target.setInterpolation(.step_end);
         try target.setPoints(&.{
             .{ .x = 1, .y = 16 },
@@ -872,7 +872,7 @@ const Model = struct {
         _ = self;
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.white());
+        header_style = header_style.fg(.white);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, title);
         return try std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ header, body });
@@ -882,18 +882,18 @@ const Model = struct {
         const editor_view = try self.text_area.view(ctx.allocator);
 
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.normal);
-        box_style = box_style.borderForeground(zz.Color.hex("#FF6B6B"));
+        box_style = box_style.borderAll(.normal);
+        box_style = box_style.borderForeground(.hex("#FF6B6B"));
         box_style = box_style.paddingLeft(1).paddingRight(1);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.hex("#FF6B6B"));
+        header_style = header_style.fg(.hex("#FF6B6B"));
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Text Editor");
 
         var hint_style = zz.Style{};
-        hint_style = hint_style.fg(zz.Color.gray(10));
+        hint_style = hint_style.fg(.gray(10));
         hint_style = hint_style.italic(true);
         hint_style = hint_style.inline_style(true);
         const hint = try hint_style.render(ctx.allocator, "Type to edit. Arrow keys to navigate.");
@@ -909,13 +909,13 @@ const Model = struct {
         // -- CJK Box --
         var cjk_header_style = zz.Style{};
         cjk_header_style = cjk_header_style.bold(true);
-        cjk_header_style = cjk_header_style.fg(zz.Color.hex("#FF6B6B"));
+        cjk_header_style = cjk_header_style.fg(.hex("#FF6B6B"));
         cjk_header_style = cjk_header_style.inline_style(true);
         const cjk_header = try cjk_header_style.render(alloc, "CJK Characters");
 
         var cjk_style = zz.Style{};
-        cjk_style = cjk_style.borderAll(zz.Border.rounded);
-        cjk_style = cjk_style.borderForeground(zz.Color.hex("#FF6B6B"));
+        cjk_style = cjk_style.borderAll(.rounded);
+        cjk_style = cjk_style.borderForeground(.hex("#FF6B6B"));
         cjk_style = cjk_style.paddingLeft(1).paddingRight(1);
         cjk_style = cjk_style.width(30);
 
@@ -926,13 +926,13 @@ const Model = struct {
         // -- Symbol Box --
         var symbol_header_style = zz.Style{};
         symbol_header_style = symbol_header_style.bold(true);
-        symbol_header_style = symbol_header_style.fg(zz.Color.hex("#4ECDC4"));
+        symbol_header_style = symbol_header_style.fg(.hex("#4ECDC4"));
         symbol_header_style = symbol_header_style.inline_style(true);
         const symbol_header = try symbol_header_style.render(alloc, "Symbols");
 
         var symbol_style = zz.Style{};
-        symbol_style = symbol_style.borderAll(zz.Border.rounded);
-        symbol_style = symbol_style.borderForeground(zz.Color.hex("#4ECDC4"));
+        symbol_style = symbol_style.borderAll(.rounded);
+        symbol_style = symbol_style.borderForeground(.hex("#4ECDC4"));
         symbol_style = symbol_style.paddingLeft(1).paddingRight(1);
         symbol_style = symbol_style.width(30);
 
@@ -946,13 +946,13 @@ const Model = struct {
         // -- Fullwidth/Halfwidth comparison box --
         var fw_header_style = zz.Style{};
         fw_header_style = fw_header_style.bold(true);
-        fw_header_style = fw_header_style.fg(zz.Color.yellow());
+        fw_header_style = fw_header_style.fg(.yellow);
         fw_header_style = fw_header_style.inline_style(true);
         const fw_header = try fw_header_style.render(alloc, "Width Comparison");
 
         var fw_style = zz.Style{};
-        fw_style = fw_style.borderAll(zz.Border.rounded);
-        fw_style = fw_style.borderForeground(zz.Color.yellow());
+        fw_style = fw_style.borderAll(.rounded);
+        fw_style = fw_style.borderForeground(.yellow);
         fw_style = fw_style.paddingLeft(1).paddingRight(1);
 
         const fw_content = try std.fmt.allocPrint(alloc, "{s}\n\n  Fullwidth : \u{FF21}\u{FF22}\u{FF23}\u{FF24}\u{FF25}   (5 chars = 10 cols)\n  Halfwidth : ABCDE        (5 chars =  5 cols)\n  Mixed     : A\u{FF22}C\u{FF24}E        (5 chars =  7 cols)", .{fw_header});
@@ -962,13 +962,13 @@ const Model = struct {
         // -- Combining characters box --
         var comb_header_style = zz.Style{};
         comb_header_style = comb_header_style.bold(true);
-        comb_header_style = comb_header_style.fg(zz.Color.magenta());
+        comb_header_style = comb_header_style.fg(.magenta);
         comb_header_style = comb_header_style.inline_style(true);
         const comb_header = try comb_header_style.render(alloc, "Combining Characters");
 
         var comb_style = zz.Style{};
-        comb_style = comb_style.borderAll(zz.Border.rounded);
-        comb_style = comb_style.borderForeground(zz.Color.magenta());
+        comb_style = comb_style.borderAll(.rounded);
+        comb_style = comb_style.borderForeground(.magenta);
         comb_style = comb_style.paddingLeft(1).paddingRight(1);
 
         const comb_content = try std.fmt.allocPrint(alloc, "{s}\n\n  e\u{0301} = e + combining acute   (1 col)\n  a\u{030A} = a + combining ring     (1 col)\n  o\u{0308} = o + combining diaeresis (1 col)\n  n\u{0303} = n + combining tilde     (1 col)", .{comb_header});
@@ -978,13 +978,13 @@ const Model = struct {
         // -- Alignment demo --
         var align_header_style = zz.Style{};
         align_header_style = align_header_style.bold(true);
-        align_header_style = align_header_style.fg(zz.Color.green());
+        align_header_style = align_header_style.fg(.green);
         align_header_style = align_header_style.inline_style(true);
         const align_header = try align_header_style.render(alloc, "Alignment Demo");
 
         var align_style = zz.Style{};
-        align_style = align_style.borderAll(zz.Border.double);
-        align_style = align_style.borderForeground(zz.Color.green());
+        align_style = align_style.borderAll(.double);
+        align_style = align_style.borderForeground(.green);
         align_style = align_style.paddingLeft(1).paddingRight(1);
 
         const align_content = try std.fmt.allocPrint(alloc, "{s}\n\n  |hello     |  5 cols\n  |\u{4F60}\u{597D}      |  4 cols (2 wide chars)\n  |\u{03B1}\u{03B2}\u{03B3}\u{03B4}      |  4 cols (Greek)\n  |caf\u{00E9}      |  4 cols (precomposed)\n  |cafe\u{0301}      |  4 cols (combining)", .{align_header});
@@ -996,7 +996,7 @@ const Model = struct {
 
         // -- Hint --
         var hint_style = zz.Style{};
-        hint_style = hint_style.fg(zz.Color.gray(10));
+        hint_style = hint_style.fg(.gray(10));
         hint_style = hint_style.italic(true);
         hint_style = hint_style.inline_style(true);
         const hint = try hint_style.render(alloc, "Unicode width is terminal-dependent; this tab uses width-stable samples.");
@@ -1015,8 +1015,8 @@ const Model = struct {
         const help_view = try help_comp.view(ctx.allocator);
 
         var status_style = zz.Style{};
-        status_style = status_style.borderAll(zz.Border.rounded);
-        status_style = status_style.borderForeground(zz.Color.gray(6));
+        status_style = status_style.borderAll(.rounded);
+        status_style = status_style.borderForeground(.gray(6));
         status_style = status_style.paddingLeft(1).paddingRight(1);
         status_style = status_style.width(@min(ctx.width -| 2, 60));
 

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -27,7 +27,7 @@ const Model = struct {
         self.brightness.label = "Brightness:";
         self.brightness.value = 75;
         self.brightness.show_value = true;
-        self.brightness.setGradient(zz.Color.fromRgb(50, 50, 50), zz.Color.yellow());
+        self.brightness.setGradient(.fromRgb(50, 50, 50), .yellow);
 
         // Thin style with decimal precision
         self.temperature = zz.SliderStyle.thin();
@@ -79,7 +79,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Slider Example") catch "Slider Example";
 
@@ -89,7 +89,7 @@ const Model = struct {
         const spd = self.progress_slider.view(ctx.allocator) catch "error";
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -44,19 +44,19 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var box_s = zz.Style{};
-        box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderAll(.rounded);
+        box_s = box_s.borderForeground(.cyan);
         box_s = box_s.paddingAll(1);
 
         const table_view = self.table.view(alloc);
         const boxed = box_s.render(alloc, table_view) catch table_view;
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -90,19 +90,19 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         // Sub-program views
         var box_a = zz.Style{};
-        box_a = box_a.borderAll(zz.Border.rounded);
-        box_a = box_a.borderForeground(if (self.active == 0) zz.Color.green() else zz.Color.gray(8));
+        box_a = box_a.borderAll(.rounded);
+        box_a = box_a.borderForeground(if (self.active == 0) .green else .gray(8));
         box_a = box_a.paddingAll(1);
         box_a = box_a.width(30);
 
         var box_b = zz.Style{};
-        box_b = box_b.borderAll(zz.Border.rounded);
-        box_b = box_b.borderForeground(if (self.active == 1) zz.Color.green() else zz.Color.gray(8));
+        box_b = box_b.borderAll(.rounded);
+        box_b = box_b.borderForeground(if (self.active == 1) .green else .gray(8));
         box_b = box_b.paddingAll(1);
         box_b = box_b.width(30);
 
@@ -112,7 +112,7 @@ const Model = struct {
         const panels = zz.join.horizontal(alloc, .top, &.{ view_a, view_b }) catch "";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const active_label = if (self.active == 0) "A" else "B";

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -124,7 +124,7 @@ const Model = struct {
         const body = self.tabs.viewWithContent(ctx.allocator, "No active route") catch "render error";
 
         var hint_style = zz.Style{};
-        hint_style = hint_style.fg(zz.Color.gray(12));
+        hint_style = hint_style.fg(.gray(12));
         hint_style = hint_style.inline_style(true);
         const help = hint_style.render(ctx.allocator, "q: quit | ←/→: switch | 1..9: jump | +/- or ↑/↓: counter actions") catch "";
 

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -76,14 +76,14 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "ZigZag Text Editor") catch "Text Editor";
 
         // Editor with border
         var editor_style = zz.Style{};
-        editor_style = editor_style.borderAll(zz.Border.rounded);
-        editor_style = editor_style.borderForeground(zz.Color.gray(12));
+        editor_style = editor_style.borderAll(.rounded);
+        editor_style = editor_style.borderForeground(.gray(12));
 
         const editor_content = self.editor.view(ctx.allocator) catch "";
         const editor_box = editor_style.render(ctx.allocator, editor_content) catch editor_content;
@@ -96,19 +96,19 @@ const Model = struct {
         ) catch "";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.gray(18));
+        status_style = status_style.fg(.gray(18));
         status_style = status_style.inline_style(true);
         const status = status_style.render(ctx.allocator, cursor_info) catch "";
 
         // Status message
         var msg_style = zz.Style{};
-        msg_style = msg_style.fg(zz.Color.green());
+        msg_style = msg_style.fg(.green);
         msg_style = msg_style.inline_style(true);
         const msg = msg_style.render(ctx.allocator, self.status_message) catch "";
 
         // Help
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(
             ctx.allocator,

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -74,16 +74,16 @@ const Model = struct {
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         // Title
-        var title_style = zz.Style{};
-        title_style = title_style.bold(true);
-        title_style = title_style.fg(.cyan);
-        title_style = title_style.inline_style(true);
+        var title_style = zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true);
         const title = title_style.render(ctx.allocator, "ZigZag Text Editor") catch "Text Editor";
 
         // Editor with border
-        var editor_style = zz.Style{};
-        editor_style = editor_style.borderAll(.rounded);
-        editor_style = editor_style.borderForeground(.gray(12));
+        var editor_style = zz.newStyle()
+            .borderAll(.rounded)
+            .borderForeground(.gray(12));
 
         const editor_content = self.editor.view(ctx.allocator) catch "";
         const editor_box = editor_style.render(ctx.allocator, editor_content) catch editor_content;
@@ -95,19 +95,19 @@ const Model = struct {
             .{ self.editor.cursor_row + 1, self.editor.cursorDisplayColumn() + 1, self.editor.lineCount() },
         ) catch "";
 
-        var status_style = zz.Style{};
+        var status_style = zz.newStyle();
         status_style = status_style.fg(.gray(18));
         status_style = status_style.inline_style(true);
         const status = status_style.render(ctx.allocator, cursor_info) catch "";
 
         // Status message
-        var msg_style = zz.Style{};
+        var msg_style = zz.newStyle();
         msg_style = msg_style.fg(.green);
         msg_style = msg_style.inline_style(true);
         const msg = msg_style.render(ctx.allocator, self.status_message) catch "";
 
         // Help
-        var help_style = zz.Style{};
+        var help_style = zz.newStyle();
         help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -33,53 +33,53 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(alloc, "Text Overflow Policies") catch "Text Overflow Policies";
 
         // visible (no overflow handling)
         var vis_style = zz.Style{};
         vis_style = vis_style.width(box_width);
-        vis_style = vis_style.borderAll(zz.Border.rounded);
-        vis_style = vis_style.borderForeground(zz.Color.gray(8));
+        vis_style = vis_style.borderAll(.rounded);
+        vis_style = vis_style.borderForeground(.gray(8));
         vis_style = vis_style.overflow(.visible);
         const vis = vis_style.render(alloc, long_text) catch "";
 
         // hidden (clip)
         var clip_style = zz.Style{};
         clip_style = clip_style.width(box_width);
-        clip_style = clip_style.borderAll(zz.Border.rounded);
-        clip_style = clip_style.borderForeground(zz.Color.yellow());
+        clip_style = clip_style.borderAll(.rounded);
+        clip_style = clip_style.borderForeground(.yellow);
         clip_style = clip_style.overflow(.hidden);
         const clip = clip_style.render(alloc, long_text) catch "";
 
         // ellipsis
         var ell_style = zz.Style{};
         ell_style = ell_style.width(box_width);
-        ell_style = ell_style.borderAll(zz.Border.rounded);
-        ell_style = ell_style.borderForeground(zz.Color.green());
+        ell_style = ell_style.borderAll(.rounded);
+        ell_style = ell_style.borderForeground(.green);
         ell_style = ell_style.overflow(.ellipsis);
         const ell = ell_style.render(alloc, long_text) catch "";
 
         // word_wrap
         var ww_style = zz.Style{};
         ww_style = ww_style.width(box_width);
-        ww_style = ww_style.borderAll(zz.Border.rounded);
-        ww_style = ww_style.borderForeground(zz.Color.blue());
+        ww_style = ww_style.borderAll(.rounded);
+        ww_style = ww_style.borderForeground(.blue);
         ww_style = ww_style.overflow(.word_wrap);
         const ww = ww_style.render(alloc, long_text) catch "";
 
         // char_wrap
         var cw_style = zz.Style{};
         cw_style = cw_style.width(box_width);
-        cw_style = cw_style.borderAll(zz.Border.rounded);
-        cw_style = cw_style.borderForeground(zz.Color.magenta());
+        cw_style = cw_style.borderAll(.rounded);
+        cw_style = cw_style.borderForeground(.magenta);
         cw_style = cw_style.overflow(.char_wrap);
         const cw = cw_style.render(alloc, long_text) catch "";
 
         // Labels
         var label_style = zz.Style{};
-        label_style = label_style.fg(zz.Color.gray(12));
+        label_style = label_style.fg(.gray(12));
         label_style = label_style.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -31,30 +31,30 @@ const Model = struct {
         const box_width: u16 = 35;
 
         // Title
-        var title_style = zz.Style{};
-        title_style = title_style.bold(true);
-        title_style = title_style.fg(.cyan);
-        title_style = title_style.inline_style(true);
-        const title = title_style.render(alloc, "Text Overflow Policies") catch "Text Overflow Policies";
+        const title = zz.newStyle()
+            .bold(true)
+            .fg(.cyan)
+            .inline_style(true)
+            .render(alloc, "Text Overflow Policies") catch "Text Overflow Policies";
 
         // visible (no overflow handling)
-        var vis_style = zz.Style{};
-        vis_style = vis_style.width(box_width);
-        vis_style = vis_style.borderAll(.rounded);
-        vis_style = vis_style.borderForeground(.gray(8));
-        vis_style = vis_style.overflow(.visible);
-        const vis = vis_style.render(alloc, long_text) catch "";
+        const vis = zz.newStyle()
+            .width(box_width)
+            .borderAll(.rounded)
+            .borderForeground(.gray(8))
+            .overflow(.visible)
+            .render(alloc, long_text) catch "";
 
         // hidden (clip)
-        var clip_style = zz.Style{};
-        clip_style = clip_style.width(box_width);
-        clip_style = clip_style.borderAll(.rounded);
-        clip_style = clip_style.borderForeground(.yellow);
-        clip_style = clip_style.overflow(.hidden);
+        var clip_style = zz.newStyle()
+            .width(box_width)
+            .borderAll(.rounded)
+            .borderForeground(.yellow)
+            .overflow(.hidden);
         const clip = clip_style.render(alloc, long_text) catch "";
 
         // ellipsis
-        var ell_style = zz.Style{};
+        var ell_style = zz.newStyle();
         ell_style = ell_style.width(box_width);
         ell_style = ell_style.borderAll(.rounded);
         ell_style = ell_style.borderForeground(.green);
@@ -62,7 +62,7 @@ const Model = struct {
         const ell = ell_style.render(alloc, long_text) catch "";
 
         // word_wrap
-        var ww_style = zz.Style{};
+        var ww_style = zz.newStyle();
         ww_style = ww_style.width(box_width);
         ww_style = ww_style.borderAll(.rounded);
         ww_style = ww_style.borderForeground(.blue);
@@ -70,7 +70,7 @@ const Model = struct {
         const ww = ww_style.render(alloc, long_text) catch "";
 
         // char_wrap
-        var cw_style = zz.Style{};
+        var cw_style = zz.newStyle();
         cw_style = cw_style.width(box_width);
         cw_style = cw_style.borderAll(.rounded);
         cw_style = cw_style.borderForeground(.magenta);
@@ -78,11 +78,12 @@ const Model = struct {
         const cw = cw_style.render(alloc, long_text) catch "";
 
         // Labels
-        var label_style = zz.Style{};
+        var label_style = zz.newStyle();
         label_style = label_style.fg(.gray(12));
         label_style = label_style.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s} visible (default):\n{s}\n\n{s} hidden (clip):\n{s}\n\n{s} ellipsis:\n{s}\n\n{s} word_wrap:\n{s}\n\n{s} char_wrap:\n{s}\n\nPress q to quit",
             .{
                 title,

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -91,7 +91,7 @@ const Model = struct {
 
         // Border preview
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
+        box_style = box_style.borderAll(.rounded);
         box_style = box_style.borderForeground(p.border_focus);
         box_style = box_style.paddingAll(1);
         box_style = box_style.fg(p.foreground);
@@ -100,7 +100,7 @@ const Model = struct {
 
         // Surface/overlay preview
         var surface_style = zz.Style{};
-        surface_style = surface_style.borderAll(zz.Border.normal);
+        surface_style = surface_style.borderAll(.normal);
         surface_style = surface_style.borderForeground(p.border_color);
         surface_style = surface_style.bg(p.surface);
         surface_style = surface_style.fg(p.foreground);
@@ -108,7 +108,7 @@ const Model = struct {
         const surface_box = surface_style.render(ctx.allocator, "Surface") catch "Surface";
 
         var overlay_style = zz.Style{};
-        overlay_style = overlay_style.borderAll(zz.Border.normal);
+        overlay_style = overlay_style.borderAll(.normal);
         overlay_style = overlay_style.borderForeground(p.border_color);
         overlay_style = overlay_style.bg(p.overlay);
         overlay_style = overlay_style.fg(p.foreground);

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -106,7 +106,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Toast Notifications") catch "Toast";
 
@@ -119,7 +119,7 @@ const Model = struct {
         };
 
         var info_style = zz.Style{};
-        info_style = info_style.fg(zz.Color.cyan());
+        info_style = info_style.fg(.cyan);
         info_style = info_style.inline_style(true);
         const info = std.fmt.allocPrint(
             ctx.allocator,
@@ -139,7 +139,7 @@ const Model = struct {
         const styled_info = info_style.render(ctx.allocator, info) catch info;
 
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help = help_style.render(ctx.allocator,
             \\Quick start: press p to move the toast around the screen.
@@ -191,9 +191,9 @@ const Model = struct {
     fn cycleBorderStyle(self: *Model) void {
         self.border_style_idx = (self.border_style_idx + 1) % 3;
         self.toast.border_chars = switch (self.border_style_idx) {
-            0 => zz.Border.rounded,
-            1 => zz.Border.normal,
-            2 => zz.Border.thick,
+            0 => .rounded,
+            1 => .normal,
+            2 => .thick,
             else => unreachable,
         };
     }

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -2,6 +2,7 @@
 //! Demonstrates the List component with item selection.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const zz = @import("zigzag");
 
 const Model = struct {
@@ -148,8 +149,8 @@ const Model = struct {
         const title = title_style.render(ctx.allocator, "Todo List") catch "Todo List";
 
         // Build todo list display using filtered_indices
-        var list_content = std.array_list.Managed(u8).init(ctx.allocator);
-        const writer = list_content.writer();
+        var list_content: Writer.Allocating = .init(ctx.allocator);
+        const writer = &list_content.writer;
 
         // Show filter if enabled
         if (self.list.filter_enabled) {

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -137,12 +137,12 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(.cyan);
         title_style = title_style.inline_style(true);
 
         var box_style = zz.Style{};
-        box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.gray(15));
+        box_style = box_style.borderAll(.rounded);
+        box_style = box_style.borderForeground(.gray(15));
         box_style = box_style.paddingAll(1);
 
         const title = title_style.render(ctx.allocator, "Todo List") catch "Todo List";
@@ -154,7 +154,7 @@ const Model = struct {
         // Show filter if enabled
         if (self.list.filter_enabled) {
             var filter_style = zz.Style{};
-            filter_style = filter_style.fg(zz.Color.yellow());
+            filter_style = filter_style.fg(.yellow);
             filter_style = filter_style.inline_style(true);
             const filter_text = std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{self.list.filter_text.items}) catch "Filter:";
             const styled_filter = filter_style.render(ctx.allocator, filter_text) catch filter_text;
@@ -187,14 +187,14 @@ const Model = struct {
             if (item.value.done) {
                 var done_style = zz.Style{};
                 done_style = done_style.strikethrough(true);
-                done_style = done_style.fg(zz.Color.gray(12));
+                done_style = done_style.fg(.gray(12));
                 done_style = done_style.inline_style(true);
                 const styled = done_style.render(ctx.allocator, item.title) catch item.title;
                 writer.writeAll(styled) catch {};
             } else if (i == self.list.cursor) {
                 var selected_style = zz.Style{};
                 selected_style = selected_style.bold(true);
-                selected_style = selected_style.fg(zz.Color.magenta());
+                selected_style = selected_style.fg(.magenta);
                 selected_style = selected_style.inline_style(true);
                 const styled = selected_style.render(ctx.allocator, item.title) catch item.title;
                 writer.writeAll(styled) catch {};
@@ -214,7 +214,7 @@ const Model = struct {
 
         // Help
         var help_style = zz.Style{};
-        help_style = help_style.fg(zz.Color.gray(12));
+        help_style = help_style.fg(.gray(12));
         help_style = help_style.inline_style(true);
         const help_text = if (self.input_mode)
             "Enter: Add  Esc: Cancel"

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -120,12 +120,12 @@ const Model = struct {
 
         // Title
         var title_s = zz.Style{};
-        title_s = title_s.bold(true).fg(zz.Color.hex("#FF6B6B")).inline_style(true);
+        title_s = title_s.bold(true).fg(.hex("#FF6B6B")).inline_style(true);
         const title = title_s.render(alloc, "Tooltip Component Demo") catch "Tooltip Component Demo";
 
         // Status
         var status_s = zz.Style{};
-        status_s = status_s.fg(zz.Color.gray(12)).inline_style(true);
+        status_s = status_s.fg(.gray(12)).inline_style(true);
         const status = status_s.render(alloc, self.status) catch "";
 
         // Button labels
@@ -141,7 +141,7 @@ const Model = struct {
 
         // Render buttons in a row
         var btn_s = zz.Style{};
-        btn_s = btn_s.fg(zz.Color.white()).inline_style(true);
+        btn_s = btn_s.fg(.white).inline_style(true);
 
         var btn_parts: [7][]const u8 = undefined;
         for (labels, 0..) |label, i| {

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -40,18 +40,18 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
 
         var box_s = zz.Style{};
-        box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderAll(.rounded);
+        box_s = box_s.borderForeground(.cyan);
 
         const list_view = self.vlist.view(alloc);
         const boxed = box_s.render(alloc, list_view) catch list_view;
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(10));
+        help_s = help_s.fg(.gray(10));
         help_s = help_s.inline_style(true);
 
         const content = std.fmt.allocPrint(alloc,

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -59,12 +59,12 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(.cyan);
         title_s = title_s.inline_style(true);
         const title = title_s.render(ctx.allocator, "ZigZag WASM Demo") catch "ZigZag WASM";
 
         var count_s = zz.Style{};
-        count_s = count_s.fg(zz.Color.green());
+        count_s = count_s.fg(.green);
         count_s = count_s.bold(true);
         count_s = count_s.inline_style(true);
         const count_text = std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count}) catch "?";
@@ -77,7 +77,7 @@ const Model = struct {
         ) catch "";
 
         var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(12));
+        help_s = help_s.fg(.gray(12));
         help_s = help_s.inline_style(true);
         const help = help_s.render(ctx.allocator, "Up/Down: change count | q: quit") catch "";
 

--- a/src/accessibility.zig
+++ b/src/accessibility.zig
@@ -3,6 +3,7 @@
 //! and semantic role annotations for terminal UIs.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const Color = @import("style/color.zig").Color;
 
 /// WCAG 2.1 contrast ratio levels.
@@ -119,30 +120,30 @@ pub const AccessibleLabel = struct {
 
     /// Format an accessible description string for screen readers.
     pub fn format(self: AccessibleLabel, allocator: std.mem.Allocator) ![]const u8 {
-        var parts = std.array_list.Managed(u8).init(allocator);
-        const w = parts.writer();
+        var parts: Writer.Allocating = .init(allocator);
+        const w = &parts.writer;
 
         if (self.role != .none) {
             try w.writeAll(self.role.label());
         }
 
         if (self.name.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(": ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(": ");
             try w.writeAll(self.name);
         }
 
         if (self.value.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(", ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(", ");
             try w.writeAll(self.value);
         }
 
         if (self.state.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(", ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(", ");
             try w.writeAll(self.state);
         }
 
         if (self.description.len > 0) {
-            if (parts.items.len > 0) try w.writeAll(" - ");
+            if (parts.writer.buffered().len > 0) try w.writeAll(" - ");
             try w.writeAll(self.description);
         }
 

--- a/src/accessibility.zig
+++ b/src/accessibility.zig
@@ -39,8 +39,8 @@ pub fn meetsAAA(fg: Color, bg: Color) bool {
 /// Suggest a foreground color (white or black) that has better contrast
 /// against the given background.
 pub fn suggestForeground(bg: Color) Color {
-    const white = Color.white();
-    const black = Color.black();
+    const white = Color.white;
+    const black = Color.black;
     const white_ratio = white.contrastRatio(bg);
     const black_ratio = black.contrastRatio(bg);
     return if (white_ratio >= black_ratio) white else black;

--- a/src/components/braille_canvas.zig
+++ b/src/components/braille_canvas.zig
@@ -9,6 +9,7 @@
 //! caller already knows pixel coordinates.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -300,8 +301,8 @@ pub const BrailleCanvas = struct {
             }
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const w = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const w = &result.writer;
 
         var row: usize = 0;
         while (row < self.cell_height) : (row += 1) {

--- a/src/components/breadcrumb.zig
+++ b/src/components/breadcrumb.zig
@@ -5,6 +5,7 @@
 //! the rendered path would exceed a max width.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -127,8 +128,8 @@ pub const Breadcrumb = struct {
     }
 
     fn renderTruncated(self: *const Breadcrumb, allocator: std.mem.Allocator, head: usize, tail: usize) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const head_slice = self.crumbs.items[0..head];
         const tail_slice = self.crumbs.items[self.crumbs.items.len - tail ..];
@@ -169,8 +170,8 @@ pub const Breadcrumb = struct {
     }
 
     fn renderCrumbs(self: *const Breadcrumb, allocator: std.mem.Allocator, items: []const Crumb) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (items, 0..) |c, i| {
             if (i > 0) {

--- a/src/components/breadcrumb.zig
+++ b/src/components/breadcrumb.zig
@@ -31,16 +31,16 @@ pub const Breadcrumb = struct {
 
     pub fn init(allocator: std.mem.Allocator) Breadcrumb {
         var seg = style_mod.Style{};
-        seg = seg.fg(Color.gray(12));
+        seg = seg.fg(.gray(12));
         seg = seg.inline_style(true);
 
         var active = style_mod.Style{};
-        active = active.fg(Color.cyan());
+        active = active.fg(.cyan);
         active = active.bold(true);
         active = active.inline_style(true);
 
         var sep = style_mod.Style{};
-        sep = sep.fg(Color.gray(8));
+        sep = sep.fg(.gray(8));
         sep = sep.inline_style(true);
 
         return .{

--- a/src/components/calendar.zig
+++ b/src/components/calendar.zig
@@ -3,6 +3,7 @@
 //! Fully customizable: styles, labels, symbols, layout.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const keys = @import("../input/keys.zig");
@@ -185,8 +186,8 @@ pub const Calendar = struct {
     }
 
     pub fn view(self: *const Calendar, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const cw: usize = @max(2, self.cell_width);
 
@@ -261,7 +262,7 @@ pub const Calendar = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn padCenter(allocator: std.mem.Allocator, text: []const u8, target: usize) []const u8 {

--- a/src/components/calendar.zig
+++ b/src/components/calendar.zig
@@ -58,34 +58,34 @@ pub const Calendar = struct {
     today_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.inline_style(true);
         break :blk s;
     },
     selected_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.fg(Color.blue());
+        s = s.fg(.blue);
         s = s.inline_style(true);
         break :blk s;
     },
     cursor_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.bg(Color.blue());
-        s = s.fg(Color.white());
+        s = s.bg(.blue);
+        s = s.fg(.white);
         s = s.inline_style(true);
         break :blk s;
     },
     weekend_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.inline_style(true);
         break :blk s;
     },
     header_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.yellow());
+        s = s.fg(.yellow);
         s = s.inline_style(true);
         break :blk s;
     },
@@ -97,7 +97,7 @@ pub const Calendar = struct {
     /// Style for the prev/next symbols in the title.
     nav_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/chart.zig
+++ b/src/components/chart.zig
@@ -1,6 +1,7 @@
 //! Cartesian chart widget with axes, legend, and multiple datasets.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const charting = @import("charting.zig");
 const canvas_mod = @import("canvas.zig");
 const join = @import("../layout/join.zig");
@@ -392,8 +393,8 @@ pub const Chart = struct {
 
     fn renderPlotRow(self: *const Chart, allocator: std.mem.Allocator, row_index: usize, plot_line: []const u8, plot_height: usize, y_label_width: usize, y_ticks: *const TickSet) ![]const u8 {
         _ = plot_height;
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.y_axis.show_labels) {
             const label = y_ticks.labelForRow(row_index) orelse "";
@@ -415,8 +416,8 @@ pub const Chart = struct {
     }
 
     fn renderXAxisLineRow(self: *const Chart, allocator: std.mem.Allocator, plot_width: usize, y_label_width: usize) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.y_axis.show_labels) {
             for (0..y_label_width) |_| try writer.writeByte(' ');
@@ -574,8 +575,8 @@ const GridOrientation = enum { vertical, horizontal };
 
 fn renderPaddedLabel(allocator: std.mem.Allocator, label: []const u8, width: usize, style: Style) ![]const u8 {
     const label_width = measure.width(label);
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     const padding = width -| label_width;
     for (0..padding) |_| try writer.writeByte(' ');

--- a/src/components/charting.zig
+++ b/src/components/charting.zig
@@ -1,6 +1,7 @@
 //! Shared plotting primitives for chart-like components.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 const style_mod = @import("../style/style.zig");
 
@@ -179,8 +180,8 @@ pub const CellBuffer = struct {
     }
 
     pub fn render(self: *const CellBuffer, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var glyph_buf: [4]u8 = undefined;
 

--- a/src/components/checkbox.zig
+++ b/src/components/checkbox.zig
@@ -2,6 +2,7 @@
 //! Standalone boolean toggle and multi-select checkbox group.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -98,8 +99,8 @@ pub const Checkbox = struct {
     }
 
     pub fn view(self: *const Checkbox, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const symbol = if (self.checked) self.checked_symbol else self.unchecked_symbol;
         const sym_style = if (!self.enabled)
@@ -375,8 +376,8 @@ pub fn CheckboxGroup(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             var rendered: usize = 0;
             while (rendered < self.height) : (rendered += 1) {

--- a/src/components/checkbox.zig
+++ b/src/components/checkbox.zig
@@ -39,28 +39,28 @@ pub const Checkbox = struct {
             },
             .checked_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.bold(true);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .unchecked_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .focused_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.magenta());
+                s = s.fg(.magenta);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .disabled_style = blk: {
                 var s = style_mod.Style{};
                 s = s.dim(true);
-                s = s.fg(Color.gray(10));
+                s = s.fg(.gray(10));
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -197,21 +197,21 @@ pub fn CheckboxGroup(comptime T: type) type {
                 },
                 .checked_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/code_view.zig
+++ b/src/components/code_view.zig
@@ -2,6 +2,7 @@
 //! Provides keyword-based highlighting for common languages.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -89,8 +90,8 @@ pub const CodeView = struct {
     };
 
     pub fn view(self: *const CodeView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var lines = std.mem.splitScalar(u8, self.source, '\n');
         var line_num: usize = self.start_line;
@@ -121,14 +122,14 @@ pub const CodeView = struct {
             line_num += 1;
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn highlightLine(self: *const CodeView, allocator: std.mem.Allocator, line: []const u8, in_multiline: *bool) []const u8 {
         if (self.language == .plain) return line;
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var i: usize = 0;
         while (i < line.len) {
@@ -211,7 +212,7 @@ pub const CodeView = struct {
             i += 1;
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn isLineComment(lang: Language, line: []const u8, pos: usize) bool {

--- a/src/components/code_view.zig
+++ b/src/components/code_view.zig
@@ -21,7 +21,7 @@ pub const CodeView = struct {
     /// Operator style.
     operator_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.white());
+        s = s.fg(.white);
         s = s.inline_style(true);
         break :blk s;
     },
@@ -29,52 +29,52 @@ pub const CodeView = struct {
     // Styles
     keyword_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.magenta());
+        s = s.fg(.magenta);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     string_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.green());
+        s = s.fg(.green);
         s = s.inline_style(true);
         break :blk s;
     },
     comment_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.italic(true);
         s = s.inline_style(true);
         break :blk s;
     },
     number_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.inline_style(true);
         break :blk s;
     },
     type_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.yellow());
+        s = s.fg(.yellow);
         s = s.inline_style(true);
         break :blk s;
     },
     builtin_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     line_number_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(8));
+        s = s.fg(.gray(8));
         s = s.inline_style(true);
         break :blk s;
     },
     highlight_bg: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.bg(Color.fromRgb(40, 40, 60));
+        s = s.bg(.fromRgb(40, 40, 60));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/command_palette.zig
+++ b/src/components/command_palette.zig
@@ -7,6 +7,7 @@
 //! back selected().
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -284,9 +285,9 @@ pub const CommandPalette = struct {
     }
 
     pub fn view(self: *const CommandPalette, allocator: std.mem.Allocator) ![]const u8 {
-        var inner = std.array_list.Managed(u8).init(allocator);
+        var inner: Writer.Allocating = .init(allocator);
         defer inner.deinit();
-        const w = inner.writer();
+        const w = &inner.writer;
 
         // Input row.
         const prompt_styled = try self.prompt_style.render(allocator, self.prompt);
@@ -318,7 +319,7 @@ pub const CommandPalette = struct {
                 if (i > start) try w.writeByte('\n');
                 const is_sel = i == self.cursor;
                 const cmd = self.commands.items[self.filtered.items[i]];
-                try self.renderRow(allocator, w.any(), cmd, is_sel);
+                try self.renderRow(allocator, w, cmd, is_sel);
             }
         }
 
@@ -334,7 +335,7 @@ pub const CommandPalette = struct {
     fn renderRow(
         self: *const CommandPalette,
         allocator: std.mem.Allocator,
-        w: std.io.AnyWriter,
+        w: *Writer,
         cmd: Command,
         is_sel: bool,
     ) !void {

--- a/src/components/command_palette.zig
+++ b/src/components/command_palette.zig
@@ -61,7 +61,7 @@ pub const CommandPalette = struct {
 
     pub fn init(allocator: std.mem.Allocator) !CommandPalette {
         var prompt_s = style_mod.Style{};
-        prompt_s = prompt_s.fg(Color.cyan());
+        prompt_s = prompt_s.fg(.cyan);
         prompt_s = prompt_s.bold(true);
         prompt_s = prompt_s.inline_style(true);
 
@@ -69,32 +69,32 @@ pub const CommandPalette = struct {
         input_s = input_s.inline_style(true);
 
         var placeholder_s = style_mod.Style{};
-        placeholder_s = placeholder_s.fg(Color.gray(8));
+        placeholder_s = placeholder_s.fg(.gray(8));
         placeholder_s = placeholder_s.inline_style(true);
 
         var label_s = style_mod.Style{};
         label_s = label_s.inline_style(true);
 
         var desc_s = style_mod.Style{};
-        desc_s = desc_s.fg(Color.gray(10));
+        desc_s = desc_s.fg(.gray(10));
         desc_s = desc_s.inline_style(true);
 
         var shortcut_s = style_mod.Style{};
-        shortcut_s = shortcut_s.fg(Color.gray(8));
+        shortcut_s = shortcut_s.fg(.gray(8));
         shortcut_s = shortcut_s.inline_style(true);
 
         var selected_s = style_mod.Style{};
-        selected_s = selected_s.bg(Color.gray(4));
+        selected_s = selected_s.bg(.gray(4));
         selected_s = selected_s.inline_style(true);
 
         var selected_label_s = style_mod.Style{};
-        selected_label_s = selected_label_s.bg(Color.gray(4));
-        selected_label_s = selected_label_s.fg(Color.cyan());
+        selected_label_s = selected_label_s.bg(.gray(4));
+        selected_label_s = selected_label_s.fg(.cyan);
         selected_label_s = selected_label_s.bold(true);
         selected_label_s = selected_label_s.inline_style(true);
 
         var empty_s = style_mod.Style{};
-        empty_s = empty_s.fg(Color.gray(8));
+        empty_s = empty_s.fg(.gray(8));
         empty_s = empty_s.italic(true);
         empty_s = empty_s.inline_style(true);
 
@@ -108,7 +108,7 @@ pub const CommandPalette = struct {
             .width = 60,
             .prompt = "> ",
             .placeholder = "Type a command…",
-            .border_chars = border_mod.Border.rounded,
+            .border_chars = .rounded,
             .prompt_style = prompt_s,
             .input_style = input_s,
             .placeholder_style = placeholder_s,

--- a/src/components/confirm.zig
+++ b/src/components/confirm.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const keys = @import("../input/keys.zig");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -118,8 +119,8 @@ pub const Confirm = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result_buf = std.array_list.Managed(u8).init(allocator);
-        const writer = result_buf.writer();
+        var result_buf: Writer.Allocating = .init(allocator);
+        const writer = &result_buf.writer;
 
         // Prompt
         const styled_prompt = try self.prompt_style.render(allocator, self.prompt_text);

--- a/src/components/confirm.zig
+++ b/src/components/confirm.zig
@@ -39,13 +39,13 @@ pub const Confirm = struct {
             .active_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .inactive_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -2,6 +2,7 @@
 //! Popup menu triggered by keyboard shortcut or mouse, positioned at a target location.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -288,8 +289,8 @@ pub fn ContextMenu(comptime Action: type) type {
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
             if (!self.visible) return try allocator.dupe(u8, "");
 
-            var result = std.array_list.Managed(u8).init(allocator);
-            const w = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const w = &result.writer;
 
             const inner_width = self.calcWidth();
 
@@ -350,11 +351,11 @@ pub fn ContextMenu(comptime Action: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeIndent(_: *const Self, writer: anytype, count: usize) !void {
+        fn writeIndent(_: *const Self, writer: *Writer, count: usize) !void {
             for (0..count) |_| try writer.writeByte(' ');
         }
 
-        fn writeBorder(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorder(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);
@@ -378,7 +379,7 @@ pub fn ContextMenu(comptime Action: type) type {
             try writer.writeAll(try bs.render(allocator, cr));
         }
 
-        fn writeBorderChar(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderChar(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -316,8 +316,8 @@ pub fn ContextMenu(comptime Action: type) type {
                         const is_active = (i == self.cursor);
                         const s = if (!a.enabled) self.disabled_style else if (is_active) self.active_style else self.item_style;
 
-                        var line = std.array_list.Managed(u8).init(allocator);
-                        const lw = line.writer();
+                        var line: Writer.Allocating = .init(allocator);
+                        const lw = &line.writer;
                         try lw.writeByte(' ');
                         try lw.writeAll(a.label);
 

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -59,39 +59,39 @@ pub fn ContextMenu(comptime Action: type) type {
                 .y = 0,
                 .item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.cyan());
+                    s = s.fg(.white);
+                    s = s.bg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .separator_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(8));
+                    s = s.fg(.gray(8));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .shortcut_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(14),
+                .border_chars = .rounded,
+                .border_fg = .gray(14),
             };
         }
 

--- a/src/components/data_table.zig
+++ b/src/components/data_table.zig
@@ -11,6 +11,7 @@
 //! (database results, log fields, CSV files).
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
@@ -291,16 +292,16 @@ pub const DataTable = struct {
     }
 
     pub fn view(self: *DataTable, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const visible_cols = try self.computeVisibleColumns(allocator);
         defer allocator.free(visible_cols);
 
         if (self.show_header) {
-            try self.renderRow(allocator, w.any(), null, visible_cols, true);
+            try self.renderRow(allocator, w, null, visible_cols, true);
             try w.writeByte('\n');
-            try self.renderHeaderSeparator(allocator, w.any(), visible_cols);
+            try self.renderHeaderSeparator(allocator, w, visible_cols);
             try w.writeByte('\n');
         }
 
@@ -311,7 +312,7 @@ pub const DataTable = struct {
         for (start..end) |row_idx| {
             if (!first) try w.writeByte('\n');
             first = false;
-            try self.renderRow(allocator, w.any(), row_idx, visible_cols, false);
+            try self.renderRow(allocator, w, row_idx, visible_cols, false);
         }
 
         return out.toOwnedSlice();
@@ -340,7 +341,7 @@ pub const DataTable = struct {
         return list.toOwnedSlice();
     }
 
-    fn renderRow(self: *const DataTable, allocator: std.mem.Allocator, writer: std.io.AnyWriter, row_idx: ?usize, visible_cols: []const usize, is_header: bool) !void {
+    fn renderRow(self: *const DataTable, allocator: std.mem.Allocator, writer: *Writer, row_idx: ?usize, visible_cols: []const usize, is_header: bool) !void {
         for (visible_cols, 0..) |col_idx, i| {
             // Frozen separator.
             if (self.frozen_columns > 0 and i == self.frozen_columns) {
@@ -378,7 +379,7 @@ pub const DataTable = struct {
         }
     }
 
-    fn renderHeaderSeparator(self: *const DataTable, allocator: std.mem.Allocator, writer: std.io.AnyWriter, visible_cols: []const usize) !void {
+    fn renderHeaderSeparator(self: *const DataTable, allocator: std.mem.Allocator, writer: *Writer, visible_cols: []const usize) !void {
         for (visible_cols, 0..) |col_idx, i| {
             if (self.frozen_columns > 0 and i == self.frozen_columns) {
                 const sep = try self.frozen_separator_style.render(allocator, "─┼─");

--- a/src/components/data_table.zig
+++ b/src/components/data_table.zig
@@ -68,16 +68,16 @@ pub const DataTable = struct {
         cell_s = cell_s.inline_style(true);
 
         var cursor_cell = style_mod.Style{};
-        cursor_cell = cursor_cell.bg(Color.cyan());
-        cursor_cell = cursor_cell.fg(Color.black());
+        cursor_cell = cursor_cell.bg(.cyan);
+        cursor_cell = cursor_cell.fg(.black);
         cursor_cell = cursor_cell.inline_style(true);
 
         var cursor_row = style_mod.Style{};
-        cursor_row = cursor_row.bg(Color.gray(4));
+        cursor_row = cursor_row.bg(.gray(4));
         cursor_row = cursor_row.inline_style(true);
 
         var frozen_sep = style_mod.Style{};
-        frozen_sep = frozen_sep.fg(Color.gray(8));
+        frozen_sep = frozen_sep.fg(.gray(8));
         frozen_sep = frozen_sep.inline_style(true);
 
         return .{
@@ -98,7 +98,7 @@ pub const DataTable = struct {
             .cursor_cell_style = cursor_cell,
             .cursor_row_style = cursor_row,
             .frozen_separator_style = frozen_sep,
-            .border_chars = border_mod.Border.normal,
+            .border_chars = .normal,
         };
     }
 

--- a/src/components/diff_view.zig
+++ b/src/components/diff_view.zig
@@ -2,6 +2,7 @@
 //! Displays unified or side-by-side text diffs with syntax coloring.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -76,8 +77,8 @@ pub const DiffView = struct {
     }
 
     fn renderUnified(self: *const DiffView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Header
         const hdr = std.fmt.allocPrint(allocator, "--- {s}\n+++ {s}", .{ self.old_label, self.new_label }) catch "";
@@ -129,16 +130,17 @@ pub const DiffView = struct {
         }
 
         // Trim trailing newline
-        if (result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
+        var array = result.toArrayList();
+        if (array.items.len > 0 and array.items[array.items.len - 1] == '\n') {
+            _ = array.pop();
         }
 
-        return result.items;
+        return array.items;
     }
 
     fn renderSideBySide(self: *const DiffView, allocator: std.mem.Allocator) []const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const old_lines = splitLines(allocator, self.old_text);
         const new_lines = splitLines(allocator, self.new_text);
@@ -185,11 +187,12 @@ pub const DiffView = struct {
             }
         }
 
-        if (result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
+        var array = result.toArrayList();
+        if (array.items.len > 0 and array.items[array.items.len - 1] == '\n') {
+            _ = array.pop();
         }
 
-        return result.items;
+        return array.items;
     }
 
     fn padRight(allocator: std.mem.Allocator, text: []const u8, target: usize) []const u8 {

--- a/src/components/diff_view.zig
+++ b/src/components/diff_view.zig
@@ -27,38 +27,38 @@ pub const DiffView = struct {
     // Styles
     add_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.green());
+        s = s.fg(.green);
         s = s.inline_style(true);
         break :blk s;
     },
     remove_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.red());
+        s = s.fg(.red);
         s = s.inline_style(true);
         break :blk s;
     },
     context_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(12));
+        s = s.fg(.gray(12));
         s = s.inline_style(true);
         break :blk s;
     },
     header_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     line_num_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(8));
+        s = s.fg(.gray(8));
         s = s.inline_style(true);
         break :blk s;
     },
     separator_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(6));
+        s = s.fg(.gray(6));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -583,8 +583,8 @@ pub fn Dropdown(comptime T: type) type {
 
                 const item_idx = visible[idx];
                 const item = self.items.items[item_idx];
-                var line = std.array_list.Managed(u8).init(allocator);
-                const line_writer = line.writer();
+                var line: Writer.Allocating = .init(allocator);
+                const line_writer = &line.writer;
 
                 try line_writer.writeByte(' ');
 

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const keys = @import("../input/keys.zig");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -485,8 +486,8 @@ pub fn Dropdown(comptime T: type) type {
         // ── Rendering ───────────────────────────────────
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Label
             if (self.label.len > 0) {
@@ -667,7 +668,7 @@ pub fn Dropdown(comptime T: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeBorderLine(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorderLine(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             const bc = self.border_chars;
             var border_style = style_mod.Style{};
             border_style = border_style.fg(self.border_fg);
@@ -696,7 +697,7 @@ pub fn Dropdown(comptime T: type) type {
             try writer.writeAll(styled_r);
         }
 
-        fn writeBorderSide(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderSide(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var border_style = style_mod.Style{};
             border_style = border_style.fg(self.border_fg);
             border_style = border_style.inline_style(true);
@@ -709,7 +710,7 @@ pub fn Dropdown(comptime T: type) type {
             try writer.writeAll(styled);
         }
 
-        fn writePadding(_: *const Self, writer: anytype, count: usize) !void {
+        fn writePadding(_: *const Self, writer: *Writer, count: usize) !void {
             for (0..count) |_| {
                 try writer.writeByte(' ');
             }

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -123,14 +123,14 @@ pub fn Dropdown(comptime T: type) type {
                 },
                 .trigger_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.white());
+                    s = s.fg(.white);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .trigger_focused_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -142,31 +142,31 @@ pub fn Dropdown(comptime T: type) type {
                 .cursor_item_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .selected_item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.green());
+                    s = s.fg(.green);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .filter_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.yellow());
+                    s = s.fg(.yellow);
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(14),
+                .border_chars = .rounded,
+                .border_fg = .gray(14),
             };
         }
 

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -2,6 +2,7 @@
 //! Allows browsing directories and selecting files.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const builtin = @import("builtin");
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
@@ -355,8 +356,8 @@ pub const FilePicker = struct {
 
     /// Render the file picker
     pub fn view(self: *const FilePicker, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Current path header
         const path_styled = try self.path_style.render(allocator, self.current_path.items);

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -78,7 +78,7 @@ pub const FilePicker = struct {
             .dir_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.blue());
+                s = s.fg(.blue);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -90,20 +90,20 @@ pub const FilePicker = struct {
             .cursor_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .size_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .path_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/focus.zig
+++ b/src/components/focus.zig
@@ -302,11 +302,11 @@ pub fn FocusGroup(comptime max_items: usize) type {
 /// ```
 pub const FocusStyle = struct {
     /// Border color when focused (default: cyan).
-    focused_border_fg: Color = Color.cyan(),
+    focused_border_fg: Color = .cyan,
     /// Border color when not focused (default: dark gray).
-    blurred_border_fg: Color = Color.gray(12),
+    blurred_border_fg: Color = .gray(12),
     /// Border character set (default: rounded).
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
+    border_chars: border_mod.BorderChars = .rounded,
 
     /// Apply focus-aware border styling to `base`.
     /// Returns a new Style with the appropriate border and color.

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -2,6 +2,7 @@
 //! Composes multiple input fields with focus management, labels, and validation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -205,8 +206,8 @@ pub fn Form(comptime max_fields: usize) type {
 
         /// Render the form.
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Title
             if (self.title.len > 0) {

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -9,6 +9,19 @@ const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
 const focus_mod = @import("focus.zig");
 
+/// Universally-supported submit bindings. Ctrl+S works in every terminal
+/// (no encoding ambiguity). Ctrl+Enter is included for terminals that
+/// implement the Kitty keyboard protocol — most don't (notably macOS
+/// Terminal.app, basic xterm), so it's a bonus, not the primary binding.
+const default_submit_keys = [_]keys.KeyEvent{
+    keys.KeyEvent.ctrl('s'),
+    .{ .key = .enter, .modifiers = .{ .ctrl = true } },
+};
+
+const default_cancel_keys = [_]keys.KeyEvent{
+    .{ .key = .escape },
+};
+
 pub fn Form(comptime max_fields: usize) type {
     return struct {
         // Fields
@@ -26,6 +39,17 @@ pub fn Form(comptime max_fields: usize) type {
         label_width: u16,
         spacing: u16,
         show_required_marker: bool,
+
+        // Submit bindings. Multiple keys can submit the form. Default
+        // includes Ctrl+S (works in every terminal) and Ctrl+Enter (only
+        // works in terminals that implement the Kitty keyboard protocol —
+        // Terminal.app and most basic xterms cannot tell Ctrl+Enter from
+        // plain Enter, so we don't rely on it).
+        submit_keys: []const keys.KeyEvent,
+        cancel_keys: []const keys.KeyEvent,
+        /// Human-readable description of submit/cancel bindings shown in the
+        /// footer hint. Override if you change submit_keys/cancel_keys.
+        hint_text: []const u8,
 
         // Styling
         label_style: style_mod.Style,
@@ -60,6 +84,9 @@ pub fn Form(comptime max_fields: usize) type {
                 .label_width = 15,
                 .spacing = 1,
                 .show_required_marker = true,
+                .submit_keys = &default_submit_keys,
+                .cancel_keys = &default_cancel_keys,
+                .hint_text = "Tab: next field | Ctrl+S: submit | Esc: cancel",
                 .label_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
@@ -173,18 +200,22 @@ pub fn Form(comptime max_fields: usize) type {
 
         /// Handle key events.
         pub fn handleKey(self: *Self, key: keys.KeyEvent) bool {
-            // Ctrl+Enter to submit
-            if (key.modifiers.ctrl and key.key == .enter) {
-                if (self.validate()) {
-                    self.submitted = true;
+            // Submit on any configured submit key.
+            for (self.submit_keys) |sk| {
+                if (sk.eql(key)) {
+                    if (self.validate()) {
+                        self.submitted = true;
+                    }
+                    return true;
                 }
-                return true;
             }
 
-            // Escape to cancel
-            if (key.key == .escape) {
-                self.cancelled = true;
-                return true;
+            // Cancel on any configured cancel key.
+            for (self.cancel_keys) |ck| {
+                if (ck.eql(key)) {
+                    self.cancelled = true;
+                    return true;
+                }
             }
 
             // Tab/Shift+Tab for focus cycling
@@ -259,7 +290,7 @@ pub fn Form(comptime max_fields: usize) type {
             var hint_style = style_mod.Style{};
             hint_style = hint_style.fg(.gray(12));
             hint_style = hint_style.inline_style(true);
-            const hint = try hint_style.render(allocator, "Tab: next field | Ctrl+Enter: submit | Esc: cancel");
+            const hint = try hint_style.render(allocator, self.hint_text);
             try writer.writeAll(hint);
 
             return result.toOwnedSlice();

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -67,24 +67,24 @@ pub fn Form(comptime max_fields: usize) type {
                 },
                 .required_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.red());
+                    s = s.fg(.red);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .error_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.red());
+                    s = s.fg(.red);
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(10),
-                .border_focus_fg = Color.cyan(),
+                .border_chars = .rounded,
+                .border_fg = .gray(10),
+                .border_focus_fg = .cyan,
                 .title = "",
                 .title_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -256,7 +256,7 @@ pub fn Form(comptime max_fields: usize) type {
             // Footer
             try writer.writeAll("\n\n");
             var hint_style = style_mod.Style{};
-            hint_style = hint_style.fg(Color.gray(12));
+            hint_style = hint_style.fg(.gray(12));
             hint_style = hint_style.inline_style(true);
             const hint = try hint_style.render(allocator, "Tab: next field | Ctrl+Enter: submit | Esc: cancel");
             try writer.writeAll(hint);

--- a/src/components/gauge.zig
+++ b/src/components/gauge.zig
@@ -2,6 +2,7 @@
 //! Supports bar, level meter, and block display styles with thresholds and gradients.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -101,8 +102,8 @@ pub const Gauge = struct {
         const bar_width: usize = self.width;
         const filled: usize = @intFromFloat(@as(f64, @floatFromInt(bar_width)) * pct);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Label
         if (self.label.len > 0) {
@@ -158,7 +159,7 @@ pub const Gauge = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn renderLevelMeter(self: *const Gauge, allocator: std.mem.Allocator) []const u8 {
@@ -166,8 +167,8 @@ pub const Gauge = struct {
         const levels: usize = 10;
         const filled: usize = @intFromFloat(@as(f64, @floatFromInt(levels)) * pct);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.label.len > 0) {
             writer.writeAll(self.label) catch {};
@@ -194,7 +195,7 @@ pub const Gauge = struct {
             writer.print(" {d:.0}%", .{pct * 100}) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn renderBlocks(self: *const Gauge, allocator: std.mem.Allocator) []const u8 {
@@ -205,8 +206,8 @@ pub const Gauge = struct {
         // Use shade characters based on intensity
         const shades = [_][]const u8{ " ", "\xe2\x96\x91", "\xe2\x96\x92", "\xe2\x96\x93", "\xe2\x96\x88" };
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.label.len > 0) {
             writer.writeAll(self.label) catch {};
@@ -234,7 +235,7 @@ pub const Gauge = struct {
             writer.print(" {d:.0}%", .{pct * 100}) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn colorForLevel(self: *const Gauge, level_pct: f64) Color {

--- a/src/components/gauge.zig
+++ b/src/components/gauge.zig
@@ -25,9 +25,9 @@ pub const Gauge = struct {
     /// Thresholds for color changes.
     thresholds: []const Threshold = &.{},
     /// Base color (used when below all thresholds).
-    base_color: Color = Color.green(),
+    base_color: Color = .green,
     /// Empty/background color.
-    empty_color: Color = Color.gray(6),
+    empty_color: Color = .gray(6),
     /// Label style.
     label_style: style_mod.Style = .{},
     /// Value/percent label style.

--- a/src/components/heatmap.zig
+++ b/src/components/heatmap.zig
@@ -2,6 +2,7 @@
 //! Displays data as a colored grid with configurable color scales.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -139,8 +140,8 @@ pub const Heatmap = struct {
         if (self.rows == 0 or self.cols == 0) return "";
 
         const mm = self.getMinMax();
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Title
         if (self.title.len > 0) {
@@ -226,7 +227,7 @@ pub const Heatmap = struct {
             writer.writeAll(max_str) catch {};
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn maxLabelWidth(labels: []const []const u8) usize {

--- a/src/components/heatmap.zig
+++ b/src/components/heatmap.zig
@@ -104,33 +104,33 @@ pub const Heatmap = struct {
     fn scaleColor(self: *const Heatmap, t: f64) Color {
         return switch (self.color_scale) {
             .green_scale => {
-                if (t < 0.01) return Color.gray(2);
+                if (t < 0.01) return .gray(2);
                 const g: u8 = @intFromFloat(80 + 175 * t);
-                return Color.fromRgb(0, g, 0);
+                return .fromRgb(0, g, 0);
             },
             .cool_to_hot => {
                 if (t < 0.25) {
                     const lt = t * 4;
-                    return Color.fromRgb(0, @intFromFloat(lt * 255), 255);
+                    return .fromRgb(0, @intFromFloat(lt * 255), 255);
                 } else if (t < 0.5) {
                     const lt = (t - 0.25) * 4;
-                    return Color.fromRgb(0, 255, @intFromFloat(255 - lt * 255));
+                    return .fromRgb(0, 255, @intFromFloat(255 - lt * 255));
                 } else if (t < 0.75) {
                     const lt = (t - 0.5) * 4;
-                    return Color.fromRgb(@intFromFloat(lt * 255), 255, 0);
+                    return .fromRgb(@intFromFloat(lt * 255), 255, 0);
                 } else {
                     const lt = (t - 0.75) * 4;
-                    return Color.fromRgb(255, @intFromFloat(255 - lt * 255), 0);
+                    return .fromRgb(255, @intFromFloat(255 - lt * 255), 0);
                 }
             },
             .grayscale => {
                 const v: u8 = @intFromFloat(t * 255);
-                return Color.fromRgb(v, v, v);
+                return .fromRgb(v, v, v);
             },
             .blue_red => {
                 const r: u8 = @intFromFloat(t * 255);
                 const b: u8 = @intFromFloat((1 - t) * 255);
-                return Color.fromRgb(r, 0, b);
+                return .fromRgb(r, 0, b);
             },
         };
     }
@@ -196,7 +196,7 @@ pub const Heatmap = struct {
                     const val_str = std.fmt.allocPrint(allocator, "{d:.0}", .{val}) catch " ";
                     const padded = padCenter(allocator, val_str, self.cell_width);
                     // Choose foreground for contrast
-                    cs = cs.fg(if (t > 0.5) Color.black() else Color.white());
+                    cs = cs.fg(if (t > 0.5) .black else .white);
                     writer.writeAll(cs.render(allocator, padded) catch padded) catch {};
                 } else {
                     var cell_buf: [8]u8 = undefined;

--- a/src/components/help.zig
+++ b/src/components/help.zig
@@ -2,6 +2,7 @@
 //! Shows keyboard shortcuts and their descriptions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -117,8 +118,8 @@ pub const Help = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var total_width: usize = 0;
 
@@ -180,8 +181,8 @@ pub const Help = struct {
             max_key_width = @max(max_key_width, measure.width(binding.key));
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (self.bindings.items, 0..) |binding, i| {
             if (i > 0) try writer.writeByte('\n');

--- a/src/components/help.zig
+++ b/src/components/help.zig
@@ -41,19 +41,19 @@ pub const Help = struct {
             .key_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .desc_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(18));
+                s = s.fg(.gray(18));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .sep_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/keybinding.zig
+++ b/src/components/keybinding.zig
@@ -2,6 +2,7 @@
 //! Provides structured key binding definitions with matching and help integration.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const Key = keys.Key;
 const KeyEvent = keys.KeyEvent;
@@ -23,8 +24,8 @@ pub const KeyBinding = struct {
 
     /// Get a display string for the key
     pub fn keyDisplay(self: *const KeyBinding, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (self.key_event.modifiers.ctrl) try writer.writeAll("ctrl+");
         if (self.key_event.modifiers.alt) try writer.writeAll("alt+");

--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -2,6 +2,7 @@
 //! Displays a list of items with selection and optional filtering.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -405,8 +406,8 @@ pub fn List(comptime T: type) type {
 
         /// Render the list
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Filter line
             if (self.filter_enabled) {

--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -94,20 +94,20 @@ pub fn List(comptime T: type) type {
                 },
                 .selected_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .filter_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.yellow());
+                    s = s.fg(.yellow);
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -2,6 +2,7 @@
 //! Converts a subset of markdown to ANSI-styled text.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -126,8 +127,8 @@ pub const Markdown = struct {
 
     /// Render markdown text to styled terminal output.
     pub fn render(self: *const Markdown, allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var lines_iter = std.mem.splitScalar(u8, source, '\n');
         var in_code_block = false;
@@ -262,8 +263,8 @@ pub const Markdown = struct {
 
     /// Render inline formatting: **bold**, *italic*, `code`, [links](url)
     fn renderInline(self: *const Markdown, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         var i: usize = 0;
         while (i < text.len) {

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -311,7 +311,7 @@ pub const Markdown = struct {
                             const styled_text = try self.link_style.render(allocator, link_text);
                             try writer.writeAll(styled_text);
                             var dim = style_mod.Style{};
-                            dim = dim.fg(Color.gray(10));
+                            dim = dim.fg(.gray(10));
                             dim = dim.inline_style(true);
                             const url_str = try std.fmt.allocPrint(allocator, " ({s})", .{url});
                             const styled_url = try dim.render(allocator, url_str);

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -32,7 +32,7 @@ pub const Markdown = struct {
             .h1_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.magenta());
+                s = s.fg(.magenta);
                 s = s.underline(true);
                 s = s.inline_style(true);
                 break :blk s;
@@ -40,14 +40,14 @@ pub const Markdown = struct {
             .h2_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .h3_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -65,26 +65,26 @@ pub const Markdown = struct {
             },
             .code_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
-                s = s.bg(Color.fromRgb(40, 40, 40));
+                s = s.fg(.yellow);
+                s = s.bg(.fromRgb(40, 40, 40));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .code_block_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .code_block_border = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .link_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.underline(true);
                 s = s.inline_style(true);
                 break :blk s;
@@ -92,25 +92,25 @@ pub const Markdown = struct {
             .blockquote_style = blk: {
                 var s = style_mod.Style{};
                 s = s.italic(true);
-                s = s.fg(Color.gray(14));
+                s = s.fg(.gray(14));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .blockquote_bar = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(10));
+                s = s.fg(.gray(10));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .list_bullet_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .hr_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/menu_bar.zig
+++ b/src/components/menu_bar.zig
@@ -2,6 +2,7 @@
 //! Horizontal menu bar with dropdown menus and keyboard navigation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -390,12 +391,12 @@ pub fn MenuBar(comptime Action: type) type {
         // ── Rendering ───────────────────────────────
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator, term_width: usize) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Render menu bar
-            var bar_content = std.array_list.Managed(u8).init(allocator);
-            const bar_writer = bar_content.writer();
+            var bar_content: Writer.Allocating = .init(allocator);
+            const bar_writer = &bar_content.writer;
 
             try bar_writer.writeAll(" ");
 
@@ -437,8 +438,8 @@ pub fn MenuBar(comptime Action: type) type {
         }
 
         fn renderDropdown(self: *const Self, allocator: std.mem.Allocator, menu: Menu) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const w = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const w = &result.writer;
 
             // Calculate width
             var max_label_width: usize = 0;
@@ -489,8 +490,8 @@ pub fn MenuBar(comptime Action: type) type {
                         const s = if (!a.enabled) self.item_disabled_style else if (is_active) self.item_active_style else self.item_style;
 
                         // Build line content
-                        var line = std.array_list.Managed(u8).init(allocator);
-                        const lw = line.writer();
+                        var line: Writer.Allocating = .init(allocator);
+                        const lw = &line.writer;
 
                         try lw.writeByte(' ');
 
@@ -537,7 +538,7 @@ pub fn MenuBar(comptime Action: type) type {
         const BorderPos = enum { top, middle, bottom };
         const BorderSide = enum { left, right };
 
-        fn writeBorder(self: *const Self, writer: anytype, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
+        fn writeBorder(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, width: usize, pos: BorderPos) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);
@@ -561,7 +562,7 @@ pub fn MenuBar(comptime Action: type) type {
             try writer.writeAll(try bs.render(allocator, cr));
         }
 
-        fn writeBorderChar(self: *const Self, writer: anytype, allocator: std.mem.Allocator, side: BorderSide) !void {
+        fn writeBorderChar(self: *const Self, writer: *Writer, allocator: std.mem.Allocator, side: BorderSide) !void {
             var bs = style_mod.Style{};
             bs = bs.fg(self.border_fg);
             bs = bs.inline_style(true);

--- a/src/components/menu_bar.zig
+++ b/src/components/menu_bar.zig
@@ -78,59 +78,59 @@ pub fn MenuBar(comptime Action: type) type {
                 .selected_action = null,
                 .bar_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.bg(Color.fromRgb(40, 40, 50));
+                    s = s.bg(.fromRgb(40, 40, 50));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .bar_item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .bar_active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.fromRgb(60, 60, 80));
+                    s = s.fg(.white);
+                    s = s.bg(.fromRgb(60, 60, 80));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.cyan());
+                    s = s.fg(.white);
+                    s = s.bg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .separator_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .shortcut_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.normal,
-                .border_fg = Color.gray(14),
+                .border_chars = .normal,
+                .border_fg = .gray(14),
                 .gap = 2,
             };
         }

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -39,6 +39,7 @@
 //! can be registered with a `FocusGroup`.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
@@ -452,8 +453,8 @@ pub const Modal = struct {
         pad_s = pad_s.inline_style(true);
         if (!self.content_bg.isNone()) pad_s = pad_s.bg(self.content_bg);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // ── Top border ──
         try writer.writeAll(try bdr_s.render(allocator, bc.top_left));
@@ -546,8 +547,8 @@ pub const Modal = struct {
             try self.writeEmptyInnerLine(allocator, writer, styled_left, styled_right, pad_s, inner_w);
 
             // Render button row content
-            var btn_buf = std.array_list.Managed(u8).init(allocator);
-            const btn_writer = btn_buf.writer();
+            var btn_buf: Writer.Allocating = .init(allocator);
+            const btn_writer = &btn_buf.writer;
 
             for (self.buttons[0..self.button_count], 0..) |maybe_btn, i| {
                 if (maybe_btn) |btn| {
@@ -610,7 +611,7 @@ pub const Modal = struct {
     fn writeEmptyInnerLine(
         self: *const Modal,
         allocator: std.mem.Allocator,
-        writer: anytype,
+        writer: *Writer,
         styled_left: []const u8,
         styled_right: []const u8,
         pad_s: style_mod.Style,

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -398,8 +398,8 @@ pub const Modal = struct {
         const modal_lines = modal_lines_list.items;
 
         // Build full-screen output
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..term_height) |row| {
             if (row > 0) try writer.writeByte('\n');

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -82,14 +82,14 @@ pub const Modal = struct {
 
     // ── Styling ────────────────────────────────────────────────────────
 
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
-    border_fg: Color = Color.gray(18),
+    border_chars: border_mod.BorderChars = .rounded,
+    border_fg: Color = .gray(18),
     content_bg: Color = .none,
-    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white() }),
-    body_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(20) }),
-    footer_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(12), .italic_v = true }),
-    button_active_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white(), .bg_color = Color.cyan() }),
-    button_inactive_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(14) }),
+    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white }),
+    body_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(20) }),
+    footer_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(12), .italic_v = true }),
+    button_active_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white, .bg_color = .cyan }),
+    button_inactive_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(14) }),
     backdrop: ?Backdrop = null,
 
     // ── Types ──────────────────────────────────────────────────────────
@@ -131,19 +131,19 @@ pub const Modal = struct {
         /// Fill character (UTF-8 string, e.g. " ", "░", "▒", "▓", "█").
         char: []const u8 = " ",
         /// Style applied to the backdrop fill.
-        style: style_mod.Style = makeStyle(.{ .bg_color = Color.gray(3) }),
+        style: style_mod.Style = makeStyle(.{ .bg_color = .gray(3) }),
 
         /// Dark semi-transparent backdrop (default).
         pub const dark = Backdrop{};
 
         /// Slightly lighter backdrop.
         pub const medium = Backdrop{
-            .style = makeStyle(.{ .bg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .bg_color = .gray(5) }),
         };
 
         /// Light backdrop.
         pub const light = Backdrop{
-            .style = makeStyle(.{ .bg_color = Color.gray(8) }),
+            .style = makeStyle(.{ .bg_color = .gray(8) }),
         };
 
         /// Clear backdrop — uses the terminal's default background color.
@@ -154,19 +154,19 @@ pub const Modal = struct {
         /// Light shade fill character (░).
         pub const shade_light = Backdrop{
             .char = "░",
-            .style = makeStyle(.{ .fg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .fg_color = .gray(5) }),
         };
 
         /// Medium shade fill character (▒).
         pub const shade_medium = Backdrop{
             .char = "▒",
-            .style = makeStyle(.{ .fg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .fg_color = .gray(5) }),
         };
 
         /// Dense shade fill character (▓).
         pub const shade_dense = Backdrop{
             .char = "▓",
-            .style = makeStyle(.{ .fg_color = Color.gray(4) }),
+            .style = makeStyle(.{ .fg_color = .gray(4) }),
         };
 
         /// Create a solid-color backdrop.
@@ -190,8 +190,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.cyan(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.cyan() }),
+            .border_fg = .cyan,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .cyan }),
         };
         m.addButton("OK", .enter);
         return m;
@@ -202,8 +202,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.yellow(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.yellow() }),
+            .border_fg = .yellow,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .yellow }),
         };
         m.addButton("Yes", .{ .char = 'y' });
         m.addButton("No", .{ .char = 'n' });
@@ -215,8 +215,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.yellow(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.yellow() }),
+            .border_fg = .yellow,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .yellow }),
         };
         m.addButton("OK", .enter);
         return m;
@@ -227,8 +227,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.red(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.red() }),
+            .border_fg = .red,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .red }),
         };
         m.addButton("OK", .enter);
         return m;

--- a/src/components/notification.zig
+++ b/src/components/notification.zig
@@ -2,6 +2,7 @@
 //! Displays auto-dismissing messages with severity levels.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -101,8 +102,8 @@ pub const Notification = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const visible_count = @min(self.messages.items.len, self.max_visible);
         const start = if (self.messages.items.len > self.max_visible)

--- a/src/components/notification.zig
+++ b/src/components/notification.zig
@@ -37,25 +37,25 @@ pub const Notification = struct {
             .max_visible = 5,
             .info_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .success_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .warning_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .err_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/paginator.zig
+++ b/src/components/paginator.zig
@@ -2,6 +2,7 @@
 //! Displays page indicators and handles navigation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -153,8 +154,8 @@ pub const Paginator = struct {
     }
 
     fn viewDots(self: *const Paginator, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..self.total_pages) |i| {
             if (i > 0) try writer.writeByte(' ');
@@ -177,8 +178,8 @@ pub const Paginator = struct {
     }
 
     fn viewCompact(self: *const Paginator, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Show limited range of pages
         const max_visible = 5;

--- a/src/components/paginator.zig
+++ b/src/components/paginator.zig
@@ -39,13 +39,13 @@ pub const Paginator = struct {
             .inactive_dot = "○",
             .active_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .inactive_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/progress.zig
+++ b/src/components/progress.zig
@@ -2,6 +2,7 @@
 //! Displays progress with customizable appearance.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -133,8 +134,8 @@ pub const Progress = struct {
 
     /// Render the progress bar
     pub fn view(self: *const Progress, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const ratio = if (self.total > 0) self.current / self.total else 0;
         const filled_width = @as(usize, @intFromFloat(ratio * @as(f64, @floatFromInt(self.width))));
@@ -190,8 +191,8 @@ pub const Progress = struct {
 
     /// Render with a label
     pub fn viewWithLabel(self: *const Progress, allocator: std.mem.Allocator, label: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         try writer.writeAll(label);
         try writer.writeAll(" ");

--- a/src/components/progress.zig
+++ b/src/components/progress.zig
@@ -41,13 +41,13 @@ pub const Progress = struct {
             .head_char = null,
             .full_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .empty_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -239,11 +239,11 @@ pub const ProgressStyle = struct {
     pub fn colored() Progress {
         var p = Progress.init();
         var full_s = style.Style{};
-        full_s = full_s.fg(Color.green());
+        full_s = full_s.fg(.green);
         full_s = full_s.inline_style(true);
         p.full_style = full_s;
         var empty_s = style.Style{};
-        empty_s = empty_s.fg(Color.red());
+        empty_s = empty_s.fg(.red);
         empty_s = empty_s.inline_style(true);
         p.empty_style = empty_s;
         return p;
@@ -259,5 +259,5 @@ pub fn interpolateColor(start: Color, end: Color, t: f64) Color {
     const g: u8 = @intFromFloat(@as(f64, @floatFromInt(start_rgb.g)) * (1.0 - t) + @as(f64, @floatFromInt(end_rgb.g)) * t);
     const b: u8 = @intFromFloat(@as(f64, @floatFromInt(start_rgb.b)) * (1.0 - t) + @as(f64, @floatFromInt(end_rgb.b)) * t);
 
-    return Color.fromRgb(r, g, b);
+    return .fromRgb(r, g, b);
 }

--- a/src/components/radio_group.zig
+++ b/src/components/radio_group.zig
@@ -2,6 +2,7 @@
 //! Single-select option group with radio button semantics.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -216,8 +217,8 @@ pub fn RadioGroup(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             var rendered: usize = 0;
             while (rendered < self.height) : (rendered += 1) {

--- a/src/components/radio_group.zig
+++ b/src/components/radio_group.zig
@@ -70,7 +70,7 @@ pub fn RadioGroup(comptime T: type) type {
                 },
                 .selected_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.bold(true);
                     s = s.inline_style(true);
                     break :blk s;
@@ -78,14 +78,14 @@ pub fn RadioGroup(comptime T: type) type {
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/rich_log.zig
+++ b/src/components/rich_log.zig
@@ -9,6 +9,7 @@
 //! is the right widget for a long-running app's persistent log/audit pane.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -262,8 +263,8 @@ pub const RichLog = struct {
     pub fn view(self: *RichLog, allocator: std.mem.Allocator) ![]const u8 {
         try self.refresh();
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         const visible = self.visible.items;
         if (visible.len == 0) {
@@ -278,13 +279,13 @@ pub const RichLog = struct {
             if (!first) try w.writeByte('\n');
             first = false;
             const entry = self.entries.items[visible[row_idx]];
-            try self.renderEntry(allocator, w.any(), entry);
+            try self.renderEntry(allocator, w, entry);
         }
 
         return out.toOwnedSlice();
     }
 
-    fn renderEntry(self: *const RichLog, allocator: std.mem.Allocator, w: std.io.AnyWriter, entry: Entry) !void {
+    fn renderEntry(self: *const RichLog, allocator: std.mem.Allocator, w: *Writer, entry: Entry) !void {
         if (self.show_timestamps) {
             const ts = try formatTimestamp(allocator, entry.timestamp_ns);
             defer allocator.free(ts);
@@ -312,7 +313,7 @@ pub const RichLog = struct {
         }
     }
 
-    fn renderHighlighted(self: *const RichLog, allocator: std.mem.Allocator, w: std.io.AnyWriter, text: []const u8) !void {
+    fn renderHighlighted(self: *const RichLog, allocator: std.mem.Allocator, w: *Writer, text: []const u8) !void {
         const term = self.search_term.items;
         var rest = text;
         while (std.mem.indexOf(u8, rest, term)) |pos| {

--- a/src/components/rich_log.zig
+++ b/src/components/rich_log.zig
@@ -86,23 +86,23 @@ pub const RichLog = struct {
 
     pub fn init(allocator: std.mem.Allocator, capacity: usize) RichLog {
         var ts = Style{};
-        ts = ts.fg(Color.gray(8));
+        ts = ts.fg(.gray(8));
         ts = ts.inline_style(true);
 
         var trace_s = Style{};
-        trace_s = trace_s.fg(Color.gray(6));
+        trace_s = trace_s.fg(.gray(6));
         trace_s = trace_s.inline_style(true);
         var debug_s = Style{};
-        debug_s = debug_s.fg(Color.gray(10));
+        debug_s = debug_s.fg(.gray(10));
         debug_s = debug_s.inline_style(true);
         var info_s = Style{};
-        info_s = info_s.fg(Color.cyan());
+        info_s = info_s.fg(.cyan);
         info_s = info_s.inline_style(true);
         var warn_s = Style{};
-        warn_s = warn_s.fg(Color.yellow());
+        warn_s = warn_s.fg(.yellow);
         warn_s = warn_s.inline_style(true);
         var err_s = Style{};
-        err_s = err_s.fg(Color.red());
+        err_s = err_s.fg(.red);
         err_s = err_s.bold(true);
         err_s = err_s.inline_style(true);
 
@@ -110,8 +110,8 @@ pub const RichLog = struct {
         text = text.inline_style(true);
 
         var hi = Style{};
-        hi = hi.bg(Color.yellow());
-        hi = hi.fg(Color.black());
+        hi = hi.bg(.yellow);
+        hi = hi.fg(.black);
         hi = hi.inline_style(true);
 
         return .{

--- a/src/components/slider.zig
+++ b/src/components/slider.zig
@@ -2,6 +2,7 @@
 //! Interactive numeric range input with keyboard control.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -170,8 +171,8 @@ pub const Slider = struct {
     }
 
     pub fn view(self: *const Slider, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Label
         if (self.label.len > 0) {

--- a/src/components/slider.zig
+++ b/src/components/slider.zig
@@ -60,20 +60,20 @@ pub const Slider = struct {
             .filled_char = "━",
             .track_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .filled_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .thumb_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.white());
+                s = s.fg(.white);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -85,7 +85,7 @@ pub const Slider = struct {
             },
             .value_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/sortable_table.zig
+++ b/src/components/sortable_table.zig
@@ -2,6 +2,7 @@
 //! Extends basic table with column sorting and text filtering.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -199,8 +200,8 @@ pub fn SortableTable(comptime num_cols: usize) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) []const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             // Compute column widths
             var widths: [num_cols]usize = undefined;
@@ -280,7 +281,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
             cs = cs.inline_style(true);
             writer.writeAll(cs.render(allocator, count) catch count) catch {};
 
-            return result.items;
+            return result.toArrayList().items;
         }
 
         fn padTo(allocator: std.mem.Allocator, text: []const u8, target: usize, alignment: Align) []const u8 {

--- a/src/components/sortable_table.zig
+++ b/src/components/sortable_table.zig
@@ -30,7 +30,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
         col_aligns: [num_cols]Align = .{.left} ** num_cols,
         show_header: bool = true,
         show_border: bool = true,
-        border_chars: border_mod.BorderChars = border_mod.Border.normal,
+        border_chars: border_mod.BorderChars = .normal,
 
         // Interactive
         cursor_row: usize = 0,
@@ -52,8 +52,8 @@ pub fn SortableTable(comptime num_cols: usize) type {
         },
         cursor_row_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.bg(Color.blue());
-            s = s.fg(Color.white());
+            s = s.bg(.blue);
+            s = s.fg(.white);
             s = s.inline_style(true);
             break :blk s;
         },
@@ -276,7 +276,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
             writer.writeByte('\n') catch {};
             const count = std.fmt.allocPrint(allocator, " {d}/{d} rows", .{ self.view_indices.items.len, self.rows.items.len }) catch "";
             var cs = style_mod.Style{};
-            cs = cs.fg(Color.gray(10));
+            cs = cs.fg(.gray(10));
             cs = cs.inline_style(true);
             writer.writeAll(cs.render(allocator, count) catch count) catch {};
 

--- a/src/components/sparkline.zig
+++ b/src/components/sparkline.zig
@@ -34,7 +34,7 @@ pub const Sparkline = struct {
             .retention_limit = 40,
             .spark_style = blk: {
                 var s = Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 break :blk charting.inlineStyle(s);
             },
             .empty_char = " ",
@@ -179,7 +179,7 @@ pub const Sparkline = struct {
         for (0..width) |bucket_index| {
             const start = @min(self.data.items.len, @as(usize, @intFromFloat(@floor(@as(f64, @floatFromInt(bucket_index)) * data_len_f / width_f))));
             const end = @min(self.data.items.len, @as(usize, @intFromFloat(@floor(@as(f64, @floatFromInt(bucket_index + 1)) * data_len_f / width_f))));
-            const slice = if (end > start) self.data.items[start..end] else self.data.items[start .. @min(self.data.items.len, start + 1)];
+            const slice = if (end > start) self.data.items[start..end] else self.data.items[start..@min(self.data.items.len, start + 1)];
             try buckets.append(summarize(slice, self.summary));
         }
 

--- a/src/components/sparkline.zig
+++ b/src/components/sparkline.zig
@@ -1,6 +1,7 @@
 //! Sparkline component with configurable aggregation and styling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const charting = @import("charting.zig");
 const progress = @import("progress.zig");
 const style_mod = @import("../style/style.zig");
@@ -110,8 +111,8 @@ pub const Sparkline = struct {
         var visible = try self.bucketValues(allocator);
         defer visible.deinit();
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         if (visible.items.len == 0) {
             for (0..self.display_width) |_| try writer.writeAll(self.empty_char);

--- a/src/components/spinner.zig
+++ b/src/components/spinner.zig
@@ -2,6 +2,7 @@
 //! Provides various spinner styles and customization options.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -97,8 +98,8 @@ pub const Spinner = struct {
 
     /// Render spinner with title
     pub fn viewWithTitle(self: *const Spinner, allocator: std.mem.Allocator, title: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const rendered_spinner = try self.view(allocator);
         try writer.writeAll(rendered_spinner);

--- a/src/components/spinner.zig
+++ b/src/components/spinner.zig
@@ -44,7 +44,7 @@ pub const Spinner = struct {
             .fps = 10,
             .spinner_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/split_pane.zig
+++ b/src/components/split_pane.zig
@@ -49,7 +49,7 @@ pub const SplitPane = struct {
 
     pub fn init(orientation: Orientation) SplitPane {
         var ds = style_mod.Style{};
-        ds = ds.fg(Color.gray(6));
+        ds = ds.fg(.gray(6));
         ds = ds.inline_style(true);
         return .{
             .orientation = orientation,

--- a/src/components/status_bar.zig
+++ b/src/components/status_bar.zig
@@ -6,6 +6,7 @@
 //! position simultaneously.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
@@ -109,8 +110,8 @@ pub const StatusBar = struct {
         const cw = measure.width(center_str);
         const rw = measure.width(right_str);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         try writer.writeAll(left_str);
 
@@ -120,14 +121,14 @@ pub const StatusBar = struct {
             const target_start = (self.width -| cw) / 2;
             const start = @max(lw, target_start);
             const gap = start -| lw;
-            try self.writeGap(writer.any(), allocator, gap);
+            try self.writeGap(writer, allocator, gap);
             try writer.writeAll(center_str);
             const consumed = lw + gap + cw;
             const trailing = (self.width -| rw) -| consumed;
-            try self.writeGap(writer.any(), allocator, trailing);
+            try self.writeGap(writer, allocator, trailing);
         } else {
             const gap = (self.width -| rw) -| lw;
-            try self.writeGap(writer.any(), allocator, gap);
+            try self.writeGap(writer, allocator, gap);
         }
 
         try writer.writeAll(right_str);
@@ -136,8 +137,8 @@ pub const StatusBar = struct {
     }
 
     fn renderGroup(self: *const StatusBar, allocator: std.mem.Allocator, items: []const Segment) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
         for (items, 0..) |seg, i| {
             if (i > 0) {
                 if (self.separator.len > 0) {
@@ -159,7 +160,7 @@ pub const StatusBar = struct {
         return out.toOwnedSlice();
     }
 
-    fn writeGap(self: *const StatusBar, writer: std.io.AnyWriter, allocator: std.mem.Allocator, count: usize) !void {
+    fn writeGap(self: *const StatusBar, writer: *std.Io.Writer, allocator: std.mem.Allocator, count: usize) !void {
         if (count == 0) return;
         const spaces = try allocator.alloc(u8, count);
         defer allocator.free(spaces);

--- a/src/components/status_bar.zig
+++ b/src/components/status_bar.zig
@@ -29,8 +29,8 @@ pub const StatusBar = struct {
 
     pub fn init(allocator: std.mem.Allocator) StatusBar {
         var base = style_mod.Style{};
-        base = base.bg(Color.gray(4));
-        base = base.fg(Color.gray(14));
+        base = base.bg(.gray(4));
+        base = base.fg(.gray(14));
         base = base.inline_style(true);
 
         return .{

--- a/src/components/stepper.zig
+++ b/src/components/stepper.zig
@@ -5,6 +5,7 @@
 //! exposes methods for navigating through the flow.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -133,8 +134,8 @@ pub const Stepper = struct {
     }
 
     fn viewHorizontal(self: *const Stepper, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (self.steps.items, 0..) |step, i| {
             if (i > 0) {
@@ -170,8 +171,8 @@ pub const Stepper = struct {
     }
 
     fn viewVertical(self: *const Stepper, allocator: std.mem.Allocator) ![]const u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
 
         for (self.steps.items, 0..) |step, i| {
             if (i > 0) try w.writeByte('\n');

--- a/src/components/stepper.zig
+++ b/src/components/stepper.zig
@@ -40,27 +40,27 @@ pub const Stepper = struct {
 
     pub fn init(allocator: std.mem.Allocator) Stepper {
         var completed = style_mod.Style{};
-        completed = completed.fg(Color.green());
+        completed = completed.fg(.green);
         completed = completed.inline_style(true);
 
         var current = style_mod.Style{};
-        current = current.fg(Color.cyan());
+        current = current.fg(.cyan);
         current = current.bold(true);
         current = current.inline_style(true);
 
         var pending = style_mod.Style{};
-        pending = pending.fg(Color.gray(8));
+        pending = pending.fg(.gray(8));
         pending = pending.inline_style(true);
 
         var connector = style_mod.Style{};
-        connector = connector.fg(Color.gray(6));
+        connector = connector.fg(.gray(6));
         connector = connector.inline_style(true);
 
         var title = style_mod.Style{};
         title = title.inline_style(true);
 
         var desc = style_mod.Style{};
-        desc = desc.fg(Color.gray(10));
+        desc = desc.fg(.gray(10));
         desc = desc.inline_style(true);
 
         return .{

--- a/src/components/styled_list.zig
+++ b/src/components/styled_list.zig
@@ -2,6 +2,7 @@
 //! Non-interactive rendering-only list with bullet, numbered, roman, alphabet enumerators.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -76,8 +77,8 @@ pub const StyledList = struct {
 
     /// Render the list
     pub fn view(self: *const StyledList, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Track counters per depth level
         var counters: [16]usize = .{0} ** 16;
@@ -134,7 +135,7 @@ pub const StyledList = struct {
 pub fn toRoman(allocator: std.mem.Allocator, n: usize) ![]const u8 {
     if (n == 0) return try allocator.dupe(u8, "0");
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     const values = [_]usize{ 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
     const symbols = [_][]const u8{ "M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I" };
@@ -154,7 +155,7 @@ pub fn toRoman(allocator: std.mem.Allocator, n: usize) ![]const u8 {
 pub fn toAlpha(allocator: std.mem.Allocator, n: usize) ![]const u8 {
     if (n == 0) return try allocator.dupe(u8, "?");
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     var num = n - 1;
 
     while (true) {

--- a/src/components/tab_group.zig
+++ b/src/components/tab_group.zig
@@ -3,6 +3,7 @@
 //! type-erased view routing for multi-screen applications.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
 const style_mod = @import("../style/style.zig");
@@ -762,8 +763,8 @@ pub const TabGroup = struct {
             }
         }
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const writer = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const writer = &out.writer;
 
         if (start > 0) try writer.writeAll(left_marker);
         for (start..end) |i| {
@@ -794,8 +795,8 @@ pub const TabGroup = struct {
             return renderer(ctx, allocator, tab, state);
         }
 
-        var base = std.array_list.Managed(u8).init(allocator);
-        const writer = base.writer();
+        var base: Writer.Allocating = .init(allocator);
+        const writer = &base.writer;
 
         try writer.writeAll(self.tab_prefix);
         if (self.show_numbers) {
@@ -1055,8 +1056,8 @@ fn rangeWidthWithMarkers(parts: []const []const u8, separator: []const u8, start
 fn joinPieces(allocator: std.mem.Allocator, parts: []const []const u8, separator: []const u8) ![]const u8 {
     if (parts.len == 0) return allocator.dupe(u8, "");
 
-    var out = std.array_list.Managed(u8).init(allocator);
-    const writer = out.writer();
+    var out: Writer.Allocating = .init(allocator);
+    const writer = &out.writer;
     for (parts, 0..) |part, i| {
         if (i > 0) try writer.writeAll(separator);
         try writer.writeAll(part);

--- a/src/components/tab_group.zig
+++ b/src/components/tab_group.zig
@@ -204,30 +204,30 @@ pub const TabGroup = struct {
 
     pub fn init(allocator: std.mem.Allocator) Self {
         var tab_style = style_mod.Style{};
-        tab_style = tab_style.fg(Color.gray(15));
+        tab_style = tab_style.fg(.gray(15));
         tab_style = tab_style.inline_style(true);
 
         var active_style = style_mod.Style{};
-        active_style = active_style.fg(Color.cyan());
+        active_style = active_style.fg(.cyan);
         active_style = active_style.bold(true);
         active_style = active_style.inline_style(true);
 
         var focused_style = style_mod.Style{};
-        focused_style = focused_style.fg(Color.yellow());
+        focused_style = focused_style.fg(.yellow);
         focused_style = focused_style.bold(true);
         focused_style = focused_style.inline_style(true);
 
         var disabled_style = style_mod.Style{};
-        disabled_style = disabled_style.fg(Color.gray(9));
+        disabled_style = disabled_style.fg(.gray(9));
         disabled_style = disabled_style.dim(true);
         disabled_style = disabled_style.inline_style(true);
 
         var sep_style = style_mod.Style{};
-        sep_style = sep_style.fg(Color.gray(11));
+        sep_style = sep_style.fg(.gray(11));
         sep_style = sep_style.inline_style(true);
 
         var overflow_style = style_mod.Style{};
-        overflow_style = overflow_style.fg(Color.gray(12));
+        overflow_style = overflow_style.fg(.gray(12));
         overflow_style = overflow_style.inline_style(true);
 
         return .{

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -255,8 +255,8 @@ pub fn Table(comptime num_cols: usize) type {
 
         /// Render the table
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             const widths = self.calculateWidths();
 

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -2,6 +2,7 @@
 //! Supports column headers, alignment, and styling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
 const Color = @import("../style/color.zig").Color;
@@ -323,7 +324,7 @@ pub fn Table(comptime num_cols: usize) type {
 
         fn writeRow(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             row: [num_cols][]const u8,
             widths: [num_cols]usize,
@@ -381,7 +382,7 @@ pub fn Table(comptime num_cols: usize) type {
 
         fn writeBorderLine(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             widths: [num_cols]usize,
             pos: BorderPosition,

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -57,7 +57,7 @@ pub fn Table(comptime num_cols: usize) type {
                 .rows = std.array_list.Managed([num_cols][]const u8).init(allocator),
                 .col_widths = .{null} ** num_cols,
                 .col_aligns = .{.left} ** num_cols,
-                .border_chars = border_mod.Border.normal,
+                .border_chars = .normal,
                 .show_header = true,
                 .show_border = true,
                 .header_style = blk: {
@@ -73,7 +73,7 @@ pub fn Table(comptime num_cols: usize) type {
                 },
                 .border_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -441,7 +441,7 @@ pub const DynamicTableType = struct {
             .allocator = allocator,
             .headers = std.array_list.Managed([]const u8).init(allocator),
             .rows = std.array_list.Managed(std.array_list.Managed([]const u8)).init(allocator),
-            .border_chars = border_mod.Border.normal,
+            .border_chars = .normal,
             .show_header = true,
             .show_border = true,
         };

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -2,6 +2,7 @@
 //! Provides text editing with multiple lines, cursor navigation, and scrolling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -543,8 +544,8 @@ pub const TextArea = struct {
 
     /// Render the text area
     pub fn view(self: *const TextArea, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const line_num_width: usize = if (self.line_numbers) 5 else 0;
         const text_width = self.width -| @as(u16, @intCast(line_num_width));
@@ -645,7 +646,7 @@ pub const TextArea = struct {
         return result.toOwnedSlice();
     }
 
-    fn renderPlaceholder(self: *const TextArea, writer: anytype, allocator: std.mem.Allocator, max_width: u16) !void {
+    fn renderPlaceholder(self: *const TextArea, writer: *Writer, allocator: std.mem.Allocator, max_width: u16) !void {
         const width_limit: usize = max_width;
         if (width_limit == 0) return;
 
@@ -679,7 +680,7 @@ pub const TextArea = struct {
 
     fn renderWrappedLineSegment(
         self: *const TextArea,
-        writer: anytype,
+        writer: *Writer,
         allocator: std.mem.Allocator,
         line: []const u8,
         line_idx: usize,
@@ -737,7 +738,7 @@ pub const TextArea = struct {
         }
     }
 
-    fn renderLine(self: *const TextArea, writer: anytype, allocator: std.mem.Allocator, line: []const u8, line_idx: usize, max_width: u16) !void {
+    fn renderLine(self: *const TextArea, writer: *Writer, allocator: std.mem.Allocator, line: []const u8, line_idx: usize, max_width: u16) !void {
         const is_cursor_line = line_idx == self.cursor_row;
 
         // Apply horizontal scroll

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -144,7 +144,7 @@ pub const TextArea = struct {
 
     /// Get the content as a string
     pub fn getValue(self: *const TextArea, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: std.array_list.Managed(u8) = .init(allocator);
 
         for (self.lines.items, 0..) |line, i| {
             if (i > 0) try result.append('\n');

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -91,13 +91,13 @@ pub const TextArea = struct {
             },
             .line_number_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .placeholder_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/text_input.zig
+++ b/src/components/text_input.zig
@@ -2,6 +2,7 @@
 //! Provides cursor navigation, text editing, and optional validation.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const style = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
@@ -377,8 +378,8 @@ pub const TextInput = struct {
 
     /// Render the input to a string
     pub fn view(self: *const TextInput, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Write prompt
         if (self.prompt.len > 0) {
@@ -422,7 +423,7 @@ pub const TextInput = struct {
         return result.toOwnedSlice();
     }
 
-    fn renderWithCursor(self: *const TextInput, writer: anytype, allocator: std.mem.Allocator) !void {
+    fn renderWithCursor(self: *const TextInput, writer: *Writer, allocator: std.mem.Allocator) !void {
         // Text before cursor
         if (self.cursor > 0) {
             const before = try self.text_style.render(allocator, self.value.items[0..self.cursor]);

--- a/src/components/text_input.zig
+++ b/src/components/text_input.zig
@@ -61,7 +61,7 @@ pub const TextInput = struct {
             },
             .placeholder_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/timer.zig
+++ b/src/components/timer.zig
@@ -2,6 +2,7 @@
 //! Displays time in various formats.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -197,8 +198,8 @@ pub const Timer = struct {
             },
         };
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // Choose style based on state
         const active_style = if (self.isDanger())

--- a/src/components/timer.zig
+++ b/src/components/timer.zig
@@ -54,14 +54,14 @@ pub const Timer = struct {
             .warning_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .danger_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/toast.zig
+++ b/src/components/toast.zig
@@ -2,6 +2,7 @@
 //! Supports positioning, stacking, icons, borders, and auto-dismiss with countdown.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const border_mod = @import("../style/border.zig");
@@ -210,9 +211,9 @@ pub const Toast = struct {
             return try allocator.dupe(u8, "");
         }
 
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: Writer.Allocating = .init(allocator);
         errdefer result.deinit();
-        const writer = result.writer();
+        const writer = &result.writer;
 
         const visible_count = @min(self.messages.items.len, self.max_visible);
 
@@ -280,9 +281,9 @@ pub const Toast = struct {
     fn renderSingleToast(self: *const Toast, allocator: std.mem.Allocator, msg: ToastMessage, current_ns: u64) ![]const u8 {
         const active_style = self.styleForLevel(msg.level);
 
-        var line = std.array_list.Managed(u8).init(allocator);
+        var line: Writer.Allocating = .init(allocator);
         errdefer line.deinit();
-        const lw = line.writer();
+        const lw = &line.writer;
 
         const icon = if (self.show_icons) switch (msg.level) {
             .info => self.info_icon,
@@ -407,9 +408,9 @@ pub const Toast = struct {
 
 fn alignLines(allocator: std.mem.Allocator, content: []const u8, alignment: style_mod.Align) ![]const u8 {
     const target_width = measure.maxLineWidth(content);
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: Writer.Allocating = .init(allocator);
     errdefer result.deinit();
-    const writer = result.writer();
+    const writer = &result.writer;
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     var first = true;

--- a/src/components/toast.zig
+++ b/src/components/toast.zig
@@ -82,40 +82,40 @@ pub const Toast = struct {
             .show_icons = true,
             .show_border = true,
             .show_countdown = false,
-            .border_chars = border_mod.Border.rounded,
+            .border_chars = .rounded,
             .info_icon = "\u{2139}  ",
             .success_icon = "\u{2713} ",
             .warning_icon = "\u{26a0} ",
             .err_icon = "\u{2717} ",
             .info_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .success_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .warning_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .err_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },
-            .info_border_fg = Color.cyan(),
-            .success_border_fg = Color.green(),
-            .warning_border_fg = Color.yellow(),
-            .err_border_fg = Color.red(),
+            .info_border_fg = .cyan,
+            .success_border_fg = .green,
+            .warning_border_fg = .yellow,
+            .err_border_fg = .red,
         };
     }
 
@@ -239,7 +239,7 @@ pub const Toast = struct {
             const overflow_text = try std.fmt.allocPrint(allocator, "  +{d} more", .{total - self.max_visible});
             defer allocator.free(overflow_text);
             var dim_style = style_mod.Style{};
-            dim_style = dim_style.fg(Color.gray(10));
+            dim_style = dim_style.fg(.gray(10));
             dim_style = dim_style.inline_style(true);
             const styled = try dim_style.render(allocator, overflow_text);
             defer allocator.free(styled);
@@ -327,7 +327,7 @@ pub const Toast = struct {
         // Countdown
         if (countdown_text.len > 0) {
             var dim_style = style_mod.Style{};
-            dim_style = dim_style.fg(Color.gray(10));
+            dim_style = dim_style.fg(.gray(10));
             dim_style = dim_style.inline_style(true);
             const styled_cd = try dim_style.render(allocator, countdown_text);
             defer allocator.free(styled_cd);

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -31,6 +31,7 @@
 //! - `Tooltip.shortcut(label, key)` — "Label  Ctrl+S" style tooltip
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const border_mod = @import("../style/border.zig");
 const Color = @import("../style/color.zig").Color;
@@ -216,8 +217,8 @@ pub const Tooltip = struct {
         pad_s = pad_s.inline_style(true);
         if (!self.content_bg.isNone()) pad_s = pad_s.bg(self.content_bg);
 
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         // ── Top border ──
         try writer.writeAll(try bdr_s.render(allocator, bc.top_left));
@@ -282,8 +283,8 @@ pub const Tooltip = struct {
         const pos = self.computePosition(box_w, box_h, term_width, term_height);
 
         // Build full-screen output line by line
-        var result = std.array_list.Managed(u8).init(allocator);
-        const wr = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const wr = &result.writer;
 
         // Collect box lines
         var box_lines = std.array_list.Managed([]const u8).init(allocator);
@@ -489,7 +490,7 @@ pub const Tooltip = struct {
     // ── Render helpers (full-screen canvas) ────────────────────────────
 
     /// Arrow on its own row (top/bottom placement).
-    fn writeArrowOnlyRow(self: *const Tooltip, allocator: std.mem.Allocator, writer: anytype, pos: Position, tw: usize) !void {
+    fn writeArrowOnlyRow(self: *const Tooltip, allocator: std.mem.Allocator, writer: *Writer, pos: Position, tw: usize) !void {
         try writer.writeAll(try nSpaces(allocator, pos.arrow_x));
         try writer.writeAll(try self.renderStyledArrow(allocator));
         const aw = self.arrowDisplayWidth();
@@ -498,7 +499,7 @@ pub const Tooltip = struct {
     }
 
     /// Box row that also has a side arrow (left/right placement).
-    fn writeBoxRowWithSideArrow(self: *const Tooltip, allocator: std.mem.Allocator, writer: anytype, pos: Position, box_line: []const u8, tw: usize) !void {
+    fn writeBoxRowWithSideArrow(self: *const Tooltip, allocator: std.mem.Allocator, writer: *Writer, pos: Position, box_line: []const u8, tw: usize) !void {
         const box_line_w = measure.width(box_line);
         const aw = self.arrowDisplayWidth();
         const styled_arrow = try self.renderStyledArrow(allocator);
@@ -526,7 +527,7 @@ pub const Tooltip = struct {
 
     // ── Private Helpers ───────────────────────────────────────────────
 
-    fn writeEmptyLine(allocator: std.mem.Allocator, writer: anytype, styled_left: []const u8, styled_right: []const u8, pad_s: style_mod.Style, inner_w: usize) !void {
+    fn writeEmptyLine(allocator: std.mem.Allocator, writer: *Writer, styled_left: []const u8, styled_right: []const u8, pad_s: style_mod.Style, inner_w: usize) !void {
         try writer.writeAll(styled_left);
         try writer.writeAll(try pad_s.render(allocator, try nSpaces(allocator, inner_w)));
         try writer.writeAll(styled_right);

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -766,8 +766,8 @@ const CellGrid = struct {
     /// Emits SGR sequences only when the style changes between cells
     /// (like Ratatui's Buffer::diff), producing minimal output.
     fn render(self: *const CellGrid, allocator: std.mem.Allocator) ![]const u8 {
-        var buf = std.array_list.Managed(u8).init(allocator);
-        const wr = buf.writer();
+        var buf: Writer.Allocating = .init(allocator);
+        const wr = &buf.writer;
 
         var prev_style = CellStyle{};
 

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -71,7 +71,7 @@ pub const Tooltip = struct {
     // ── Styling ────────────────────────────────────────────────────────
 
     border_chars: border_mod.BorderChars = .rounded,
-    border_fg: Color = Color.gray(14),
+    border_fg: Color = .gray(14),
     /// Background for the content area (padding + text) inside the border.
     content_bg: Color = .none,
     /// Background for border characters. Three-state via `?Color`:

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -70,7 +70,7 @@ pub const Tooltip = struct {
 
     // ── Styling ────────────────────────────────────────────────────────
 
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
+    border_chars: border_mod.BorderChars = .rounded,
     border_fg: Color = Color.gray(14),
     /// Background for the content area (padding + text) inside the border.
     content_bg: Color = .none,
@@ -79,13 +79,13 @@ pub const Tooltip = struct {
     /// - `.none` — explicitly no bg; with `inherit_bg` the base shows through.
     /// - any color — use that color for borders only.
     border_bg: ?Color = null,
-    text_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(20) }),
-    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white() }),
+    text_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(20) }),
+    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white }),
 
     /// Show an arrow pointing from tooltip toward the target.
     show_arrow: bool = true,
     /// Color of the arrow character.
-    arrow_fg: Color = Color.gray(14),
+    arrow_fg: Color = .gray(14),
     /// Background for the arrow character. Three-state via `?Color`:
     /// - `null` (default) — no bg; with `inherit_bg` the base shows through.
     /// - `.none` — explicitly no bg, even when `inherit_bg` is on.
@@ -140,9 +140,9 @@ pub const Tooltip = struct {
     pub fn help(text: []const u8) Tooltip {
         return .{
             .text = text,
-            .text_style = makeStyle(.{ .dim_v = true, .italic_v = true, .fg_color = Color.gray(16) }),
-            .border_fg = Color.gray(10),
-            .arrow_fg = Color.gray(10),
+            .text_style = makeStyle(.{ .dim_v = true, .italic_v = true, .fg_color = .gray(16) }),
+            .border_fg = .gray(10),
+            .arrow_fg = .gray(10),
         };
     }
 
@@ -151,8 +151,8 @@ pub const Tooltip = struct {
         return .{
             .text = key,
             .title = label,
-            .title_style = makeStyle(.{ .fg_color = Color.gray(18) }),
-            .text_style = makeStyle(.{ .bold_v = true, .fg_color = Color.cyan() }),
+            .title_style = makeStyle(.{ .fg_color = .gray(18) }),
+            .text_style = makeStyle(.{ .bold_v = true, .fg_color = .cyan }),
         };
     }
 

--- a/src/components/tree.zig
+++ b/src/components/tree.zig
@@ -122,8 +122,8 @@ pub fn Tree(comptime T: type) type {
 
         /// Render the tree
         pub fn view(self: *const Self, allocator: std.mem.Allocator) ![]const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
 
             for (self.root_indices.items, 0..) |root_idx, i| {
                 if (i > 0) try writer.writeAll("\n");

--- a/src/components/tree.zig
+++ b/src/components/tree.zig
@@ -2,6 +2,7 @@
 //! Renders a tree structure with expandable nodes and customizable enumerators.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 
@@ -134,7 +135,7 @@ pub fn Tree(comptime T: type) type {
 
         fn renderNode(
             self: *const Self,
-            writer: anytype,
+            writer: *Writer,
             allocator: std.mem.Allocator,
             node_idx: usize,
             prefix: []const u8,

--- a/src/components/viewport.zig
+++ b/src/components/viewport.zig
@@ -1,6 +1,7 @@
 //! Scrollable content viewport component.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
 const style = @import("../style/style.zig");
@@ -269,8 +270,8 @@ pub const Viewport = struct {
     }
 
     pub fn view(self: *const Viewport, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         const visible_width = self.visibleWidth();
 
@@ -346,7 +347,7 @@ pub const Viewport = struct {
 
     fn getSubstring(self: *const Viewport, allocator: std.mem.Allocator, line: []const u8, start_col: usize, max_width: usize) ![]const u8 {
         _ = self;
-        var result = std.array_list.Managed(u8).init(allocator);
+        var result: std.array_list.Managed(u8) = .init(allocator);
 
         var col: usize = 0;
         var i: usize = 0;

--- a/src/components/virtual_list.zig
+++ b/src/components/virtual_list.zig
@@ -2,6 +2,7 @@
 //! Only renders items visible in the viewport.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const keys = @import("../input/keys.zig");
@@ -146,14 +147,14 @@ pub fn VirtualList(comptime T: type) type {
         }
 
         pub fn view(self: *const Self, allocator: std.mem.Allocator) []const u8 {
-            var result = std.array_list.Managed(u8).init(allocator);
-            const writer = result.writer();
+            var result: Writer.Allocating = .init(allocator);
+            const writer = &result.writer;
             const total = self.items.len;
             const vh: usize = self.viewport_height;
 
             if (total == 0) {
                 writer.writeAll(self.empty_text) catch {};
-                return result.items;
+                return result.toArrayList().items;
             }
 
             const end = @min(self.offset + vh, total);
@@ -199,7 +200,7 @@ pub fn VirtualList(comptime T: type) type {
                 writer.writeAll(cs.render(allocator, count_str) catch count_str) catch {};
             }
 
-            return result.items;
+            return result.toArrayList().items;
         }
 
         fn defaultRender(item: T, index: usize, allocator: std.mem.Allocator) []const u8 {

--- a/src/components/virtual_list.zig
+++ b/src/components/virtual_list.zig
@@ -35,8 +35,8 @@ pub fn VirtualList(comptime T: type) type {
         // Styling
         cursor_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.bg(Color.blue());
-            s = s.fg(Color.white());
+            s = s.bg(.blue);
+            s = s.fg(.white);
             s = s.inline_style(true);
             break :blk s;
         },
@@ -47,13 +47,13 @@ pub fn VirtualList(comptime T: type) type {
         },
         selected_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.fg(Color.green());
+            s = s.fg(.green);
             s = s.inline_style(true);
             break :blk s;
         },
         scrollbar_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.fg(Color.gray(8));
+            s = s.fg(.gray(8));
             s = s.inline_style(true);
             break :blk s;
         },
@@ -194,7 +194,7 @@ pub fn VirtualList(comptime T: type) type {
                 writer.writeByte('\n') catch {};
                 const count_str = std.fmt.allocPrint(allocator, " {d}/{d}", .{ self.cursor + 1, total }) catch "";
                 var cs = style_mod.Style{};
-                cs = cs.fg(Color.gray(10));
+                cs = cs.fg(.gray(10));
                 cs = cs.inline_style(true);
                 writer.writeAll(cs.render(allocator, count_str) catch count_str) catch {};
             }

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -19,6 +19,7 @@
 //! `handler` callbacks are also supported for fire-and-forget actions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("../input/keys.zig");
 const KeyEvent = keys.KeyEvent;
 const style_mod = @import("../style/style.zig");
@@ -197,8 +198,8 @@ pub const ActionRegistry = struct {
 
     /// Format a key event for display: "ctrl+s", "esc", "enter", etc.
     pub fn formatKey(allocator: std.mem.Allocator, event: KeyEvent) ![]u8 {
-        var out = std.array_list.Managed(u8).init(allocator);
-        const w = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const w = &out.writer;
         if (event.modifiers.ctrl) try w.writeAll("ctrl+");
         if (event.modifiers.alt) try w.writeAll("alt+");
         if (event.modifiers.shift) try w.writeAll("shift+");
@@ -258,9 +259,9 @@ pub const Footer = struct {
     }
 
     pub fn view(self: *const Footer, allocator: std.mem.Allocator) ![]const u8 {
-        var inner = std.array_list.Managed(u8).init(allocator);
+        var inner: Writer.Allocating = .init(allocator);
         defer inner.deinit();
-        const w = inner.writer();
+        const w = &inner.writer;
 
         var first = true;
         for (self.registry.actions.items) |a| {
@@ -284,8 +285,8 @@ pub const Footer = struct {
         defer allocator.free(text);
         const text_w = measure.width(text);
 
-        var out = std.array_list.Managed(u8).init(allocator);
-        const ow = out.writer();
+        var out: Writer.Allocating = .init(allocator);
+        const ow = &out.writer;
         try ow.writeAll(text);
         if (text_w < self.width) {
             const pad = self.width - text_w;

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -236,14 +236,14 @@ pub const Footer = struct {
 
     pub fn init(registry: *const ActionRegistry) Footer {
         var key_s = style_mod.Style{};
-        key_s = key_s.fg(Color.cyan());
+        key_s = key_s.fg(.cyan);
         key_s = key_s.bold(true);
         key_s = key_s.inline_style(true);
         var label_s = style_mod.Style{};
-        label_s = label_s.fg(Color.gray(12));
+        label_s = label_s.fg(.gray(12));
         label_s = label_s.inline_style(true);
         var base = style_mod.Style{};
-        base = base.bg(Color.gray(3));
+        base = base.bg(.gray(3));
         base = base.inline_style(true);
         return .{
             .registry = registry,

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -17,6 +17,7 @@
 //! The console is safe to call from any thread; writes are mutex-guarded.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 pub const Level = enum {
     trace,
@@ -224,22 +225,21 @@ pub const DevConsole = struct {
     }
 
     fn format(self: *const DevConsole, buf: []u8, level: Level, comptime fmt: []const u8, args: anytype) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const w = fbs.writer();
+        var writer: Writer = .fixed(buf);
         if (self.show_timestamps) {
             const now = std.time.timestamp();
             const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(now) };
             const day = epoch.getDaySeconds();
-            try w.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
+            try writer.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
                 day.getHoursIntoDay(),
                 day.getMinutesIntoHour(),
                 day.getSecondsIntoMinute(),
             });
         }
-        try w.print("{s} ", .{level.label()});
-        try w.print(fmt, args);
-        try w.writeByte('\n');
-        return fbs.getWritten();
+        try writer.print("{s} ", .{level.label()});
+        try writer.print(fmt, args);
+        try writer.writeByte('\n');
+        return writer.buffered();
     }
 
     // Convenience wrappers.

--- a/src/core/screen_stack.zig
+++ b/src/core/screen_stack.zig
@@ -25,6 +25,7 @@
 //! used for confirm dialogs or command palettes).
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const Context = @import("context.zig").Context;
 const keys = @import("../input/keys.zig");
 const measure = @import("../layout/measure.zig");
@@ -246,8 +247,8 @@ fn compose(allocator: std.mem.Allocator, background: []const u8, overlay: []cons
         while (iter.next()) |line| try ov_lines.append(line);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const w = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const w = &result.writer;
 
     var row: usize = 0;
     while (row < bg_lines.items.len) : (row += 1) {

--- a/src/input/keys.zig
+++ b/src/input/keys.zig
@@ -2,6 +2,7 @@
 //! Provides a comprehensive set of key types for terminal input.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 /// Modifier keys that can be combined with other keys
 pub const Modifiers = packed struct {
@@ -176,7 +177,7 @@ pub const KeyEvent = struct {
         self: KeyEvent,
         comptime fmt: []const u8,
         options: std.fmt.FormatOptions,
-        writer: anytype,
+        writer: *Writer,
     ) !void {
         _ = fmt;
         _ = options;

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -2,6 +2,7 @@
 //! Supports standard terminal mouse protocols.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const keys = @import("keys.zig");
 
 /// Mouse button types
@@ -40,7 +41,7 @@ pub const MouseEvent = struct {
         self: MouseEvent,
         comptime fmt: []const u8,
         options: std.fmt.FormatOptions,
-        writer: anytype,
+        writer: *Writer,
     ) !void {
         _ = fmt;
         _ = options;

--- a/src/layout/join.zig
+++ b/src/layout/join.zig
@@ -2,6 +2,7 @@
 //! Provides horizontal and vertical joining with alignment options.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 
 /// Vertical alignment for horizontal joins
@@ -54,8 +55,8 @@ pub fn horizontal(allocator: std.mem.Allocator, valign: VAlign, parts: []const [
     }
 
     // Build result
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (0..max_height) |row| {
         if (row > 0) try writer.writeByte('\n');
@@ -110,8 +111,8 @@ pub fn vertical(allocator: std.mem.Allocator, halign: HAlign, parts: []const []c
         max_width = @max(max_width, measure.maxLineWidth(part));
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (parts, 0..) |part, part_idx| {
         if (part_idx > 0) try writer.writeByte('\n');

--- a/src/layout/layer.zig
+++ b/src/layout/layer.zig
@@ -3,6 +3,7 @@
 //! into a single output with proper z-ordering and transparency.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 
 /// A single layer in the stack.
@@ -81,8 +82,8 @@ pub const LayerStack = struct {
         }
 
         // Render grid to string
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        const writer = &result.writer;
 
         for (0..h) |row| {
             if (row > 0) writer.writeByte('\n') catch {};
@@ -98,7 +99,7 @@ pub const LayerStack = struct {
             }
         }
 
-        return result.items;
+        return result.toArrayList().items;
     }
 
     fn paintLayer(self: *const LayerStack, grid: []Cell, w: usize, h: usize, layer: Layer) void {

--- a/src/layout/measure.zig
+++ b/src/layout/measure.zig
@@ -2,6 +2,7 @@
 //! Properly handles ANSI escape sequences and Unicode characters.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const unicode = @import("../unicode.zig");
 
 /// Calculate the visible width of a string (excluding ANSI escape sequences)
@@ -141,7 +142,7 @@ pub fn padRight(allocator: std.mem.Allocator, str: []const u8, target_width: usi
     const current_width = width(str);
     if (current_width >= target_width) return try allocator.dupe(u8, str);
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     try result.appendSlice(str);
 
     for (0..(target_width - current_width)) |_| {
@@ -156,7 +157,7 @@ pub fn padLeft(allocator: std.mem.Allocator, str: []const u8, target_width: usiz
     const current_width = width(str);
     if (current_width >= target_width) return try allocator.dupe(u8, str);
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     for (0..(target_width - current_width)) |_| {
         try result.append(' ');
@@ -175,7 +176,7 @@ pub fn center(allocator: std.mem.Allocator, str: []const u8, target_width: usize
     const left_padding = total_padding / 2;
     const right_padding = total_padding - left_padding;
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     for (0..left_padding) |_| {
         try result.append(' ');
@@ -199,7 +200,7 @@ pub fn truncate(allocator: std.mem.Allocator, str: []const u8, max_width: usize)
         return result;
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     var w: usize = 0;
     var i: usize = 0;
     var in_escape = false;

--- a/src/layout/measure.zig
+++ b/src/layout/measure.zig
@@ -86,6 +86,82 @@ pub fn width(str: []const u8) usize {
     return @max(max_width, w);
 }
 
+/// Comptime-friendly variant of `width`. Bypasses the runtime width-strategy
+/// atomic and uses the full Unicode table directly so it can run at comptime.
+pub fn widthCt(str: []const u8) usize {
+    @setEvalBranchQuota(100_000);
+    var w: usize = 0;
+    var max_width: usize = 0;
+    var in_escape = false;
+    var escape_bracket = false;
+
+    var i: usize = 0;
+    while (i < str.len) {
+        const c = str[i];
+
+        if (c == 0x1b) {
+            in_escape = true;
+            escape_bracket = false;
+            i += 1;
+            continue;
+        }
+
+        if (in_escape) {
+            if (c == '[') {
+                escape_bracket = true;
+            } else if (escape_bracket) {
+                if ((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z')) {
+                    in_escape = false;
+                    escape_bracket = false;
+                }
+            } else if (c == ']') {
+                i += 1;
+                while (i < str.len and str[i] != 0x07) {
+                    if (str[i] == 0x1b and i + 1 < str.len and str[i + 1] == '\\') {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                in_escape = false;
+            } else {
+                in_escape = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if (c == '\n') {
+            max_width = @max(max_width, w);
+            w = 0;
+            i += 1;
+            continue;
+        }
+
+        if (c == '\r' or c == '\t') {
+            if (c == '\t') w += 8 - (w % 8);
+            i += 1;
+            continue;
+        }
+
+        const byte_len = std.unicode.utf8ByteSequenceLength(c) catch 1;
+        if (i + byte_len <= str.len) {
+            const codepoint = std.unicode.utf8Decode(str[i..][0..byte_len]) catch {
+                w += 1;
+                i += 1;
+                continue;
+            };
+            w += unicode.display_width.charWidth(codepoint);
+            i += byte_len;
+        } else {
+            w += 1;
+            i += 1;
+        }
+    }
+
+    return @max(max_width, w);
+}
+
 /// Calculate the height of a string (number of lines)
 pub fn height(str: []const u8) usize {
     if (str.len == 0) return 0;

--- a/src/layout/place.zig
+++ b/src/layout/place.zig
@@ -2,6 +2,7 @@
 //! Provides 2D positioning with horizontal and vertical alignment.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("measure.zig");
 const unicode = @import("../unicode.zig");
 
@@ -36,8 +37,8 @@ pub fn place(
         return try allocator.dupe(u8, content);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     // Calculate vertical offset
     const v_padding = if (height > content_height) height - content_height else 0;
@@ -110,8 +111,8 @@ pub fn placeAt(
     y: usize,
     content: []const u8,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     var content_lines = std.array_list.Managed([]const u8).init(allocator);
@@ -195,8 +196,8 @@ pub fn overlay(
         try content_lines.append(line);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     for (0..base_height) |row| {
         if (row > 0) try writer.writeByte('\n');
@@ -316,8 +317,8 @@ pub fn placeFloat(
         return try allocator.dupe(u8, content);
     }
 
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     // Calculate offsets from float positions
     const h_space = if (width > content_width) width - content_width else 0;

--- a/src/root.zig
+++ b/src/root.zig
@@ -107,12 +107,15 @@ pub const MouseState = hitbox.MouseState;
 pub const MouseInteraction = hitbox.Interaction;
 
 // Style
+pub fn newStyle() Style {
+    return .{};
+}
 pub const style = @import("style/style.zig");
 pub const Style = style.Style;
 pub const color = @import("style/color.zig");
 pub const Color = color.Color;
+pub const Border = border.BorderChars;
 pub const border = @import("style/border.zig");
-pub const Border = border.Border;
 pub const theme = @import("style/theme.zig");
 pub const Theme = theme.Theme;
 pub const Palette = theme.Palette;

--- a/src/style/border.zig
+++ b/src/style/border.zig
@@ -17,10 +17,7 @@ pub const BorderChars = struct {
     middle_top: []const u8,
     middle_bottom: []const u8,
     cross: []const u8,
-};
 
-/// Predefined border styles
-pub const Border = struct {
     /// No border
     pub const none = BorderChars{
         .top_left = "",

--- a/src/style/border.zig
+++ b/src/style/border.zig
@@ -2,6 +2,7 @@
 //! Provides various border character sets and drawing functions.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 
 /// Border character set
@@ -240,8 +241,8 @@ pub fn drawBorder(
     width: usize,
     height: usize,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     const inner_width = if (sides.left and sides.right) width -| 2 else if (sides.left or sides.right) width -| 1 else width;
 

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -26,56 +26,24 @@ pub const Color = union(enum) {
     };
 
     // Basic ANSI colors
-    pub fn black() Color {
-        return .{ .ansi = .black };
-    }
-    pub fn red() Color {
-        return .{ .ansi = .red };
-    }
-    pub fn green() Color {
-        return .{ .ansi = .green };
-    }
-    pub fn yellow() Color {
-        return .{ .ansi = .yellow };
-    }
-    pub fn blue() Color {
-        return .{ .ansi = .blue };
-    }
-    pub fn magenta() Color {
-        return .{ .ansi = .magenta };
-    }
-    pub fn cyan() Color {
-        return .{ .ansi = .cyan };
-    }
-    pub fn white() Color {
-        return .{ .ansi = .white };
-    }
+    pub const black: Color = .{ .ansi = .black };
+    pub const red: Color = .{ .ansi = .red };
+    pub const green: Color = .{ .ansi = .green };
+    pub const yellow: Color = .{ .ansi = .yellow };
+    pub const blue: Color = .{ .ansi = .blue };
+    pub const magenta: Color = .{ .ansi = .magenta };
+    pub const cyan: Color = .{ .ansi = .cyan };
+    pub const white: Color = .{ .ansi = .white };
 
     // Bright ANSI colors
-    pub fn brightBlack() Color {
-        return .{ .ansi = .bright_black };
-    }
-    pub fn brightRed() Color {
-        return .{ .ansi = .bright_red };
-    }
-    pub fn brightGreen() Color {
-        return .{ .ansi = .bright_green };
-    }
-    pub fn brightYellow() Color {
-        return .{ .ansi = .bright_yellow };
-    }
-    pub fn brightBlue() Color {
-        return .{ .ansi = .bright_blue };
-    }
-    pub fn brightMagenta() Color {
-        return .{ .ansi = .bright_magenta };
-    }
-    pub fn brightCyan() Color {
-        return .{ .ansi = .bright_cyan };
-    }
-    pub fn brightWhite() Color {
-        return .{ .ansi = .bright_white };
-    }
+    pub const brightBlack: Color = .{ .ansi = .bright_black };
+    pub const brightRed: Color = .{ .ansi = .bright_red };
+    pub const brightGreen: Color = .{ .ansi = .bright_green };
+    pub const brightYellow: Color = .{ .ansi = .bright_yellow };
+    pub const brightBlue: Color = .{ .ansi = .bright_blue };
+    pub const brightMagenta: Color = .{ .ansi = .bright_magenta };
+    pub const brightCyan: Color = .{ .ansi = .bright_cyan };
+    pub const brightWhite: Color = .{ .ansi = .bright_white };
 
     /// Create a color from RGB values
     pub fn fromRgb(r: u8, g: u8, b: u8) Color {

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -2,6 +2,7 @@
 //! Supports ANSI 16, 256, and TrueColor (24-bit) colors.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const builtin = @import("builtin");
 const ansi = @import("../terminal/ansi.zig");
 
@@ -90,7 +91,7 @@ pub const Color = union(enum) {
     }
 
     /// Write foreground color ANSI sequence
-    pub fn writeFg(self: Color, writer: anytype) !void {
+    pub fn writeFg(self: Color, writer: *Writer) !void {
         switch (self) {
             .none => {},
             .ansi => |c| try writer.print(ansi.CSI ++ "{d}m", .{c.fgCode()}),
@@ -100,7 +101,7 @@ pub const Color = union(enum) {
     }
 
     /// Write background color ANSI sequence
-    pub fn writeBg(self: Color, writer: anytype) !void {
+    pub fn writeBg(self: Color, writer: *Writer) !void {
         switch (self) {
             .none => {},
             .ansi => |c| try writer.print(ansi.CSI ++ "{d}m", .{c.bgCode()}),

--- a/src/style/compress.zig
+++ b/src/style/compress.zig
@@ -110,8 +110,8 @@ pub const StyleState = struct {
 /// Post-process an ANSI string to remove redundant escape sequences.
 /// Strips consecutive resets and duplicate attribute settings.
 pub fn compressAnsi(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var i: usize = 0;
     var last_was_reset = false;

--- a/src/style/compress.zig
+++ b/src/style/compress.zig
@@ -2,6 +2,7 @@
 //! Reduces ANSI escape sequence overhead by tracking terminal state and emitting only diffs.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("../terminal/ansi.zig");
 
 /// Tracks the current terminal style state for efficient transitions
@@ -30,7 +31,7 @@ pub const StyleState = struct {
     }
 
     /// Emit only the ANSI escape sequences needed to transition to the target state
-    pub fn transitionTo(self: *StyleState, writer: anytype, target: StyleState) !void {
+    pub fn transitionTo(self: *StyleState, writer: *Writer, target: StyleState) !void {
         // If target is fully default, just emit reset
         if (!target.bold and !target.dim and !target.italic and !target.underline and
             !target.blink and !target.reverse and !target.strikethrough and

--- a/src/style/overflow.zig
+++ b/src/style/overflow.zig
@@ -2,6 +2,7 @@
 //! Provides configurable overflow policies: clip, ellipsis, word-wrap, char-wrap.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
 
 /// Overflow policy for text that exceeds width constraints.
@@ -28,7 +29,7 @@ pub fn applyOverflow(
 ) ![]const u8 {
     if (policy == .visible or max_width == 0) return text;
 
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
 
     var lines = std.mem.splitScalar(u8, text, '\n');
     var first_line = true;
@@ -45,7 +46,7 @@ pub fn applyOverflow(
         }
     }
 
-    return try result.toOwnedSlice();
+    return result.toOwnedSlice();
 }
 
 fn applyClip(result: *std.array_list.Managed(u8), line: []const u8, max_width: u16) !void {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -985,8 +985,8 @@ pub const StyleRange = struct {
 
 /// Render text with different styles applied to specific byte ranges
 pub fn renderWithRanges(allocator: std.mem.Allocator, text: []const u8, ranges: []const StyleRange) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var pos: usize = 0;
     while (pos < text.len) {
@@ -1029,8 +1029,8 @@ pub fn renderWithHighlights(
     highlight_style: Style,
     base_style: Style,
 ) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
-    const writer = result.writer();
+    var result: Writer.Allocating = .init(allocator);
+    const writer = &result.writer;
 
     var pos: usize = 0;
     var pi: usize = 0; // position index

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -10,7 +10,6 @@ const overflow_mod = @import("overflow.zig");
 pub const Overflow = overflow_mod.Overflow;
 
 pub const Color = color_mod.Color;
-pub const Border = border_mod.Border;
 pub const BorderChars = border_mod.BorderChars;
 pub const Sides = border_mod.Sides;
 
@@ -91,8 +90,8 @@ pub const Style = struct {
     margin_val: Spacing = .{},
 
     // Border
-    border_style: BorderChars = Border.none,
-    border_sides: Sides = Sides.none,
+    border_style: BorderChars = .none,
+    border_sides: Sides = .none,
     border_fg: Color = .none,
     border_bg: Color = .none,
 
@@ -271,8 +270,8 @@ pub const Style = struct {
 
     pub fn unsetBorder(self: Self) Self {
         var s = self;
-        s.border_style = Border.none;
-        s.border_sides = Sides.none;
+        s.border_style = .none;
+        s.border_sides = .none;
         s.border_fg = .none;
         s.border_bg = .none;
         s.border_top_fg = .none;
@@ -318,7 +317,7 @@ pub const Style = struct {
     }
 
     pub fn paddingAll(self: Self, n: u16) Self {
-        return self.padding(Spacing.all(n));
+        return self.padding(.all(n));
     }
 
     pub fn paddingLeft(self: Self, n: u16) Self {
@@ -352,7 +351,7 @@ pub const Style = struct {
     }
 
     pub fn marginAll(self: Self, n: u16) Self {
-        return self.margin(Spacing.all(n));
+        return self.margin(.all(n));
     }
 
     pub fn marginLeft(self: Self, n: u16) Self {
@@ -388,7 +387,7 @@ pub const Style = struct {
     }
 
     pub fn borderAll(self: Self, chars: BorderChars) Self {
-        return self.border(chars, Sides.all);
+        return self.border(chars, .all);
     }
 
     pub fn borderForeground(self: Self, c: Color) Self {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -2,6 +2,7 @@
 //! Provides a builder pattern for composing styles.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const color_mod = @import("color.zig");
 const border_mod = @import("border.zig");
 const ansi = @import("../terminal/ansi.zig");
@@ -572,20 +573,21 @@ pub const Style = struct {
 
     /// Render styled text
     pub fn render(self: Self, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-        var result = std.array_list.Managed(u8).init(allocator);
-        const writer = result.writer();
+        var result: Writer.Allocating = .init(allocator);
+        defer result.deinit();
+        var buf: Writer.Allocating = .init(allocator);
+        defer buf.deinit();
 
         // Preprocess tabs if tab_width is set
         var processed_text = text;
         if (self.tab_width_val) |tw| {
-            var buf = std.array_list.Managed(u8).init(allocator);
             for (text) |c| {
                 if (c == '\t') {
                     for (0..tw) |_| {
-                        try buf.append(' ');
+                        try buf.writer.writeByte(' ');
                     }
                 } else {
-                    try buf.append(c);
+                    try buf.writer.writeByte(c);
                 }
             }
             processed_text = try buf.toOwnedSlice();
@@ -629,43 +631,45 @@ pub const Style = struct {
 
         // Write margin top
         for (0..self.margin_val.top) |_| {
-            try self.writeMarginLeft(writer);
+            try self.writeMarginLeft(&result.writer);
             if (!self.margin_bg.isNone()) {
-                try self.margin_bg.writeBg(writer);
+                try self.margin_bg.writeBg(&result.writer);
                 for (0..target_width) |_| {
-                    try writer.writeByte(' ');
+                    try result.writer.writeByte(' ');
                 }
-                try self.writeMarginRight(writer, target_width);
-                try writer.writeAll(ansi.reset);
+                try self.writeMarginRight(&result.writer, target_width);
+                try result.writer.writeAll(ansi.reset);
             }
-            try writer.writeByte('\n');
+            try result.writer.writeByte('\n');
         }
 
         // Build styled content
-        try self.writeStyledContent(writer, processed_text, target_width, target_height);
+        try self.writeStyledContent(&result.writer, processed_text, target_width, target_height);
 
         // Write margin bottom
         for (0..self.margin_val.bottom) |_| {
-            try writer.writeByte('\n');
-            try self.writeMarginLeft(writer);
+            try result.writer.writeByte('\n');
+            try self.writeMarginLeft(&result.writer);
             if (!self.margin_bg.isNone()) {
-                try self.margin_bg.writeBg(writer);
+                try self.margin_bg.writeBg(&result.writer);
                 for (0..target_width) |_| {
-                    try writer.writeByte(' ');
+                    try result.writer.writeByte(' ');
                 }
-                try self.writeMarginRight(writer, target_width);
-                try writer.writeAll(ansi.reset);
+                try self.writeMarginRight(&result.writer, target_width);
+                try result.writer.writeAll(ansi.reset);
             }
         }
 
-        if (!self.inline_mode and result.items.len > 0 and result.items[result.items.len - 1] == '\n') {
-            _ = result.pop();
-        }
+        var array = result.toArrayList();
+        if (!self.inline_mode and
+            array.items.len > 0 and
+            array.items[array.items.len - 1] == '\n')
+            _ = array.pop();
 
-        return result.toOwnedSlice();
+        return array.toOwnedSlice(allocator);
     }
 
-    fn writeStyledContent(self: Self, writer: anytype, text: []const u8, target_width: usize, target_height: usize) !void {
+    fn writeStyledContent(self: Self, writer: *Writer, text: []const u8, target_width: usize, target_height: usize) !void {
         const inner_width = target_width -|
             self.padding_val.left -| self.padding_val.right -|
             @as(usize, if (self.border_sides.left) 1 else 0) -|
@@ -732,7 +736,7 @@ pub const Style = struct {
             (self.strikethrough_spaces and (self.strikethrough_attr orelse false));
     }
 
-    fn writeContentLine(self: Self, writer: anytype, line: []const u8, inner_width: usize) !void {
+    fn writeContentLine(self: Self, writer: *Writer, line: []const u8, inner_width: usize) !void {
         try self.writeMarginLeft(writer);
 
         // Left border
@@ -826,7 +830,7 @@ pub const Style = struct {
     }
 
     /// Write text with per-character whitespace attribute control
-    fn writeWithWhitespaceControl(self: Self, writer: anytype, text: []const u8) !void {
+    fn writeWithWhitespaceControl(self: Self, writer: *Writer, text: []const u8) !void {
         var i: usize = 0;
         while (i < text.len) {
             const byte_len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
@@ -874,7 +878,7 @@ pub const Style = struct {
     }
 
     /// Write N spaces with whitespace control
-    fn writeSpacesWithControl(self: Self, writer: anytype, count: usize) !void {
+    fn writeSpacesWithControl(self: Self, writer: *Writer, count: usize) !void {
         if (count == 0) return;
         if (!self.color_whitespace and !self.background.isNone()) {
             try writer.writeAll(ansi.reset);
@@ -895,7 +899,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeMarginLeft(self: Self, writer: anytype) !void {
+    fn writeMarginLeft(self: Self, writer: *Writer) !void {
         if (!self.margin_bg.isNone() and self.margin_val.left > 0) {
             try self.margin_bg.writeBg(writer);
         }
@@ -907,7 +911,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeMarginRight(self: Self, writer: anytype, content_width: usize) !void {
+    fn writeMarginRight(self: Self, writer: *Writer, content_width: usize) !void {
         _ = content_width;
         if (self.margin_val.right > 0) {
             if (!self.margin_bg.isNone()) {
@@ -922,7 +926,7 @@ pub const Style = struct {
         }
     }
 
-    fn writeStyleStart(self: Self, writer: anytype) !void {
+    fn writeStyleStart(self: Self, writer: *Writer) !void {
         if (self.bold_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.bold});
         if (self.dim_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.dim});
         if (self.italic_attr orelse false) try writer.print(ansi.CSI ++ "{d}m", .{ansi.SGR.italic});
@@ -937,7 +941,7 @@ pub const Style = struct {
 
     const BorderSide = enum { top, right, bottom, left };
 
-    fn writeBorderColorSide(self: Self, writer: anytype, side: BorderSide) !void {
+    fn writeBorderColorSide(self: Self, writer: *Writer, side: BorderSide) !void {
         const side_fg = switch (side) {
             .top => self.border_top_fg,
             .right => self.border_right_fg,
@@ -956,7 +960,7 @@ pub const Style = struct {
         try resolved_bg.writeBg(writer);
     }
 
-    fn writeBorderColor(self: Self, writer: anytype) !void {
+    fn writeBorderColor(self: Self, writer: *Writer) !void {
         try self.border_fg.writeFg(writer);
         try self.border_bg.writeBg(writer);
     }

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -575,12 +575,13 @@ pub const Style = struct {
     pub fn render(self: Self, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
         var result: Writer.Allocating = .init(allocator);
         defer result.deinit();
-        var buf: Writer.Allocating = .init(allocator);
-        defer buf.deinit();
 
-        // Preprocess tabs if tab_width is set
+        // Preprocess tabs if tab_width is set. Only allocate the scratch
+        // buffer when expansion is actually needed.
         var processed_text = text;
         if (self.tab_width_val) |tw| {
+            var buf: Writer.Allocating = .init(allocator);
+            defer buf.deinit();
             for (text) |c| {
                 if (c == '\t') {
                     for (0..tw) |_| {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -670,6 +670,312 @@ pub const Style = struct {
         return array.toOwnedSlice(allocator);
     }
 
+    /// Comptime version of `render`. Both `self` and `text` must be known at
+    /// comptime; the result is a baked `[]const u8` requiring no allocator.
+    /// Currently rejects `transform_fn` and non-`.visible` overflow at
+    /// comptime — use `render` for those.
+    pub fn renderComptime(comptime self: Self, comptime text: []const u8) []const u8 {
+        @setEvalBranchQuota(1_000_000);
+        if (self.transform_fn != null) @compileError("Style.renderComptime: transform_fn not yet supported; use Style.render");
+        if (self.overflow_mode != .visible) @compileError("Style.renderComptime: overflow not yet supported; use Style.render");
+
+        comptime var processed: []const u8 = text;
+        if (self.tab_width_val) |tw| {
+            comptime var expanded: []const u8 = "";
+            for (text) |c| {
+                if (c == '\t') {
+                    for (0..tw) |_| expanded = expanded ++ " ";
+                } else {
+                    expanded = expanded ++ &[_]u8{c};
+                }
+            }
+            processed = expanded;
+        }
+
+        const content_width = measure.widthCt(processed);
+
+        comptime var target_width: usize = content_width;
+        if (self.width_val) |w| target_width = w;
+        if (self.max_width_val) |mw| target_width = @min(target_width, mw);
+        target_width += self.padding_val.left + self.padding_val.right;
+        if (self.border_sides.left) target_width += 1;
+        if (self.border_sides.right) target_width += 1;
+
+        comptime var out: []const u8 = "";
+
+        for (0..self.margin_val.top) |_| {
+            out = out ++ ctMarginLeft(self);
+            if (!self.margin_bg.isNone()) {
+                out = out ++ ctColorBg(self.margin_bg);
+                for (0..target_width) |_| out = out ++ " ";
+                out = out ++ ctMarginRight(self);
+                out = out ++ ansi.reset;
+            }
+            out = out ++ "\n";
+        }
+
+        out = out ++ ctStyledContent(self, processed, target_width);
+
+        for (0..self.margin_val.bottom) |_| {
+            out = out ++ "\n" ++ ctMarginLeft(self);
+            if (!self.margin_bg.isNone()) {
+                out = out ++ ctColorBg(self.margin_bg);
+                for (0..target_width) |_| out = out ++ " ";
+                out = out ++ ctMarginRight(self);
+                out = out ++ ansi.reset;
+            }
+        }
+
+        if (!self.inline_mode and out.len > 0 and out[out.len - 1] == '\n') {
+            return out[0 .. out.len - 1];
+        }
+        return out;
+    }
+
+    fn ctColorFg(comptime c: Color) []const u8 {
+        return switch (c) {
+            .none => "",
+            .ansi => |x| std.fmt.comptimePrint(ansi.CSI ++ "{d}m", .{x.fgCode()}),
+            .ansi256 => |n| std.fmt.comptimePrint(ansi.CSI ++ "38;5;{d}m", .{n}),
+            .rgb => |x| std.fmt.comptimePrint(ansi.CSI ++ "38;2;{d};{d};{d}m", .{ x.r, x.g, x.b }),
+        };
+    }
+
+    fn ctColorBg(comptime c: Color) []const u8 {
+        return switch (c) {
+            .none => "",
+            .ansi => |x| std.fmt.comptimePrint(ansi.CSI ++ "{d}m", .{x.bgCode()}),
+            .ansi256 => |n| std.fmt.comptimePrint(ansi.CSI ++ "48;5;{d}m", .{n}),
+            .rgb => |x| std.fmt.comptimePrint(ansi.CSI ++ "48;2;{d};{d};{d}m", .{ x.r, x.g, x.b }),
+        };
+    }
+
+    fn ctSgr(comptime code: u8) []const u8 {
+        return std.fmt.comptimePrint(ansi.CSI ++ "{d}m", .{code});
+    }
+
+    fn ctStyleStart(comptime self: Self) []const u8 {
+        comptime var s: []const u8 = "";
+        if (self.bold_attr orelse false) s = s ++ ctSgr(ansi.SGR.bold);
+        if (self.dim_attr orelse false) s = s ++ ctSgr(ansi.SGR.dim);
+        if (self.italic_attr orelse false) s = s ++ ctSgr(ansi.SGR.italic);
+        if (self.underline_attr orelse false) s = s ++ ctSgr(ansi.SGR.underline);
+        if (self.blink_attr orelse false) s = s ++ ctSgr(ansi.SGR.blink);
+        if (self.reverse_attr orelse false) s = s ++ ctSgr(ansi.SGR.reverse);
+        if (self.strikethrough_attr orelse false) s = s ++ ctSgr(ansi.SGR.strikethrough);
+        s = s ++ ctColorFg(self.foreground);
+        s = s ++ ctColorBg(self.background);
+        return s;
+    }
+
+    fn ctMarginLeft(comptime self: Self) []const u8 {
+        if (self.margin_val.left == 0) return "";
+        comptime var s: []const u8 = "";
+        if (!self.margin_bg.isNone()) s = s ++ ctColorBg(self.margin_bg);
+        for (0..self.margin_val.left) |_| s = s ++ " ";
+        if (!self.margin_bg.isNone()) s = s ++ ansi.reset;
+        return s;
+    }
+
+    fn ctMarginRight(comptime self: Self) []const u8 {
+        if (self.margin_val.right == 0) return "";
+        comptime var s: []const u8 = "";
+        if (!self.margin_bg.isNone()) s = s ++ ctColorBg(self.margin_bg);
+        for (0..self.margin_val.right) |_| s = s ++ " ";
+        if (!self.margin_bg.isNone()) s = s ++ ansi.reset;
+        return s;
+    }
+
+    fn ctBorderColorSide(comptime self: Self, comptime side: BorderSide) []const u8 {
+        const side_fg = switch (side) {
+            .top => self.border_top_fg,
+            .right => self.border_right_fg,
+            .bottom => self.border_bottom_fg,
+            .left => self.border_left_fg,
+        };
+        const side_bg = switch (side) {
+            .top => self.border_top_bg,
+            .right => self.border_right_bg,
+            .bottom => self.border_bottom_bg,
+            .left => self.border_left_bg,
+        };
+        const resolved_fg = if (!side_fg.isNone()) side_fg else self.border_fg;
+        const resolved_bg = if (!side_bg.isNone()) side_bg else self.border_bg;
+        return ctColorFg(resolved_fg) ++ ctColorBg(resolved_bg);
+    }
+
+    fn ctNeedsWhitespaceAware(comptime self: Self) bool {
+        return (!self.color_whitespace and !self.background.isNone()) or
+            (self.underline_spaces and (self.underline_attr orelse false)) or
+            (self.strikethrough_spaces and (self.strikethrough_attr orelse false));
+    }
+
+    fn ctWithWhitespace(comptime self: Self, comptime text: []const u8) []const u8 {
+        comptime var out: []const u8 = "";
+        comptime var i: usize = 0;
+        while (i < text.len) {
+            const byte_len = std.unicode.utf8ByteSequenceLength(text[i]) catch 1;
+            const end = @min(i + byte_len, text.len);
+            const ch = text[i..end];
+            const is_space = ch.len == 1 and ch[0] == ' ';
+            if (is_space) {
+                if (!self.color_whitespace and !self.background.isNone()) {
+                    out = out ++ ansi.reset;
+                    if (self.underline_spaces and (self.underline_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.underline);
+                    if (self.strikethrough_spaces and (self.strikethrough_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.strikethrough);
+                    out = out ++ " ";
+                    out = out ++ ctStyleStart(self);
+                } else {
+                    if (!self.underline_spaces and (self.underline_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.no_underline);
+                    if (!self.strikethrough_spaces and (self.strikethrough_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.no_strikethrough);
+                    out = out ++ " ";
+                    if (!self.underline_spaces and (self.underline_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.underline);
+                    if (!self.strikethrough_spaces and (self.strikethrough_attr orelse false))
+                        out = out ++ ctSgr(ansi.SGR.strikethrough);
+                }
+            } else {
+                out = out ++ ch;
+            }
+            i = end;
+        }
+        return out;
+    }
+
+    fn ctSpacesWithCtrl(comptime self: Self, comptime count: usize) []const u8 {
+        if (count == 0) return "";
+        comptime var out: []const u8 = "";
+        if (!self.color_whitespace and !self.background.isNone()) {
+            out = out ++ ansi.reset;
+            if (self.underline_spaces and (self.underline_attr orelse false))
+                out = out ++ ctSgr(ansi.SGR.underline);
+            if (self.strikethrough_spaces and (self.strikethrough_attr orelse false))
+                out = out ++ ctSgr(ansi.SGR.strikethrough);
+            for (0..count) |_| out = out ++ " ";
+            out = out ++ ctStyleStart(self);
+        } else {
+            for (0..count) |_| out = out ++ " ";
+        }
+        return out;
+    }
+
+    fn ctContentLine(comptime self: Self, comptime line: []const u8, comptime inner_width: usize) []const u8 {
+        comptime var out: []const u8 = "";
+        out = out ++ ctMarginLeft(self);
+        if (self.border_sides.left) {
+            out = out ++ ctBorderColorSide(self, .left);
+            out = out ++ self.border_style.vertical;
+            out = out ++ ansi.reset;
+        }
+        out = out ++ ctStyleStart(self);
+        for (0..self.padding_val.left) |_| out = out ++ " ";
+
+        const line_w = measure.widthCt(line);
+        const content_pad = if (inner_width > line_w) inner_width - line_w else 0;
+
+        if (ctNeedsWhitespaceAware(self)) {
+            switch (self.align_horizontal) {
+                .left => {
+                    out = out ++ ctWithWhitespace(self, line);
+                    out = out ++ ctSpacesWithCtrl(self, content_pad);
+                },
+                .center => {
+                    const lp = content_pad / 2;
+                    const rp = content_pad - lp;
+                    out = out ++ ctSpacesWithCtrl(self, lp);
+                    out = out ++ ctWithWhitespace(self, line);
+                    out = out ++ ctSpacesWithCtrl(self, rp);
+                },
+                .right => {
+                    out = out ++ ctSpacesWithCtrl(self, content_pad);
+                    out = out ++ ctWithWhitespace(self, line);
+                },
+            }
+        } else {
+            switch (self.align_horizontal) {
+                .left => {
+                    out = out ++ line;
+                    for (0..content_pad) |_| out = out ++ " ";
+                },
+                .center => {
+                    const lp = content_pad / 2;
+                    const rp = content_pad - lp;
+                    for (0..lp) |_| out = out ++ " ";
+                    out = out ++ line;
+                    for (0..rp) |_| out = out ++ " ";
+                },
+                .right => {
+                    for (0..content_pad) |_| out = out ++ " ";
+                    out = out ++ line;
+                },
+            }
+        }
+
+        for (0..self.padding_val.right) |_| out = out ++ " ";
+        out = out ++ ansi.reset;
+        if (self.border_sides.right) {
+            out = out ++ ctBorderColorSide(self, .right);
+            out = out ++ self.border_style.vertical;
+            out = out ++ ansi.reset;
+        }
+        out = out ++ ctMarginRight(self);
+        if (!self.inline_mode) out = out ++ "\n";
+        return out;
+    }
+
+    fn ctStyledContent(comptime self: Self, comptime text: []const u8, comptime target_width: usize) []const u8 {
+        const inner_width = target_width -|
+            self.padding_val.left -| self.padding_val.right -|
+            @as(usize, if (self.border_sides.left) 1 else 0) -|
+            @as(usize, if (self.border_sides.right) 1 else 0);
+
+        comptime var out: []const u8 = "";
+        out = out ++ ctStyleStart(self);
+
+        if (self.border_sides.top) {
+            out = out ++ ctMarginLeft(self);
+            out = out ++ ctBorderColorSide(self, .top);
+            if (self.border_sides.left) out = out ++ self.border_style.top_left;
+            for (0..inner_width + self.padding_val.left + self.padding_val.right) |_| {
+                out = out ++ self.border_style.horizontal;
+            }
+            if (self.border_sides.right) out = out ++ self.border_style.top_right;
+            out = out ++ ansi.reset;
+            out = out ++ ctMarginRight(self);
+            if (!self.inline_mode) out = out ++ "\n";
+        }
+
+        for (0..self.padding_val.top) |_| {
+            out = out ++ ctContentLine(self, "", inner_width);
+        }
+
+        comptime var lines = std.mem.splitScalar(u8, text, '\n');
+        inline while (lines.next()) |line| {
+            out = out ++ ctContentLine(self, line, inner_width);
+        }
+
+        for (0..self.padding_val.bottom) |_| {
+            out = out ++ ctContentLine(self, "", inner_width);
+        }
+
+        if (self.border_sides.bottom) {
+            out = out ++ ctMarginLeft(self);
+            out = out ++ ctBorderColorSide(self, .bottom);
+            if (self.border_sides.left) out = out ++ self.border_style.bottom_left;
+            for (0..inner_width + self.padding_val.left + self.padding_val.right) |_| {
+                out = out ++ self.border_style.horizontal;
+            }
+            if (self.border_sides.right) out = out ++ self.border_style.bottom_right;
+            out = out ++ ansi.reset;
+            out = out ++ ctMarginRight(self);
+        }
+        return out;
+    }
+
     fn writeStyledContent(self: Self, writer: *Writer, text: []const u8, target_width: usize, target_height: usize) !void {
         const inner_width = target_width -|
             self.padding_val.left -| self.padding_val.right -|

--- a/src/style/theme.zig
+++ b/src/style/theme.zig
@@ -38,223 +38,223 @@ pub const Palette = struct {
     // ── Built-in presets ──────────────────────────────
 
     pub const default_dark = Palette{
-        .primary = Color.cyan(),
-        .secondary = Color.magenta(),
-        .accent = Color.yellow(),
-        .background = Color.fromRgb(24, 24, 32),
-        .surface = Color.fromRgb(32, 32, 42),
-        .overlay = Color.fromRgb(40, 40, 52),
-        .foreground = Color.white(),
-        .muted = Color.gray(14),
-        .subtle = Color.gray(10),
-        .success = Color.green(),
-        .warning = Color.yellow(),
-        .danger = Color.red(),
-        .info = Color.cyan(),
-        .border_color = Color.gray(12),
-        .border_focus = Color.cyan(),
-        .highlight = Color.fromRgb(60, 60, 80),
-        .highlight_text = Color.white(),
+        .primary = .cyan,
+        .secondary = .magenta,
+        .accent = .yellow,
+        .background = .fromRgb(24, 24, 32),
+        .surface = .fromRgb(32, 32, 42),
+        .overlay = .fromRgb(40, 40, 52),
+        .foreground = .white,
+        .muted = .gray(14),
+        .subtle = .gray(10),
+        .success = .green,
+        .warning = .yellow,
+        .danger = .red,
+        .info = .cyan,
+        .border_color = .gray(12),
+        .border_focus = .cyan,
+        .highlight = .fromRgb(60, 60, 80),
+        .highlight_text = .white,
     };
 
     pub const default_light = Palette{
-        .primary = Color.fromRgb(0, 120, 180),
-        .secondary = Color.fromRgb(140, 60, 160),
-        .accent = Color.fromRgb(180, 120, 0),
-        .background = Color.fromRgb(250, 250, 250),
-        .surface = Color.fromRgb(240, 240, 240),
-        .overlay = Color.fromRgb(230, 230, 230),
-        .foreground = Color.fromRgb(30, 30, 30),
-        .muted = Color.fromRgb(100, 100, 100),
-        .subtle = Color.fromRgb(160, 160, 160),
-        .success = Color.fromRgb(40, 160, 40),
-        .warning = Color.fromRgb(200, 150, 0),
-        .danger = Color.fromRgb(200, 40, 40),
-        .info = Color.fromRgb(0, 120, 180),
-        .border_color = Color.fromRgb(180, 180, 180),
-        .border_focus = Color.fromRgb(0, 120, 180),
-        .highlight = Color.fromRgb(200, 220, 240),
-        .highlight_text = Color.fromRgb(30, 30, 30),
+        .primary = .fromRgb(0, 120, 180),
+        .secondary = .fromRgb(140, 60, 160),
+        .accent = .fromRgb(180, 120, 0),
+        .background = .fromRgb(250, 250, 250),
+        .surface = .fromRgb(240, 240, 240),
+        .overlay = .fromRgb(230, 230, 230),
+        .foreground = .fromRgb(30, 30, 30),
+        .muted = .fromRgb(100, 100, 100),
+        .subtle = .fromRgb(160, 160, 160),
+        .success = .fromRgb(40, 160, 40),
+        .warning = .fromRgb(200, 150, 0),
+        .danger = .fromRgb(200, 40, 40),
+        .info = .fromRgb(0, 120, 180),
+        .border_color = .fromRgb(180, 180, 180),
+        .border_focus = .fromRgb(0, 120, 180),
+        .highlight = .fromRgb(200, 220, 240),
+        .highlight_text = .fromRgb(30, 30, 30),
     };
 
     pub const catppuccin_mocha = Palette{
-        .primary = Color.fromRgb(137, 180, 250), // blue
-        .secondary = Color.fromRgb(203, 166, 247), // mauve
-        .accent = Color.fromRgb(249, 226, 175), // yellow
-        .background = Color.fromRgb(30, 30, 46), // base
-        .surface = Color.fromRgb(49, 50, 68), // surface0
-        .overlay = Color.fromRgb(69, 71, 90), // surface1
-        .foreground = Color.fromRgb(205, 214, 244), // text
-        .muted = Color.fromRgb(166, 173, 200), // subtext0
-        .subtle = Color.fromRgb(127, 132, 156), // overlay1
-        .success = Color.fromRgb(166, 227, 161), // green
-        .warning = Color.fromRgb(249, 226, 175), // yellow
-        .danger = Color.fromRgb(243, 139, 168), // red
-        .info = Color.fromRgb(137, 180, 250), // blue
-        .border_color = Color.fromRgb(88, 91, 112), // overlay0
-        .border_focus = Color.fromRgb(137, 180, 250), // blue
-        .highlight = Color.fromRgb(49, 50, 68), // surface0
-        .highlight_text = Color.fromRgb(205, 214, 244), // text
+        .primary = .fromRgb(137, 180, 250), // blue
+        .secondary = .fromRgb(203, 166, 247), // mauve
+        .accent = .fromRgb(249, 226, 175), // yellow
+        .background = .fromRgb(30, 30, 46), // base
+        .surface = .fromRgb(49, 50, 68), // surface0
+        .overlay = .fromRgb(69, 71, 90), // surface1
+        .foreground = .fromRgb(205, 214, 244), // text
+        .muted = .fromRgb(166, 173, 200), // subtext0
+        .subtle = .fromRgb(127, 132, 156), // overlay1
+        .success = .fromRgb(166, 227, 161), // green
+        .warning = .fromRgb(249, 226, 175), // yellow
+        .danger = .fromRgb(243, 139, 168), // red
+        .info = .fromRgb(137, 180, 250), // blue
+        .border_color = .fromRgb(88, 91, 112), // overlay0
+        .border_focus = .fromRgb(137, 180, 250), // blue
+        .highlight = .fromRgb(49, 50, 68), // surface0
+        .highlight_text = .fromRgb(205, 214, 244), // text
     };
 
     pub const catppuccin_latte = Palette{
-        .primary = Color.fromRgb(30, 102, 245), // blue
-        .secondary = Color.fromRgb(136, 57, 239), // mauve
-        .accent = Color.fromRgb(223, 142, 29), // yellow
-        .background = Color.fromRgb(239, 241, 245), // base
-        .surface = Color.fromRgb(204, 208, 218), // surface0
-        .overlay = Color.fromRgb(188, 192, 204), // surface1
-        .foreground = Color.fromRgb(76, 79, 105), // text
-        .muted = Color.fromRgb(108, 111, 133), // subtext0
-        .subtle = Color.fromRgb(140, 143, 161), // overlay1
-        .success = Color.fromRgb(64, 160, 43), // green
-        .warning = Color.fromRgb(223, 142, 29), // yellow
-        .danger = Color.fromRgb(210, 15, 57), // red
-        .info = Color.fromRgb(30, 102, 245), // blue
-        .border_color = Color.fromRgb(156, 160, 176), // overlay0
-        .border_focus = Color.fromRgb(30, 102, 245), // blue
-        .highlight = Color.fromRgb(204, 208, 218), // surface0
-        .highlight_text = Color.fromRgb(76, 79, 105), // text
+        .primary = .fromRgb(30, 102, 245), // blue
+        .secondary = .fromRgb(136, 57, 239), // mauve
+        .accent = .fromRgb(223, 142, 29), // yellow
+        .background = .fromRgb(239, 241, 245), // base
+        .surface = .fromRgb(204, 208, 218), // surface0
+        .overlay = .fromRgb(188, 192, 204), // surface1
+        .foreground = .fromRgb(76, 79, 105), // text
+        .muted = .fromRgb(108, 111, 133), // subtext0
+        .subtle = .fromRgb(140, 143, 161), // overlay1
+        .success = .fromRgb(64, 160, 43), // green
+        .warning = .fromRgb(223, 142, 29), // yellow
+        .danger = .fromRgb(210, 15, 57), // red
+        .info = .fromRgb(30, 102, 245), // blue
+        .border_color = .fromRgb(156, 160, 176), // overlay0
+        .border_focus = .fromRgb(30, 102, 245), // blue
+        .highlight = .fromRgb(204, 208, 218), // surface0
+        .highlight_text = .fromRgb(76, 79, 105), // text
     };
 
     pub const dracula = Palette{
-        .primary = Color.fromRgb(189, 147, 249), // purple
-        .secondary = Color.fromRgb(255, 121, 198), // pink
-        .accent = Color.fromRgb(241, 250, 140), // yellow
-        .background = Color.fromRgb(40, 42, 54), // background
-        .surface = Color.fromRgb(68, 71, 90), // current line
-        .overlay = Color.fromRgb(68, 71, 90), // current line
-        .foreground = Color.fromRgb(248, 248, 242), // foreground
-        .muted = Color.fromRgb(98, 114, 164), // comment
-        .subtle = Color.fromRgb(98, 114, 164), // comment
-        .success = Color.fromRgb(80, 250, 123), // green
-        .warning = Color.fromRgb(255, 184, 108), // orange
-        .danger = Color.fromRgb(255, 85, 85), // red
-        .info = Color.fromRgb(139, 233, 253), // cyan
-        .border_color = Color.fromRgb(98, 114, 164), // comment
-        .border_focus = Color.fromRgb(189, 147, 249), // purple
-        .highlight = Color.fromRgb(68, 71, 90), // current line
-        .highlight_text = Color.fromRgb(248, 248, 242), // foreground
+        .primary = .fromRgb(189, 147, 249), // purple
+        .secondary = .fromRgb(255, 121, 198), // pink
+        .accent = .fromRgb(241, 250, 140), // yellow
+        .background = .fromRgb(40, 42, 54), // background
+        .surface = .fromRgb(68, 71, 90), // current line
+        .overlay = .fromRgb(68, 71, 90), // current line
+        .foreground = .fromRgb(248, 248, 242), // foreground
+        .muted = .fromRgb(98, 114, 164), // comment
+        .subtle = .fromRgb(98, 114, 164), // comment
+        .success = .fromRgb(80, 250, 123), // green
+        .warning = .fromRgb(255, 184, 108), // orange
+        .danger = .fromRgb(255, 85, 85), // red
+        .info = .fromRgb(139, 233, 253), // cyan
+        .border_color = .fromRgb(98, 114, 164), // comment
+        .border_focus = .fromRgb(189, 147, 249), // purple
+        .highlight = .fromRgb(68, 71, 90), // current line
+        .highlight_text = .fromRgb(248, 248, 242), // foreground
     };
 
     pub const nord = Palette{
-        .primary = Color.fromRgb(136, 192, 208), // nord8 frost
-        .secondary = Color.fromRgb(129, 161, 193), // nord9
-        .accent = Color.fromRgb(235, 203, 139), // nord13 aurora yellow
-        .background = Color.fromRgb(46, 52, 64), // nord0 polar night
-        .surface = Color.fromRgb(59, 66, 82), // nord1
-        .overlay = Color.fromRgb(67, 76, 94), // nord2
-        .foreground = Color.fromRgb(236, 239, 244), // nord6 snow storm
-        .muted = Color.fromRgb(216, 222, 233), // nord4
-        .subtle = Color.fromRgb(76, 86, 106), // nord3
-        .success = Color.fromRgb(163, 190, 140), // nord14 aurora green
-        .warning = Color.fromRgb(235, 203, 139), // nord13
-        .danger = Color.fromRgb(191, 97, 106), // nord11 aurora red
-        .info = Color.fromRgb(136, 192, 208), // nord8
-        .border_color = Color.fromRgb(76, 86, 106), // nord3
-        .border_focus = Color.fromRgb(136, 192, 208), // nord8
-        .highlight = Color.fromRgb(59, 66, 82), // nord1
-        .highlight_text = Color.fromRgb(236, 239, 244), // nord6
+        .primary = .fromRgb(136, 192, 208), // nord8 frost
+        .secondary = .fromRgb(129, 161, 193), // nord9
+        .accent = .fromRgb(235, 203, 139), // nord13 aurora yellow
+        .background = .fromRgb(46, 52, 64), // nord0 polar night
+        .surface = .fromRgb(59, 66, 82), // nord1
+        .overlay = .fromRgb(67, 76, 94), // nord2
+        .foreground = .fromRgb(236, 239, 244), // nord6 snow storm
+        .muted = .fromRgb(216, 222, 233), // nord4
+        .subtle = .fromRgb(76, 86, 106), // nord3
+        .success = .fromRgb(163, 190, 140), // nord14 aurora green
+        .warning = .fromRgb(235, 203, 139), // nord13
+        .danger = .fromRgb(191, 97, 106), // nord11 aurora red
+        .info = .fromRgb(136, 192, 208), // nord8
+        .border_color = .fromRgb(76, 86, 106), // nord3
+        .border_focus = .fromRgb(136, 192, 208), // nord8
+        .highlight = .fromRgb(59, 66, 82), // nord1
+        .highlight_text = .fromRgb(236, 239, 244), // nord6
     };
 
     pub const high_contrast = Palette{
-        .primary = Color.fromRgb(0, 200, 255),
-        .secondary = Color.fromRgb(255, 100, 255),
-        .accent = Color.fromRgb(255, 255, 0),
-        .background = Color.fromRgb(0, 0, 0),
-        .surface = Color.fromRgb(20, 20, 20),
-        .overlay = Color.fromRgb(40, 40, 40),
-        .foreground = Color.fromRgb(255, 255, 255),
-        .muted = Color.fromRgb(200, 200, 200),
-        .subtle = Color.fromRgb(150, 150, 150),
-        .success = Color.fromRgb(0, 255, 0),
-        .warning = Color.fromRgb(255, 255, 0),
-        .danger = Color.fromRgb(255, 0, 0),
-        .info = Color.fromRgb(0, 200, 255),
-        .border_color = Color.fromRgb(200, 200, 200),
-        .border_focus = Color.fromRgb(0, 200, 255),
-        .highlight = Color.fromRgb(0, 80, 120),
-        .highlight_text = Color.fromRgb(255, 255, 255),
+        .primary = .fromRgb(0, 200, 255),
+        .secondary = .fromRgb(255, 100, 255),
+        .accent = .fromRgb(255, 255, 0),
+        .background = .fromRgb(0, 0, 0),
+        .surface = .fromRgb(20, 20, 20),
+        .overlay = .fromRgb(40, 40, 40),
+        .foreground = .fromRgb(255, 255, 255),
+        .muted = .fromRgb(200, 200, 200),
+        .subtle = .fromRgb(150, 150, 150),
+        .success = .fromRgb(0, 255, 0),
+        .warning = .fromRgb(255, 255, 0),
+        .danger = .fromRgb(255, 0, 0),
+        .info = .fromRgb(0, 200, 255),
+        .border_color = .fromRgb(200, 200, 200),
+        .border_focus = .fromRgb(0, 200, 255),
+        .highlight = .fromRgb(0, 80, 120),
+        .highlight_text = .fromRgb(255, 255, 255),
     };
 
     pub const tokyo_night = Palette{
-        .primary = Color.fromRgb(122, 162, 247), // blue
-        .secondary = Color.fromRgb(187, 154, 247), // purple
-        .accent = Color.fromRgb(224, 175, 104), // yellow
-        .background = Color.fromRgb(26, 27, 38), // bg
-        .surface = Color.fromRgb(36, 40, 59), // bg_highlight
-        .overlay = Color.fromRgb(41, 46, 66), // terminal_black
-        .foreground = Color.fromRgb(192, 202, 245), // fg
-        .muted = Color.fromRgb(144, 153, 191), // comment
-        .subtle = Color.fromRgb(86, 95, 137), // dark5
-        .success = Color.fromRgb(158, 206, 106), // green
-        .warning = Color.fromRgb(224, 175, 104), // yellow
-        .danger = Color.fromRgb(247, 118, 142), // red
-        .info = Color.fromRgb(125, 207, 255), // cyan
-        .border_color = Color.fromRgb(41, 46, 66),
-        .border_focus = Color.fromRgb(122, 162, 247),
-        .highlight = Color.fromRgb(41, 46, 66),
-        .highlight_text = Color.fromRgb(192, 202, 245),
+        .primary = .fromRgb(122, 162, 247), // blue
+        .secondary = .fromRgb(187, 154, 247), // purple
+        .accent = .fromRgb(224, 175, 104), // yellow
+        .background = .fromRgb(26, 27, 38), // bg
+        .surface = .fromRgb(36, 40, 59), // bg_highlight
+        .overlay = .fromRgb(41, 46, 66), // terminal_black
+        .foreground = .fromRgb(192, 202, 245), // fg
+        .muted = .fromRgb(144, 153, 191), // comment
+        .subtle = .fromRgb(86, 95, 137), // dark5
+        .success = .fromRgb(158, 206, 106), // green
+        .warning = .fromRgb(224, 175, 104), // yellow
+        .danger = .fromRgb(247, 118, 142), // red
+        .info = .fromRgb(125, 207, 255), // cyan
+        .border_color = .fromRgb(41, 46, 66),
+        .border_focus = .fromRgb(122, 162, 247),
+        .highlight = .fromRgb(41, 46, 66),
+        .highlight_text = .fromRgb(192, 202, 245),
     };
 
     pub const gruvbox_dark = Palette{
-        .primary = Color.fromRgb(131, 165, 152), // aqua
-        .secondary = Color.fromRgb(211, 134, 155), // purple
-        .accent = Color.fromRgb(250, 189, 47), // yellow
-        .background = Color.fromRgb(40, 40, 40), // bg
-        .surface = Color.fromRgb(60, 56, 54), // bg1
-        .overlay = Color.fromRgb(80, 73, 69), // bg2
-        .foreground = Color.fromRgb(235, 219, 178), // fg
-        .muted = Color.fromRgb(168, 153, 132), // gray
-        .subtle = Color.fromRgb(124, 111, 100), // bg4
-        .success = Color.fromRgb(184, 187, 38), // green
-        .warning = Color.fromRgb(250, 189, 47), // yellow
-        .danger = Color.fromRgb(251, 73, 52), // red
-        .info = Color.fromRgb(131, 165, 152), // aqua
-        .border_color = Color.fromRgb(80, 73, 69),
-        .border_focus = Color.fromRgb(131, 165, 152),
-        .highlight = Color.fromRgb(80, 73, 69),
-        .highlight_text = Color.fromRgb(235, 219, 178),
+        .primary = .fromRgb(131, 165, 152), // aqua
+        .secondary = .fromRgb(211, 134, 155), // purple
+        .accent = .fromRgb(250, 189, 47), // yellow
+        .background = .fromRgb(40, 40, 40), // bg
+        .surface = .fromRgb(60, 56, 54), // bg1
+        .overlay = .fromRgb(80, 73, 69), // bg2
+        .foreground = .fromRgb(235, 219, 178), // fg
+        .muted = .fromRgb(168, 153, 132), // gray
+        .subtle = .fromRgb(124, 111, 100), // bg4
+        .success = .fromRgb(184, 187, 38), // green
+        .warning = .fromRgb(250, 189, 47), // yellow
+        .danger = .fromRgb(251, 73, 52), // red
+        .info = .fromRgb(131, 165, 152), // aqua
+        .border_color = .fromRgb(80, 73, 69),
+        .border_focus = .fromRgb(131, 165, 152),
+        .highlight = .fromRgb(80, 73, 69),
+        .highlight_text = .fromRgb(235, 219, 178),
     };
 
     pub const solarized_dark = Palette{
-        .primary = Color.fromRgb(38, 139, 210), // blue
-        .secondary = Color.fromRgb(108, 113, 196), // violet
-        .accent = Color.fromRgb(181, 137, 0), // yellow
-        .background = Color.fromRgb(0, 43, 54), // base03
-        .surface = Color.fromRgb(7, 54, 66), // base02
-        .overlay = Color.fromRgb(88, 110, 117), // base01
-        .foreground = Color.fromRgb(131, 148, 150), // base0
-        .muted = Color.fromRgb(101, 123, 131), // base00
-        .subtle = Color.fromRgb(88, 110, 117), // base01
-        .success = Color.fromRgb(133, 153, 0), // green
-        .warning = Color.fromRgb(181, 137, 0), // yellow
-        .danger = Color.fromRgb(220, 50, 47), // red
-        .info = Color.fromRgb(42, 161, 152), // cyan
-        .border_color = Color.fromRgb(88, 110, 117),
-        .border_focus = Color.fromRgb(38, 139, 210),
-        .highlight = Color.fromRgb(7, 54, 66),
-        .highlight_text = Color.fromRgb(147, 161, 161),
+        .primary = .fromRgb(38, 139, 210), // blue
+        .secondary = .fromRgb(108, 113, 196), // violet
+        .accent = .fromRgb(181, 137, 0), // yellow
+        .background = .fromRgb(0, 43, 54), // base03
+        .surface = .fromRgb(7, 54, 66), // base02
+        .overlay = .fromRgb(88, 110, 117), // base01
+        .foreground = .fromRgb(131, 148, 150), // base0
+        .muted = .fromRgb(101, 123, 131), // base00
+        .subtle = .fromRgb(88, 110, 117), // base01
+        .success = .fromRgb(133, 153, 0), // green
+        .warning = .fromRgb(181, 137, 0), // yellow
+        .danger = .fromRgb(220, 50, 47), // red
+        .info = .fromRgb(42, 161, 152), // cyan
+        .border_color = .fromRgb(88, 110, 117),
+        .border_focus = .fromRgb(38, 139, 210),
+        .highlight = .fromRgb(7, 54, 66),
+        .highlight_text = .fromRgb(147, 161, 161),
     };
 
     pub const solarized_light = Palette{
-        .primary = Color.fromRgb(38, 139, 210), // blue
-        .secondary = Color.fromRgb(108, 113, 196), // violet
-        .accent = Color.fromRgb(181, 137, 0), // yellow
-        .background = Color.fromRgb(253, 246, 227), // base3
-        .surface = Color.fromRgb(238, 232, 213), // base2
-        .overlay = Color.fromRgb(147, 161, 161), // base1
-        .foreground = Color.fromRgb(101, 123, 131), // base00
-        .muted = Color.fromRgb(131, 148, 150), // base0
-        .subtle = Color.fromRgb(147, 161, 161), // base1
-        .success = Color.fromRgb(133, 153, 0), // green
-        .warning = Color.fromRgb(181, 137, 0), // yellow
-        .danger = Color.fromRgb(220, 50, 47), // red
-        .info = Color.fromRgb(42, 161, 152), // cyan
-        .border_color = Color.fromRgb(147, 161, 161),
-        .border_focus = Color.fromRgb(38, 139, 210),
-        .highlight = Color.fromRgb(238, 232, 213),
-        .highlight_text = Color.fromRgb(88, 110, 117),
+        .primary = .fromRgb(38, 139, 210), // blue
+        .secondary = .fromRgb(108, 113, 196), // violet
+        .accent = .fromRgb(181, 137, 0), // yellow
+        .background = .fromRgb(253, 246, 227), // base3
+        .surface = .fromRgb(238, 232, 213), // base2
+        .overlay = .fromRgb(147, 161, 161), // base1
+        .foreground = .fromRgb(101, 123, 131), // base00
+        .muted = .fromRgb(131, 148, 150), // base0
+        .subtle = .fromRgb(147, 161, 161), // base1
+        .success = .fromRgb(133, 153, 0), // green
+        .warning = .fromRgb(181, 137, 0), // yellow
+        .danger = .fromRgb(220, 50, 47), // red
+        .info = .fromRgb(42, 161, 152), // cyan
+        .border_color = .fromRgb(147, 161, 161),
+        .border_focus = .fromRgb(38, 139, 210),
+        .highlight = .fromRgb(238, 232, 213),
+        .highlight_text = .fromRgb(88, 110, 117),
     };
 
     /// List of all built-in palette names for iteration.
@@ -283,18 +283,18 @@ pub const AdaptivePalette = struct {
     }
 
     pub const catppuccin = AdaptivePalette{
-        .light = Palette.catppuccin_latte,
-        .dark = Palette.catppuccin_mocha,
+        .light = .catppuccin_latte,
+        .dark = .catppuccin_mocha,
     };
 
     pub const default = AdaptivePalette{
-        .light = Palette.default_light,
-        .dark = Palette.default_dark,
+        .light = .default_light,
+        .dark = .default_dark,
     };
 
     pub const solarized = AdaptivePalette{
-        .light = Palette.solarized_light,
-        .dark = Palette.solarized_dark,
+        .light = .solarized_light,
+        .dark = .solarized_dark,
     };
 };
 
@@ -310,7 +310,7 @@ pub const ThemeManager = struct {
         const is_dark = @import("color.zig").hasDarkBackground();
         const palette = AdaptivePalette.default.resolve(is_dark);
         return .{
-            .current = Theme.fromPalette(palette),
+            .current = .fromPalette(palette),
             .is_dark = is_dark,
             .palette_index = 0,
         };
@@ -320,7 +320,7 @@ pub const ThemeManager = struct {
     pub fn initWithPalette(palette: Palette) ThemeManager {
         const is_dark = @import("color.zig").hasDarkBackground();
         return .{
-            .current = Theme.fromPalette(palette),
+            .current = .fromPalette(palette),
             .is_dark = is_dark,
             .palette_index = 0,
         };
@@ -328,27 +328,27 @@ pub const ThemeManager = struct {
 
     /// Switch to a specific palette.
     pub fn setPalette(self: *ThemeManager, palette: Palette) void {
-        self.current = Theme.fromPalette(palette);
+        self.current = .fromPalette(palette);
     }
 
     /// Switch to a named built-in palette by index.
     pub fn setBuiltinByIndex(self: *ThemeManager, index: usize) void {
         if (index < Palette.builtins.len) {
             self.palette_index = index;
-            self.current = Theme.fromPalette(Palette.builtins[index].palette);
+            self.current = .fromPalette(Palette.builtins[index].palette);
         }
     }
 
     /// Cycle to the next built-in palette.
     pub fn nextBuiltin(self: *ThemeManager) void {
         self.palette_index = (self.palette_index + 1) % Palette.builtins.len;
-        self.current = Theme.fromPalette(Palette.builtins[self.palette_index].palette);
+        self.current = .fromPalette(Palette.builtins[self.palette_index].palette);
     }
 
     /// Cycle to the previous built-in palette.
     pub fn prevBuiltin(self: *ThemeManager) void {
         self.palette_index = if (self.palette_index == 0) Palette.builtins.len - 1 else self.palette_index - 1;
-        self.current = Theme.fromPalette(Palette.builtins[self.palette_index].palette);
+        self.current = .fromPalette(Palette.builtins[self.palette_index].palette);
     }
 
     /// Get the name of the current built-in palette.

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -2,6 +2,7 @@
 //! Provides functions to generate standard terminal control sequences.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 
 /// ANSI escape codes
 pub const ESC = "\x1b";
@@ -62,98 +63,98 @@ pub const kitty_keyboard_enable = CSI ++ ">1u";
 pub const kitty_keyboard_disable = CSI ++ "<u";
 
 /// Move cursor to position (1-indexed)
-pub fn cursorTo(writer: anytype, row: u16, col: u16) !void {
+pub fn cursorTo(writer: *Writer, row: u16, col: u16) !void {
     try writer.print(CSI ++ "{d};{d}H", .{ row, col });
 }
 
 /// Move cursor to position (0-indexed)
-pub fn cursorTo0(writer: anytype, row: u16, col: u16) !void {
+pub fn cursorTo0(writer: *Writer, row: u16, col: u16) !void {
     try writer.print(CSI ++ "{d};{d}H", .{ row + 1, col + 1 });
 }
 
 /// Move cursor up
-pub fn cursorUp(writer: anytype, n: u16) !void {
+pub fn cursorUp(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}A", .{n});
 }
 
 /// Move cursor down
-pub fn cursorDown(writer: anytype, n: u16) !void {
+pub fn cursorDown(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}B", .{n});
 }
 
 /// Move cursor forward (right)
-pub fn cursorForward(writer: anytype, n: u16) !void {
+pub fn cursorForward(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}C", .{n});
 }
 
 /// Move cursor backward (left)
-pub fn cursorBack(writer: anytype, n: u16) !void {
+pub fn cursorBack(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}D", .{n});
 }
 
 /// Move cursor to column (1-indexed)
-pub fn cursorToCol(writer: anytype, col: u16) !void {
+pub fn cursorToCol(writer: *Writer, col: u16) !void {
     try writer.print(CSI ++ "{d}G", .{col});
 }
 
 /// Move cursor to column (0-indexed)
-pub fn cursorToCol0(writer: anytype, col: u16) !void {
+pub fn cursorToCol0(writer: *Writer, col: u16) !void {
     try writer.print(CSI ++ "{d}G", .{col + 1});
 }
 
 /// Request cursor position (response: ESC[row;colR)
-pub fn requestCursorPos(writer: anytype) !void {
+pub fn requestCursorPos(writer: *Writer) !void {
     try writer.writeAll(CSI ++ "6n");
 }
 
 /// Set scrolling region
-pub fn setScrollRegion(writer: anytype, top: u16, bottom: u16) !void {
+pub fn setScrollRegion(writer: *Writer, top: u16, bottom: u16) !void {
     try writer.print(CSI ++ "{d};{d}r", .{ top, bottom });
 }
 
 /// Reset scrolling region
-pub fn resetScrollRegion(writer: anytype) !void {
+pub fn resetScrollRegion(writer: *Writer) !void {
     try writer.writeAll(CSI ++ "r");
 }
 
 /// Scroll up (content moves up, blank lines at bottom)
-pub fn scrollUp(writer: anytype, n: u16) !void {
+pub fn scrollUp(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}S", .{n});
 }
 
 /// Scroll down (content moves down, blank lines at top)
-pub fn scrollDown(writer: anytype, n: u16) !void {
+pub fn scrollDown(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}T", .{n});
 }
 
 /// Erase n characters from cursor position
-pub fn eraseChars(writer: anytype, n: u16) !void {
+pub fn eraseChars(writer: *Writer, n: u16) !void {
     try writer.print(CSI ++ "{d}X", .{n});
 }
 
 /// Insert n blank lines at cursor position
-pub fn insertLines(writer: anytype, n: u16) !void {
+pub fn insertLines(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}L", .{n});
 }
 
 /// Delete n lines at cursor position
-pub fn deleteLines(writer: anytype, n: u16) !void {
+pub fn deleteLines(writer: *Writer, n: u16) !void {
     if (n > 0) try writer.print(CSI ++ "{d}M", .{n});
 }
 
 /// Set window title
-pub fn setTitle(writer: anytype, title: []const u8) !void {
+pub fn setTitle(writer: *Writer, title: []const u8) !void {
     try writer.print(OSC ++ "0;{s}\x07", .{title});
 }
 
-fn writeOscTerminator(writer: anytype, terminator: OscTerminator) !void {
+fn writeOscTerminator(writer: *Writer, terminator: OscTerminator) !void {
     switch (terminator) {
         .bel => try writer.writeAll("\x07"),
         .st => try writer.writeAll(ST),
     }
 }
 
-fn writeEscapedForDcs(writer: anytype, bytes: []const u8) !void {
+fn writeEscapedForDcs(writer: *Writer, bytes: []const u8) !void {
     var start: usize = 0;
     for (bytes, 0..) |byte, idx| {
         if (byte != 0x1b) continue;
@@ -173,7 +174,7 @@ fn writeEscapedForDcs(writer: anytype, bytes: []const u8) !void {
 /// Start an OSC 52 sequence and write the fixed header:
 /// `OSC 52 ; <target> ;`
 pub fn osc52Start(
-    writer: anytype,
+    writer: *Writer,
     target: []const u8,
     passthrough: Osc52Passthrough,
 ) !void {
@@ -199,7 +200,7 @@ pub fn osc52Start(
 }
 
 /// Finish an OSC 52 sequence started by `osc52Start`.
-pub fn osc52End(writer: anytype, terminator: OscTerminator, passthrough: Osc52Passthrough) !void {
+pub fn osc52End(writer: *Writer, terminator: OscTerminator, passthrough: Osc52Passthrough) !void {
     switch (passthrough) {
         .none => try writeOscTerminator(writer, terminator),
         .tmux, .dcs => {
@@ -214,7 +215,7 @@ pub fn osc52End(writer: anytype, terminator: OscTerminator, passthrough: Osc52Pa
 
 /// Write a complete OSC 52 sequence with a pre-encoded base64 payload.
 pub fn osc52Encoded(
-    writer: anytype,
+    writer: *Writer,
     target: []const u8,
     payload_b64: []const u8,
     terminator: OscTerminator,
@@ -290,7 +291,7 @@ pub const SGR = struct {
 };
 
 /// Generate SGR sequence
-pub fn sgr(writer: anytype, codes: []const u8) !void {
+pub fn sgr(writer: *Writer, codes: []const u8) !void {
     try writer.writeAll(CSI);
     for (codes, 0..) |code, i| {
         if (i > 0) try writer.writeByte(';');
@@ -300,32 +301,32 @@ pub fn sgr(writer: anytype, codes: []const u8) !void {
 }
 
 /// Generate 256-color foreground
-pub fn fg256(writer: anytype, color: u8) !void {
+pub fn fg256(writer: *Writer, color: u8) !void {
     try writer.print(CSI ++ "38;5;{d}m", .{color});
 }
 
 /// Generate 256-color background
-pub fn bg256(writer: anytype, color: u8) !void {
+pub fn bg256(writer: *Writer, color: u8) !void {
     try writer.print(CSI ++ "48;5;{d}m", .{color});
 }
 
 /// Generate true color (24-bit) foreground
-pub fn fgRgb(writer: anytype, r: u8, g: u8, b: u8) !void {
+pub fn fgRgb(writer: *Writer, r: u8, g: u8, b: u8) !void {
     try writer.print(CSI ++ "38;2;{d};{d};{d}m", .{ r, g, b });
 }
 
 /// Generate true color (24-bit) background
-pub fn bgRgb(writer: anytype, r: u8, g: u8, b: u8) !void {
+pub fn bgRgb(writer: *Writer, r: u8, g: u8, b: u8) !void {
     try writer.print(CSI ++ "48;2;{d};{d};{d}m", .{ r, g, b });
 }
 
 /// Hyperlink (OSC 8)
-pub fn hyperlink(writer: anytype, url: []const u8, text: []const u8) !void {
+pub fn hyperlink(writer: *Writer, url: []const u8, text: []const u8) !void {
     try writer.print(OSC ++ "8;;{s}\x07{s}" ++ OSC ++ "8;;\x07", .{ url, text });
 }
 
 /// Kitty graphics protocol command (APC G ... ST)
-pub fn kittyGraphics(writer: anytype, params: []const u8, payload: []const u8) !void {
+pub fn kittyGraphics(writer: *Writer, params: []const u8, payload: []const u8) !void {
     try writer.writeAll(APC ++ "G");
     try writer.writeAll(params);
     try writer.writeAll(";");
@@ -334,7 +335,7 @@ pub fn kittyGraphics(writer: anytype, params: []const u8, payload: []const u8) !
 }
 
 /// iTerm2 inline image command (OSC 1337;File=...:... BEL)
-pub fn iterm2InlineImage(writer: anytype, params: []const u8, payload: []const u8) !void {
+pub fn iterm2InlineImage(writer: *Writer, params: []const u8, payload: []const u8) !void {
     try writer.writeAll(OSC ++ "1337;File=");
     try writer.writeAll(params);
     try writer.writeAll(":");
@@ -344,28 +345,28 @@ pub fn iterm2InlineImage(writer: anytype, params: []const u8, payload: []const u
 
 test "osc52Encoded direct BEL" {
     var buf: [128]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .bel, .none);
-    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x07", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .bel, .none);
+    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x07", writer.buffered());
 }
 
 test "osc52Encoded direct ST" {
     var buf: [128]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .st, .none);
-    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .st, .none);
+    try std.testing.expectEqualStrings("\x1b]52;c;YQ==\x1b\\", writer.buffered());
 }
 
 test "osc52Encoded tmux passthrough BEL" {
     var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .bel, .tmux);
-    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x07\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .bel, .tmux);
+    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x07\x1b\\", writer.buffered());
 }
 
 test "osc52Encoded tmux passthrough ST" {
     var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try osc52Encoded(stream.writer(), "c", "YQ==", .st, .tmux);
-    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x1b\x1b\\\x1b\\", stream.getWritten());
+    var writer: Writer = .fixed(&buf);
+    try osc52Encoded(&writer, "c", "YQ==", .st, .tmux);
+    try std.testing.expectEqualStrings("\x1bPtmux;\x1b\x1b]52;c;YQ==\x1b\x1b\\\x1b\\", writer.buffered());
 }

--- a/src/terminal/platform/posix.zig
+++ b/src/terminal/platform/posix.zig
@@ -2,6 +2,7 @@
 //! Handles raw mode, terminal size, and signal handling.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const posix = std.posix;
 const ansi = @import("../ansi.zig");
 
@@ -118,7 +119,7 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_enter);
@@ -126,7 +127,7 @@ pub fn enterAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Exit alternate screen buffer
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_exit);
@@ -134,7 +135,7 @@ pub fn exitAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Enable mouse tracking
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
 
     // Enable SGR mouse mode with all motion tracking
@@ -143,7 +144,7 @@ pub fn enableMouse(state: *State, writer: anytype) !void {
 }
 
 /// Disable mouse tracking
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
 
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -144,18 +144,31 @@ export fn zigzagPushInput(len: usize) void {
     input_write_pos = @min(len, input_ring.len);
 }
 
-/// Writer adapter that sends bytes to the JS host.
+/// Unbuffered `std.Io.Writer` adapter that drains bytes to the JS host.
 pub const WasmWriter = struct {
-    pub const Error = error{};
+    writer: Writer,
 
-    pub fn write(_: *const WasmWriter, bytes: []const u8) Error!usize {
-        jsWrite(bytes.ptr, bytes.len);
-        return bytes.len;
+    const vtable: Writer.VTable = .{ .drain = drain };
+
+    pub fn init() WasmWriter {
+        return .{ .writer = .{ .vtable = &vtable, .buffer = &.{} } };
     }
 
-    pub fn writer(self: *const WasmWriter) std.io.GenericWriter(*const WasmWriter, Error, write) {
-        return .{ .context = self };
+    fn drain(_: *Writer, data: []const []const u8, splat: usize) Writer.Error!usize {
+        var consumed: usize = 0;
+        if (data.len > 1) for (data[0 .. data.len - 1]) |chunk| {
+            if (chunk.len == 0) continue;
+            jsWrite(chunk.ptr, chunk.len);
+            consumed += chunk.len;
+        };
+        const pattern = data[data.len - 1];
+        if (pattern.len > 0 and splat > 0) {
+            var i: usize = 0;
+            while (i < splat) : (i += 1) jsWrite(pattern.ptr, pattern.len);
+            consumed += pattern.len * splat;
+        }
+        return consumed;
     }
 };
 
-pub const wasm_writer_instance = WasmWriter{};
+pub var wasm_writer_instance: WasmWriter = .init();

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -4,6 +4,7 @@
 //! or similar browser-based terminal emulator.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("../ansi.zig");
 
 pub const TerminalError = error{
@@ -67,28 +68,28 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer.
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
     try writer.writeAll(ansi.alt_screen_enter);
     state.in_alt_screen = true;
 }
 
 /// Exit alternate screen buffer.
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
     try writer.writeAll(ansi.alt_screen_exit);
     state.in_alt_screen = false;
 }
 
 /// Enable mouse tracking.
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
     try writer.writeAll("\x1b[?1003h\x1b[?1006h");
     state.mouse_enabled = true;
 }
 
 /// Disable mouse tracking.
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");
     state.mouse_enabled = false;

--- a/src/terminal/platform/wasm.zig
+++ b/src/terminal/platform/wasm.zig
@@ -155,6 +155,10 @@ pub const WasmWriter = struct {
     }
 
     fn drain(_: *Writer, data: []const []const u8, splat: usize) Writer.Error!usize {
+        // Empty data == pure flush; the splat pattern lives at the last
+        // element so we must early-return before indexing.
+        if (data.len == 0) return 0;
+
         var consumed: usize = 0;
         if (data.len > 1) for (data[0 .. data.len - 1]) |chunk| {
             if (chunk.len == 0) continue;

--- a/src/terminal/platform/windows.zig
+++ b/src/terminal/platform/windows.zig
@@ -2,6 +2,7 @@
 //! Provides terminal control for Windows systems.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const windows = std.os.windows;
 const ansi = @import("../ansi.zig");
 
@@ -194,7 +195,7 @@ pub fn disableRawMode(state: *State) void {
 }
 
 /// Enter alternate screen buffer
-pub fn enterAltScreen(state: *State, writer: anytype) !void {
+pub fn enterAltScreen(state: *State, writer: *Writer) !void {
     if (state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_enter);
@@ -202,7 +203,7 @@ pub fn enterAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Exit alternate screen buffer
-pub fn exitAltScreen(state: *State, writer: anytype) !void {
+pub fn exitAltScreen(state: *State, writer: *Writer) !void {
     if (!state.in_alt_screen) return;
 
     try writer.writeAll(ansi.alt_screen_exit);
@@ -210,7 +211,7 @@ pub fn exitAltScreen(state: *State, writer: anytype) !void {
 }
 
 /// Enable mouse tracking
-pub fn enableMouse(state: *State, writer: anytype) !void {
+pub fn enableMouse(state: *State, writer: *Writer) !void {
     if (state.mouse_enabled) return;
 
     // Enable mouse input in console mode
@@ -227,7 +228,7 @@ pub fn enableMouse(state: *State, writer: anytype) !void {
 }
 
 /// Disable mouse tracking
-pub fn disableMouse(state: *State, writer: anytype) !void {
+pub fn disableMouse(state: *State, writer: *Writer) !void {
     if (!state.mouse_enabled) return;
 
     try writer.writeAll("\x1b[?1006l\x1b[?1003l");

--- a/src/terminal/screen.zig
+++ b/src/terminal/screen.zig
@@ -2,6 +2,7 @@
 //! Provides double-buffering to minimize flickering and optimize updates.
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const ansi = @import("ansi.zig");
 const unicode = @import("../unicode.zig");
 
@@ -161,7 +162,7 @@ pub const Screen = struct {
     }
 
     /// Render screen differences to the writer
-    pub fn renderDiff(self: *const Screen, prev: *const Screen, writer: anytype) !void {
+    pub fn renderDiff(self: *const Screen, prev: *const Screen, writer: *Writer) !void {
         var last_x: u16 = 0;
         var last_y: u16 = 0;
         var need_move = true;
@@ -215,7 +216,7 @@ pub const Screen = struct {
     }
 
     /// Render entire screen to writer
-    pub fn render(self: *const Screen, writer: anytype) !void {
+    pub fn render(self: *const Screen, writer: *Writer) !void {
         try writer.writeAll(ansi.cursor_home);
         try writer.writeAll(ansi.reset);
 
@@ -252,7 +253,7 @@ pub const Screen = struct {
         try writer.writeAll(ansi.reset);
     }
 
-    fn applyStyle(writer: anytype, current: *Cell, new: Cell) !void {
+    fn applyStyle(writer: *Writer, current: *Cell, new: Cell) !void {
         var needs_reset = false;
 
         // Check if we need to reset (turning off attributes)

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -1830,6 +1830,11 @@ pub const Terminal = struct {
                 io_w.end = 0;
             }
 
+            // The std.Io.Writer.VTable contract treats data.len == 0 as a
+            // pure flush; the splat pattern lives at data[data.len - 1] so we
+            // must early-return before indexing.
+            if (data.len == 0) return 0;
+
             var consumed: usize = 0;
             if (data.len > 1) {
                 for (data[0 .. data.len - 1]) |chunk| {

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -1851,7 +1851,7 @@ pub const Terminal = struct {
 
         fn sinkAll(self: *Writer, bytes: []const u8) std.Io.Writer.Error!void {
             if (is_wasm) {
-                _ = platform.WasmWriter.write(&platform.wasm_writer_instance, bytes) catch return error.WriteFailed;
+                try platform.wasm_writer_instance.writer.writeAll(bytes);
             } else {
                 self.file.writeAll(bytes) catch return error.WriteFailed;
             }

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -2,6 +2,7 @@
 //! Handles raw mode, alternate screen, mouse tracking, and input/output.
 
 const std = @import("std");
+const FixedWriter = std.Io.Writer.fixed;
 const builtin = @import("builtin");
 pub const ansi = @import("ansi.zig");
 pub const screen = @import("screen.zig");
@@ -261,10 +262,8 @@ pub const Config = struct {
 pub const Terminal = struct {
     state: platform.State,
     config: Config,
-    stdout: std.fs.File,
     stdin: std.fs.File,
-    write_buffer: [4096]u8 = undefined,
-    write_pos: usize = 0,
+    out: Writer,
     pending_input: [8192]u8 = undefined,
     pending_input_len: usize = 0,
     unicode_width_caps: UnicodeWidthCapabilities = .{},
@@ -276,8 +275,8 @@ pub const Terminal = struct {
         var term: Terminal = if (is_wasm) .{
             .state = state,
             .config = config,
-            .stdout = undefined,
             .stdin = undefined,
+            .out = .init({}),
         } else blk: {
             const stdout = config.output orelse std.fs.File.stdout();
             const stdin = config.input orelse std.fs.File.stdin();
@@ -285,17 +284,17 @@ pub const Terminal = struct {
             // Apply custom fd overrides
             if (builtin.os.tag != .windows) {
                 if (config.input) |inp| state.stdin_fd = inp.handle;
-                if (config.output) |out| state.stdout_fd = out.handle;
+                if (config.output) |o| state.stdout_fd = o.handle;
             } else {
                 if (config.input) |inp| state.stdin_handle = inp.handle;
-                if (config.output) |out| state.stdout_handle = out.handle;
+                if (config.output) |o| state.stdout_handle = o.handle;
             }
 
             break :blk .{
                 .state = state,
                 .config = config,
-                .stdout = stdout,
                 .stdin = stdin,
+                .out = .init(stdout),
             };
         };
 
@@ -393,15 +392,9 @@ pub const Terminal = struct {
         platform.disableRawMode(&self.state);
     }
 
-    /// Write bytes to internal buffer
+    /// Write bytes through the buffered terminal writer.
     fn writeBytes(self: *Terminal, bytes: []const u8) !void {
-        for (bytes) |byte| {
-            if (self.write_pos >= self.write_buffer.len) {
-                try self.flush();
-            }
-            self.write_buffer[self.write_pos] = byte;
-            self.write_pos += 1;
-        }
+        try self.writer().writeAll(bytes);
     }
 
     /// Get terminal size
@@ -435,26 +428,15 @@ pub const Terminal = struct {
         return platform.checkResize();
     }
 
-    /// Get a simple writer interface
-    pub fn writer(self: *Terminal) Writer {
-        return Writer{ .terminal = self };
+    /// Get a Writer interface.
+    pub fn writer(self: *Terminal) *std.Io.Writer {
+        self.out.bind();
+        return &self.out.writer;
     }
 
-    /// Flush output buffer
+    /// Flush buffered terminal output to the underlying sink.
     pub fn flush(self: *Terminal) !void {
-        if (self.write_pos > 0) {
-            if (is_wasm) {
-                platform.WasmWriter.write(&platform.wasm_writer_instance, self.write_buffer[0..self.write_pos]) catch {};
-            } else {
-                self.stdout.writeAll(self.write_buffer[0..self.write_pos]) catch |err| {
-                    return switch (err) {
-                        error.WouldBlock => error.WouldBlock,
-                        else => error.BrokenPipe,
-                    };
-                };
-            }
-            self.write_pos = 0;
-        }
+        try self.writer().flush();
     }
 
     /// Clear the screen
@@ -627,8 +609,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or image_data.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=T,t=d,f={d}", .{@intFromEnum(options.format)});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -642,7 +623,7 @@ pub const Terminal = struct {
         if (options.pixel_width) |pw| try params_writer.print(",s={d}", .{pw});
         if (options.pixel_height) |ph| try params_writer.print(",v={d}", .{ph});
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), image_data);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), image_data);
         return true;
     }
 
@@ -652,8 +633,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or path.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("a=T,t=f,f=100");
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -665,7 +645,7 @@ pub const Terminal = struct {
         if (options.z_index) |z| try params_writer.print(",z={d}", .{z});
         if (options.unicode_placeholder) try params_writer.writeAll(",U=1");
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), path);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), path);
         return true;
     }
 
@@ -675,8 +655,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics or payload.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=t,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -695,7 +674,7 @@ pub const Terminal = struct {
             },
         }
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), payload);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), payload);
         return true;
     }
 
@@ -705,13 +684,12 @@ pub const Terminal = struct {
         if (!fileExists(path)) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=t,t=f,f=100,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
 
-        try self.sendKittyGraphicsPayload(stream.getWritten(), path);
+        try self.sendKittyGraphicsPayload(params_writer.buffered(), path);
         return true;
     }
 
@@ -720,8 +698,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.print("a=p,i={d}", .{options.image_id});
         if (options.quiet) try params_writer.writeAll(",q=2");
@@ -733,7 +710,7 @@ pub const Terminal = struct {
         if (options.unicode_placeholder) try params_writer.writeAll(",U=1");
 
         // Virtual placement has no payload.
-        try ansi.kittyGraphics(self.writer(), stream.getWritten(), "");
+        try ansi.kittyGraphics(self.writer(), params_writer.buffered(), "");
         return true;
     }
 
@@ -742,8 +719,7 @@ pub const Terminal = struct {
         if (!self.image_caps.kitty_graphics) return false;
 
         var params_buf: [128]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("a=d,q=2");
         switch (target) {
@@ -752,7 +728,7 @@ pub const Terminal = struct {
             .all => try params_writer.writeAll(",d=A"),
         }
 
-        try ansi.kittyGraphics(self.writer(), stream.getWritten(), "");
+        try ansi.kittyGraphics(self.writer(), params_writer.buffered(), "");
         return true;
     }
 
@@ -767,8 +743,7 @@ pub const Terminal = struct {
         const stat = try file.stat();
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("inline=1");
         if (options.width_cells) |cols| try params_writer.print(";width={d}", .{cols});
@@ -784,7 +759,7 @@ pub const Terminal = struct {
             try params_writer.print(";name={s}", .{file_name_b64});
         }
 
-        try self.sendIterm2InlineImagePayload(stream.getWritten(), &file, stat.size);
+        try self.sendIterm2InlineImagePayload(params_writer.buffered(), &file, stat.size);
         return true;
     }
 
@@ -794,8 +769,7 @@ pub const Terminal = struct {
         if (!self.image_caps.iterm2_inline_image or data.len == 0) return false;
 
         var params_buf: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&params_buf);
-        const params_writer = stream.writer();
+        var params_writer = FixedWriter(&params_buf);
 
         try params_writer.writeAll("inline=1");
         if (options.width_cells) |cols| try params_writer.print(";width={d}", .{cols});
@@ -804,7 +778,7 @@ pub const Terminal = struct {
         if (!options.move_cursor) try params_writer.writeAll(";doNotMoveCursor=1");
         try params_writer.print(";size={d}", .{data.len});
 
-        try self.sendIterm2InlineImageDataPayload(stream.getWritten(), data);
+        try self.sendIterm2InlineImageDataPayload(params_writer.buffered(), data);
         return true;
     }
 
@@ -1823,18 +1797,64 @@ pub const Terminal = struct {
         return std.mem.indexOf(u8, value, needle) != null;
     }
 
-    /// Simple writer struct for compatibility
+    /// Buffered writer that exposes a `std.Io.Writer` interface and drains to
+    /// the terminal's output sink (stdout file, or the wasm host on wasm).
     pub const Writer = struct {
-        terminal: *Terminal,
+        file: if (is_wasm) void else std.fs.File,
+        buffer: [4096]u8 = undefined,
+        writer: std.Io.Writer,
 
-        pub fn writeAll(self: Writer, bytes: []const u8) !void {
-            try self.terminal.writeBytes(bytes);
+        const vtable: std.Io.Writer.VTable = .{ .drain = drain };
+
+        pub fn init(file: if (is_wasm) void else std.fs.File) Writer {
+            return .{
+                .file = file,
+                .writer = .{ .vtable = &vtable, .buffer = &.{} },
+            };
         }
 
-        pub fn print(self: Writer, comptime fmt: []const u8, args: anytype) !void {
-            var buf: [256]u8 = undefined;
-            const result = std.fmt.bufPrint(&buf, fmt, args) catch return;
-            try self.terminal.writeBytes(result);
+        /// Wires the `std.Io.Writer` to the local buffer. Called by the
+        /// containing `Terminal` whenever it hands the writer out, so the
+        /// buffer pointer stays valid even if the `Terminal` was moved.
+        /// `writer.end` is preserved across moves, so re-binding is safe.
+        pub fn bind(self: *Writer) void {
+            self.writer.buffer = &self.buffer;
+        }
+
+        fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+            const self: *Writer = @fieldParentPtr("writer", io_w);
+
+            const buffered = io_w.buffered();
+            if (buffered.len != 0) {
+                try self.sinkAll(buffered);
+                io_w.end = 0;
+            }
+
+            var consumed: usize = 0;
+            if (data.len > 1) {
+                for (data[0 .. data.len - 1]) |chunk| {
+                    if (chunk.len == 0) continue;
+                    try self.sinkAll(chunk);
+                    consumed += chunk.len;
+                }
+            }
+
+            const pattern = data[data.len - 1];
+            if (pattern.len > 0 and splat > 0) {
+                var i: usize = 0;
+                while (i < splat) : (i += 1) try self.sinkAll(pattern);
+                consumed += pattern.len * splat;
+            }
+
+            return consumed;
+        }
+
+        fn sinkAll(self: *Writer, bytes: []const u8) std.Io.Writer.Error!void {
+            if (is_wasm) {
+                _ = platform.WasmWriter.write(&platform.wasm_writer_instance, bytes) catch return error.WriteFailed;
+            } else {
+                self.file.writeAll(bytes) catch return error.WriteFailed;
+            }
         }
     };
 };

--- a/tests/accessibility_tests.zig
+++ b/tests/accessibility_tests.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 const zz = @import("zigzag");
 
 test "checkContrast white on black is AAA" {
-    const level = zz.a11y.checkContrast(zz.Color.white(), zz.Color.black());
+    const level = zz.a11y.checkContrast(.white, .black);
     try testing.expectEqual(zz.ContrastLevel.aaa, level);
 }
 
@@ -15,25 +15,25 @@ test "checkContrast similar colors fail" {
 }
 
 test "meetsAA white on dark blue" {
-    const fg = zz.Color.white();
+    const fg = zz.Color.white;
     const bg = zz.Color.fromRgb(0, 0, 100);
     try testing.expect(zz.a11y.meetsAA(fg, bg));
 }
 
 test "meetsAAA white on black" {
-    try testing.expect(zz.a11y.meetsAAA(zz.Color.white(), zz.Color.black()));
+    try testing.expect(zz.a11y.meetsAAA(.white, .black));
 }
 
 test "suggestForeground picks white for dark bg" {
     const bg = zz.Color.fromRgb(20, 20, 20);
     const suggested = zz.a11y.suggestForeground(bg);
-    try testing.expectEqual(zz.Color.white(), suggested);
+    try testing.expectEqual(zz.Color.white, suggested);
 }
 
 test "suggestForeground picks black for light bg" {
     const bg = zz.Color.fromRgb(240, 240, 240);
     const suggested = zz.a11y.suggestForeground(bg);
-    try testing.expectEqual(zz.Color.black(), suggested);
+    try testing.expectEqual(zz.Color.black, suggested);
 }
 
 test "Role label" {

--- a/tests/animation_tests.zig
+++ b/tests/animation_tests.zig
@@ -22,8 +22,8 @@ test "Easing ease_out ends slow" {
 
 test "Easing boundaries" {
     const easings = [_]zz.Easing{
-        .linear,     .ease_in,         .ease_out,
-        .ease_in_out, .ease_in_cubic, .ease_out_cubic,
+        .linear,            .ease_in,       .ease_out,
+        .ease_in_out,       .ease_in_cubic, .ease_out_cubic,
         .ease_in_out_cubic, .bounce,
     };
     for (easings) |e| {
@@ -148,7 +148,7 @@ test "lerp clamps t" {
 }
 
 test "tweenColor interpolates" {
-    const c = zz.tweenColor(zz.Color.red(), zz.Color.blue(), 0.5);
+    const c = zz.tweenColor(.red, .blue, 0.5);
     const rgb = c.toRgb();
     try testing.expect(rgb != null);
 }

--- a/tests/input_tests.zig
+++ b/tests/input_tests.zig
@@ -1,6 +1,7 @@
 //! Input handling tests
 
 const std = @import("std");
+const Writer = std.Io.Writer;
 const testing = std.testing;
 const zz = @import("zigzag");
 
@@ -138,11 +139,11 @@ test "KeyEvent format" {
         .modifiers = .{ .ctrl = true },
     };
 
-    var buf = std.array_list.Managed(u8).init(allocator);
+    var buf: Writer.Allocating = .init(allocator);
     defer buf.deinit();
 
-    try event.format("", .{}, buf.writer());
-    try testing.expectEqualStrings("ctrl+a", buf.items);
+    try event.format("", .{}, &buf.writer);
+    try testing.expectEqualStrings("ctrl+a", buf.written());
 }
 
 test "parseAll multiple keys" {

--- a/tests/modal_tests.zig
+++ b/tests/modal_tests.zig
@@ -328,8 +328,8 @@ test "backdrop presets render without error" {
         Modal.Backdrop.shade_light,
         Modal.Backdrop.shade_medium,
         Modal.Backdrop.shade_dense,
-        Modal.Backdrop.solid(zz.Color.blue()),
-        Modal.Backdrop.custom("*", zz.Color.red(), zz.Color.black()),
+        Modal.Backdrop.solid(.blue),
+        Modal.Backdrop.custom("*", .red, .black),
     };
 
     for (presets) |preset| {

--- a/tests/slider_tests.zig
+++ b/tests/slider_tests.zig
@@ -99,7 +99,7 @@ test "Slider view renders" {
 test "Slider view with gradient" {
     var s = zz.Slider.init(0, 100);
     s.setValue(50);
-    s.setGradient(zz.Color.red(), zz.Color.green());
+    s.setGradient(.red, .green);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/style_tests.zig
+++ b/tests/style_tests.zig
@@ -22,10 +22,10 @@ test "Color.hex parsing" {
 }
 
 test "Color basic colors" {
-    const red = zz.Color.red();
+    const red = zz.Color.red;
     try testing.expect(red == .ansi);
 
-    const cyan = zz.Color.cyan();
+    const cyan = zz.Color.cyan;
     try testing.expect(cyan == .ansi);
 
     const rgb = zz.Color.fromRgb(100, 150, 200);
@@ -38,8 +38,8 @@ test "Color basic colors" {
 test "Style builder pattern" {
     var style = zz.Style{};
     style = style.bold(true);
-    style = style.fg(zz.Color.red());
-    style = style.bg(zz.Color.black());
+    style = style.fg(.red);
+    style = style.bg(.black);
     style = style.paddingAll(1);
     style = style.marginAll(2);
 
@@ -55,7 +55,7 @@ test "Style render" {
 
     var style = zz.Style{};
     style = style.bold(true);
-    style = style.fg(zz.Color.cyan());
+    style = style.fg(.cyan);
 
     const result = try style.render(allocator, "Hello");
     defer allocator.free(result);
@@ -70,7 +70,7 @@ test "Style render keeps internal newlines but no trailing newline" {
     const allocator = testing.allocator;
 
     var style = zz.Style{};
-    style = style.fg(zz.Color.cyan());
+    style = style.fg(.cyan);
 
     const result = try style.render(allocator, "A\nB");
     defer allocator.free(result);
@@ -80,18 +80,18 @@ test "Style render keeps internal newlines but no trailing newline" {
 }
 
 test "Border styles exist" {
-    _ = zz.Border.normal;
-    _ = zz.Border.rounded;
-    _ = zz.Border.double;
-    _ = zz.Border.thick;
-    _ = zz.Border.ascii;
-    _ = zz.Border.none;
+    _ = zz.border.BorderChars.normal;
+    _ = zz.border.BorderChars.rounded;
+    _ = zz.border.BorderChars.double;
+    _ = zz.border.BorderChars.thick;
+    _ = zz.border.BorderChars.ascii;
+    _ = zz.border.BorderChars.none;
 }
 
 test "Style with border" {
     var style = zz.Style{};
-    style = style.borderAll(zz.Border.rounded);
-    style = style.borderForeground(zz.Color.cyan());
+    style = style.borderAll(.rounded);
+    style = style.borderForeground(.cyan);
 
     try testing.expect(style.border_sides.top);
     try testing.expect(style.border_sides.bottom);

--- a/tests/theme_tests.zig
+++ b/tests/theme_tests.zig
@@ -32,7 +32,7 @@ test "Palette all presets are valid" {
 }
 
 test "Theme fromPalette derives component themes" {
-    const t = zz.Theme.fromPalette(zz.Palette.dracula);
+    const t = zz.Theme.fromPalette(.dracula);
 
     // Text theme inherits from palette
     const p = zz.Palette.dracula;
@@ -63,7 +63,7 @@ test "AdaptivePalette resolves correctly" {
 }
 
 test "Theme styleWith creates inline style" {
-    const s = zz.Theme.styleWith(zz.Color.red());
+    const s = zz.Theme.styleWith(.red);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -73,7 +73,7 @@ test "Theme styleWith creates inline style" {
 }
 
 test "Theme boldStyleWith creates bold inline style" {
-    const s = zz.Theme.boldStyleWith(zz.Color.green());
+    const s = zz.Theme.boldStyleWith(.green);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -111,27 +111,27 @@ test "ThemeManager setPalette with custom palette" {
     var tm = zz.ThemeManager.init();
 
     const custom = zz.Palette{
-        .primary = zz.Color.red(),
-        .secondary = zz.Color.blue(),
-        .accent = zz.Color.green(),
-        .background = zz.Color.black(),
-        .surface = zz.Color.black(),
-        .overlay = zz.Color.black(),
-        .foreground = zz.Color.white(),
-        .muted = zz.Color.gray(14),
-        .subtle = zz.Color.gray(10),
-        .success = zz.Color.green(),
-        .warning = zz.Color.yellow(),
-        .danger = zz.Color.red(),
-        .info = zz.Color.cyan(),
-        .border_color = zz.Color.gray(12),
-        .border_focus = zz.Color.red(),
-        .highlight = zz.Color.gray(5),
-        .highlight_text = zz.Color.white(),
+        .primary = .red,
+        .secondary = .blue,
+        .accent = .green,
+        .background = .black,
+        .surface = .black,
+        .overlay = .black,
+        .foreground = .white,
+        .muted = .gray(14),
+        .subtle = .gray(10),
+        .success = .green,
+        .warning = .yellow,
+        .danger = .red,
+        .info = .cyan,
+        .border_color = .gray(12),
+        .border_focus = .red,
+        .highlight = .gray(5),
+        .highlight_text = .white,
     };
 
     tm.setPalette(custom);
-    try testing.expectEqual(zz.Color.red(), tm.current.palette.primary);
+    try testing.expectEqual(zz.Color.red, tm.current.palette.primary);
 }
 
 test "ThemeManager builtinCount" {
@@ -159,8 +159,8 @@ test "Theme can be overridden per-component" {
     var t = zz.Theme.fromPalette(zz.Palette.nord);
 
     // Override list cursor color
-    t.list.cursor_fg = zz.Color.red();
-    try testing.expectEqual(zz.Color.red(), t.list.cursor_fg);
+    t.list.cursor_fg = zz.Color.red;
+    try testing.expectEqual(zz.Color.red, t.list.cursor_fg);
 
     // Other fields unchanged
     try testing.expectEqual(zz.Palette.nord.foreground, t.list.item_fg);

--- a/tests/toast_tests.zig
+++ b/tests/toast_tests.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Writer = std.Io.Writer;
 const testing = std.testing;
 const zz = @import("zigzag");
 
@@ -212,7 +213,7 @@ fn rightEdgeDisplay(line: []const u8) usize {
 }
 
 fn stripAnsi(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-    var result = std.array_list.Managed(u8).init(allocator);
+    var result: std.array_list.Managed(u8) = .init(allocator);
     errdefer result.deinit();
 
     var i: usize = 0;

--- a/tests/viewport_tests.zig
+++ b/tests/viewport_tests.zig
@@ -49,7 +49,7 @@ test "viewport slices ANSI styled content without corrupting output" {
     defer viewport.deinit();
 
     var s = zz.Style{};
-    s = s.fg(zz.Color.cyan());
+    s = s.fg(.cyan);
     s = s.inline_style(true);
     const styled = try s.render(allocator, "abcdef");
     defer allocator.free(styled);


### PR DESCRIPTION
Made colors comptime values and moved border defaults into the border struct itself so they are usable with result location semantics.

There is a zz.newStyle() in root, I can remove that if you don't want it but I already had it rather ingrained. There also is a renderComptime in Style that allows rendering comptime known values without allocations, something we do a lot of:
```zig
const style = comptime zz.newStyle().
    .fg(.blue)
    .renderComptime("help text");
```