### PR TITLE
comptime color and border values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,8 @@ A delightful TUI framework for Zig, inspired by [Bubble Tea](https://github.com/
 ## Installation
 
 Add ZigZag to your `build.zig.zon`:
-
-```zig
-.dependencies = .{
-    .zigzag = .{
-        .url = "https://github.com/meszmate/zigzag/archive/refs/heads/main.tar.gz",
-        .hash = "...",
-    },
-},
-// To pin a specific version instead:
-// .url = "https://github.com/meszmate/zigzag/archive/refs/tags/v0.1.0.tar.gz",
+```sh
+zig fetch --save git+https://github.com/meszmate/zigzag#main
 ```
 
 Then in your `build.zig`:
@@ -82,14 +74,14 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const style = (zz.Style{}).bold(true).fg(zz.Color.cyan());
+        const style = zz.newStyle().bold(true).fg(.cyan);
         const text = std.fmt.allocPrint(ctx.allocator, "Count: {d}\n\nPress q to quit", .{self.count}) catch "Error";
         return style.render(ctx.allocator, text) catch text;
     }
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
     defer _ = gpa.deinit();
 
     var program = try zz.Program(Model).init(gpa.allocator());
@@ -168,18 +160,18 @@ return .{ .delete_image = .all };              // Free all cached images
 The styling system is inspired by Lipgloss:
 
 ```zig
-const style = (zz.Style{})
+const style = zz.newStyle()
     .bold(true)
     .italic(true)
-    .fg(zz.Color.cyan())
-    .bg(zz.Color.black())
+    .fg(.cyan)
+    .bg(.black)
     .paddingAll(1)
     .marginAll(2)
-    .marginBackground(zz.Color.gray(3))
-    .borderAll(zz.Border.rounded)
-    .borderForeground(zz.Color.magenta())
-    .borderTopForeground(zz.Color.cyan())    // Per-side border colors
-    .borderBottomForeground(zz.Color.green())
+    .marginBackground(.gray(3))
+    .borderAll(.rounded)
+    .borderForeground(.magenta)
+    .borderTopForeground(.cyan)    // Per-side border colors
+    .borderBottomForeground(.green)
     .tabWidth(4)
     .width(40)
     .alignH(.center);
@@ -188,14 +180,14 @@ const output = try style.render(allocator, "Hello, World!");
 // render() does not append an implicit trailing '\n'
 
 // Text transforms
-const upper_style = (zz.Style{}).transform(zz.transforms.uppercase);
+const upper_style = zz.newStyle().transform(.uppercase);
 const shouting = try upper_style.render(allocator, "hello"); // "HELLO"
 
 // Inline mode is useful when embedding block-styled output in a single line
-const inline = (zz.Style{}).fg(zz.Color.cyan()).inline_style(true);
+const inline = zz.newStyle().fg(.cyan).inline_style(true);
 
 // Whitespace formatting controls
-const ws_style = (zz.Style{})
+const ws_style = zz.newStyle()
     .underline(true)
     .setUnderlineSpaces(true)      // Underline extends through spaces
     .setColorWhitespace(false);     // Don't apply bg color to whitespace
@@ -204,11 +196,11 @@ const ws_style = (zz.Style{})
 const derived = style.unsetBold().unsetPadding().unsetBorder();
 
 // Style inheritance (unset values inherit from parent)
-const child = (zz.Style{}).fg(zz.Color.red()).inherit(style);
+const child = zz.newStyle().fg(.red).inherit(style);
 
 // Style ranges - apply different styles to byte ranges
 const ranges = &[_]zz.StyleRange{
-    .{ .start = 0, .end = 5, .s = (zz.Style{}).bold(true) },
+    .{ .start = 0, .end = 5, .s = zz.newStyle().bold(true) },
 };
 const ranged = try zz.renderWithRanges(allocator, "Hello World", ranges);
 
@@ -220,9 +212,9 @@ const highlighted = try zz.renderWithHighlights(allocator, "hello", &.{0, 2}, hi
 
 ```zig
 // Basic ANSI colors
-zz.Color.red()
-zz.Color.cyan()
-zz.Color.brightGreen()
+zz.Color.red
+zz.Color.cyan
+zz.Color.brightGreen
 
 // 256-color palette
 zz.Color.color256(123)
@@ -234,9 +226,9 @@ zz.Color.hex("#FF8040")
 
 // Adaptive colors (change based on terminal capabilities)
 const adaptive = zz.AdaptiveColor{
-    .true_color = zz.Color.hex("#FF8040"),
-    .color_256 = zz.Color.color256(208),
-    .ansi = zz.Color.red(),
+    .true_color = .hex("#FF8040"),
+    .color_256 = .color256(208),
+    .ansi = .red,
 };
 const resolved = adaptive.resolve(ctx.true_color, ctx.color_256);
 
@@ -245,7 +237,7 @@ const resolved = adaptive.resolve(ctx.true_color, ctx.color_256);
 // ctx.is_dark_background: bool
 
 // Color interpolation (for gradients)
-const mid = zz.interpolateColor(zz.Color.red(), zz.Color.green(), 0.5);
+const mid = zz.interpolateColor(.red, .green, 0.5);
 ```
 
 ### Borders
@@ -314,8 +306,8 @@ try viewport.setContent(long_text);
 viewport.setWrap(true);
 viewport.setScrollbarChars("·", "█");
 viewport.setScrollbarStyle(
-    (zz.Style{}).fg(zz.Color.gray(8)).inline_style(true),
-    (zz.Style{}).fg(zz.Color.cyan()).inline_style(true),
+    zz.newStyle().fg(.gray(8)).inline_style(true),
+    zz.newStyle().fg(.cyan).inline_style(true),
 );
 viewport.handleKey(key_event);  // Supports j/k, Page Up/Down, etc.
 ```
@@ -327,7 +319,7 @@ Progress bar with optional color gradients:
 ```zig
 var progress = zz.Progress.init();
 progress.setWidth(40);
-progress.setGradient(zz.Color.hex("#FF6B6B"), zz.Color.hex("#4ECDC4"));
+progress.setGradient(.hex("#FF6B6B"), .hex("#4ECDC4"));
 progress.setPercent(75);
 const bar = try progress.view(allocator);
 ```
@@ -398,7 +390,7 @@ Mini chart using Unicode block elements with configurable bucketing, ranges, and
 var spark = zz.Sparkline.init(allocator);
 spark.setWidth(20);
 spark.setSummary(.average);
-spark.setGradient(zz.Color.hex("#F97316"), zz.Color.hex("#22C55E"));
+spark.setGradient(.hex("#F97316"), .hex("#22C55E"));
 try spark.push(10.0);
 try spark.push(25.0);
 try spark.push(15.0);
@@ -421,7 +413,7 @@ chart.x_axis = .{ .title = "Time", .tick_count = 5, .show_grid = true };
 chart.y_axis = .{ .title = "CPU", .tick_count = 5, .show_grid = true };
 
 var dataset = try zz.ChartDataset.init(allocator, "load");
-dataset.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+dataset.setStyle(zz.newStyle().fg(.cyan).bold(true));
 dataset.setShowPoints(true);
 dataset.setInterpolation(.monotone_cubic);
 dataset.setInterpolationSteps(10);
@@ -443,8 +435,8 @@ Vertical or horizontal bar chart with labels, values, and positive/negative base
 var bars = zz.BarChart.init(allocator);
 bars.setOrientation(.horizontal);
 bars.show_values = true;
-try bars.addBar(try zz.Bar.init(allocator, "api", 31));
-try bars.addBar(try zz.Bar.init(allocator, "db", -12));
+try bars.addBar(try .init(allocator, "api", 31));
+try bars.addBar(try .init(allocator, "db", -12));
 const view = try bars.view(allocator);
 ```
 
@@ -459,8 +451,8 @@ defer canvas.deinit();
 canvas.setSize(24, 10);
 canvas.setMarker(.braille);
 canvas.setRanges(.{ .min = -1, .max = 1 }, .{ .min = -1, .max = 1 });
-try canvas.drawLineStyled(-1, -1, 1, 1, (zz.Style{}).fg(zz.Color.yellow()), null);
-try canvas.drawPointStyled(0.25, 0.7, (zz.Style{}).fg(zz.Color.cyan()), null);
+try canvas.drawLineStyled(-1, -1, 1, 1, zz.newStyle().fg(.yellow), null);
+try canvas.drawPointStyled(0.25, 0.7, zz.newStyle().fg(.cyan), null);
 const view = try canvas.view(allocator);
 ```
 
@@ -578,8 +570,8 @@ gauge.label = "CPU";
 gauge.full_char = "\xe2\x96\x88";   // Customizable fill character
 gauge.empty_char = "\xe2\x96\x91";  // Customizable empty character
 gauge.thresholds = &.{
-    .{ .value = 80, .color = zz.Color.yellow() },
-    .{ .value = 90, .color = zz.Color.red() },
+    .{ .value = 80, .color = .yellow },
+    .{ .value = 90, .color = .red },
 };
 const output = gauge.view(allocator);
 ```
@@ -615,7 +607,7 @@ cal.week_start_monday = true;
 cal.day_headers_mon = .{ "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su" }; // Customizable
 cal.month_names = .{ "Jan", "Feb", ... };  // Customizable
 cal.prev_symbol = "\xe2\x97\x80"; // Customizable nav symbols
-cal.addMarkedDate(25, zz.Color.red());
+cal.addMarkedDate(25, .red);
 cal.update(key_event);             // Arrows, Enter, PgUp/PgDn, Shift+L/R
 const output = cal.view(allocator);
 ```
@@ -883,9 +875,9 @@ var fg: zz.FocusGroup(3) = .{ .wrap = false };
 
 // Custom focus ring colors
 const fs = zz.FocusStyle{
-    .focused_border_fg = zz.Color.green(),
-    .blurred_border_fg = zz.Color.gray(8),
-    .border_chars = zz.Border.double,
+    .focused_border_fg = .green,
+    .blurred_border_fg = .gray(8),
+    .border_chars = .double,
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const Model = struct {
     }
 
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const style = zz.newStyle().bold(true).fg(.cyan);
+        const style = (zz.Style{}).bold(true).fg(.cyan);
         const text = std.fmt.allocPrint(ctx.allocator, "Count: {d}\n\nPress q to quit", .{self.count}) catch "Error";
         return style.render(ctx.allocator, text) catch text;
     }
@@ -160,7 +160,7 @@ return .{ .delete_image = .all };              // Free all cached images
 The styling system is inspired by Lipgloss:
 
 ```zig
-const style = zz.newStyle()
+const style = (zz.Style{})
     .bold(true)
     .italic(true)
     .fg(.cyan)
@@ -180,14 +180,14 @@ const output = try style.render(allocator, "Hello, World!");
 // render() does not append an implicit trailing '\n'
 
 // Text transforms
-const upper_style = zz.newStyle().transform(.uppercase);
+const upper_style = (zz.Style{}).transform(.uppercase);
 const shouting = try upper_style.render(allocator, "hello"); // "HELLO"
 
 // Inline mode is useful when embedding block-styled output in a single line
-const inline = zz.newStyle().fg(.cyan).inline_style(true);
+const inline = (zz.Style{}).fg(.cyan).inline_style(true);
 
 // Whitespace formatting controls
-const ws_style = zz.newStyle()
+const ws_style = (zz.Style{})
     .underline(true)
     .setUnderlineSpaces(true)      // Underline extends through spaces
     .setColorWhitespace(false);     // Don't apply bg color to whitespace
@@ -196,11 +196,11 @@ const ws_style = zz.newStyle()
 const derived = style.unsetBold().unsetPadding().unsetBorder();
 
 // Style inheritance (unset values inherit from parent)
-const child = zz.newStyle().fg(.red).inherit(style);
+const child = (zz.Style{}).fg(.red).inherit(style);
 
 // Style ranges - apply different styles to byte ranges
 const ranges = &[_]zz.StyleRange{
-    .{ .start = 0, .end = 5, .s = zz.newStyle().bold(true) },
+    .{ .start = 0, .end = 5, .s = (zz.Style{}).bold(true) },
 };
 const ranged = try zz.renderWithRanges(allocator, "Hello World", ranges);
 
@@ -306,8 +306,8 @@ try viewport.setContent(long_text);
 viewport.setWrap(true);
 viewport.setScrollbarChars("·", "█");
 viewport.setScrollbarStyle(
-    zz.newStyle().fg(.gray(8)).inline_style(true),
-    zz.newStyle().fg(.cyan).inline_style(true),
+    (zz.Style{}).fg(.gray(8)).inline_style(true),
+    (zz.Style{}).fg(.cyan).inline_style(true),
 );
 viewport.handleKey(key_event);  // Supports j/k, Page Up/Down, etc.
 ```
@@ -413,7 +413,7 @@ chart.x_axis = .{ .title = "Time", .tick_count = 5, .show_grid = true };
 chart.y_axis = .{ .title = "CPU", .tick_count = 5, .show_grid = true };
 
 var dataset = try zz.ChartDataset.init(allocator, "load");
-dataset.setStyle(zz.newStyle().fg(.cyan).bold(true));
+dataset.setStyle((zz.Style{}).fg(.cyan).bold(true));
 dataset.setShowPoints(true);
 dataset.setInterpolation(.monotone_cubic);
 dataset.setInterpolationSteps(10);
@@ -451,8 +451,8 @@ defer canvas.deinit();
 canvas.setSize(24, 10);
 canvas.setMarker(.braille);
 canvas.setRanges(.{ .min = -1, .max = 1 }, .{ .min = -1, .max = 1 });
-try canvas.drawLineStyled(-1, -1, 1, 1, zz.newStyle().fg(.yellow), null);
-try canvas.drawPointStyled(0.25, 0.7, zz.newStyle().fg(.cyan), null);
+try canvas.drawLineStyled(-1, -1, 1, 1, (zz.Style{}).fg(.yellow), null);
+try canvas.drawPointStyled(0.25, 0.7, (zz.Style{}).fg(.cyan), null);
 const view = try canvas.view(allocator);
 ```
 

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -22,14 +22,14 @@ const Model = struct {
 
     pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
         self.pairs = .{
-            .{ .name = "White on Black", .fg = zz.Color.white(), .bg = zz.Color.black() },
-            .{ .name = "Black on White", .fg = zz.Color.black(), .bg = zz.Color.white() },
-            .{ .name = "Cyan on Dark", .fg = zz.Color.cyan(), .bg = zz.Color.fromRgb(30, 30, 46) },
-            .{ .name = "Gray on Gray", .fg = zz.Color.fromRgb(120, 120, 120), .bg = zz.Color.fromRgb(140, 140, 140) },
-            .{ .name = "Yellow on White", .fg = zz.Color.yellow(), .bg = zz.Color.white() },
-            .{ .name = "Green on Black", .fg = zz.Color.green(), .bg = zz.Color.black() },
-            .{ .name = "Red on Dark Red", .fg = zz.Color.red(), .bg = zz.Color.fromRgb(60, 10, 10) },
-            .{ .name = "Blue on Blue", .fg = zz.Color.fromRgb(100, 100, 200), .bg = zz.Color.fromRgb(80, 80, 180) },
+            .{ .name = "White on Black", .fg = .white, .bg = .black },
+            .{ .name = "Black on White", .fg = .black, .bg = .white },
+            .{ .name = "Cyan on Dark", .fg = .cyan, .bg = .fromRgb(30, 30, 46) },
+            .{ .name = "Gray on Gray", .fg = .fromRgb(120, 120, 120), .bg = .fromRgb(140, 140, 140) },
+            .{ .name = "Yellow on White", .fg = .yellow, .bg = .white },
+            .{ .name = "Green on Black", .fg = .green, .bg = .black },
+            .{ .name = "Red on Dark Red", .fg = .red, .bg = .fromRgb(60, 10, 10) },
+            .{ .name = "Blue on Blue", .fg = .fromRgb(100, 100, 200), .bg = .fromRgb(80, 80, 180) },
         };
         self.selected = 0;
         return .none;
@@ -53,11 +53,11 @@ const Model = struct {
         const w = &result.writer;
 
         // Title
-        var title_s = zz.Style{};
-        title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.white());
-        title_s = title_s.inline_style(true);
-        const title = title_s.render(ctx.allocator, "Accessibility: WCAG Contrast Checker") catch "A11y Demo";
+        const title = zz.newStyle()
+            .bold(true)
+            .fg(.white)
+            .inline_style(true)
+            .render(ctx.allocator, "Accessibility: WCAG Contrast Checker") catch "A11y Demo";
         w.print("{s}\n\n", .{title}) catch {};
 
         // Table header
@@ -78,10 +78,10 @@ const Model = struct {
 
             // Level badge color
             const level_color: zz.Color = switch (level) {
-                .aaa => zz.Color.green(),
-                .aa => zz.Color.cyan(),
-                .aa_large => zz.Color.yellow(),
-                .fail => zz.Color.red(),
+                .aaa => .green,
+                .aa => .cyan,
+                .aa_large => .yellow,
+                .fail => .red,
             };
 
             // Row indicator
@@ -99,11 +99,11 @@ const Model = struct {
             w.print("{d:.1}:1   ", .{ratio}) catch {};
 
             // Level badge
-            var badge_s = zz.Style{};
-            badge_s = badge_s.fg(level_color);
-            badge_s = badge_s.bold(true);
-            badge_s = badge_s.inline_style(true);
-            const badge = badge_s.render(ctx.allocator, level_name) catch level_name;
+            const badge = zz.newStyle()
+                .fg(level_color)
+                .bold(true)
+                .inline_style(true)
+                .render(ctx.allocator, level_name) catch level_name;
             w.print("{s}", .{badge}) catch {};
             const badge_len = level_name.len;
             if (badge_len < 10) {
@@ -111,11 +111,11 @@ const Model = struct {
             }
 
             // Sample text with the actual colors
-            var sample_s = zz.Style{};
-            sample_s = sample_s.fg(pair.fg);
-            sample_s = sample_s.bg(pair.bg);
-            sample_s = sample_s.inline_style(true);
-            const sample = sample_s.render(ctx.allocator, " Sample Text ") catch "Sample";
+            const sample = zz.newStyle()
+                .fg(pair.fg)
+                .bg(pair.bg)
+                .inline_style(true)
+                .render(ctx.allocator, " Sample Text ") catch "Sample";
             w.print("{s}", .{sample}) catch {};
 
             w.writeByte('\n') catch {};
@@ -138,23 +138,23 @@ const Model = struct {
             },
         };
         const label_text = a11y_label.format(ctx.allocator) catch "?";
-        var label_s = zz.Style{};
-        label_s = label_s.fg(zz.Color.gray(14));
-        label_s = label_s.inline_style(true);
-        const label_rendered = label_s.render(ctx.allocator, label_text) catch label_text;
-        w.print("Screen reader: {s}\n", .{label_rendered}) catch {};
+        const label = zz.newStyle()
+            .fg(.gray(14))
+            .inline_style(true)
+            .render(ctx.allocator, label_text) catch label_text;
+        w.print("Screen reader: {s}\n", .{label}) catch {};
 
         // Suggested foreground
         const suggested = zz.a11y.suggestForeground(pair.bg);
-        const sugg_name: []const u8 = if (std.meta.eql(suggested, zz.Color.white())) "white" else "black";
+        const sugg_name: []const u8 = if (std.meta.eql(suggested, .white)) "white" else "black";
         w.print("Suggested foreground for this bg: {s}\n", .{sugg_name}) catch {};
 
         // Help
         w.writeAll("\n") catch {};
-        var help_s = zz.Style{};
-        help_s = help_s.fg(zz.Color.gray(12));
-        help_s = help_s.inline_style(true);
-        const help = help_s.render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";
+        const help = zz.newStyle()
+            .fg(.gray(12))
+            .inline_style(true)
+            .render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";
         w.writeAll(help) catch {};
 
         return result.toOwnedSlice() catch "Error";
@@ -162,8 +162,8 @@ const Model = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
 
     var program = try zz.Program(Model).init(gpa.allocator());
     defer program.deinit();

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -53,7 +53,7 @@ const Model = struct {
         const w = &result.writer;
 
         // Title
-        const title = zz.newStyle()
+        const title = (zz.Style{})
             .bold(true)
             .fg(.white)
             .inline_style(true)
@@ -99,7 +99,7 @@ const Model = struct {
             w.print("{d:.1}:1   ", .{ratio}) catch {};
 
             // Level badge
-            const badge = zz.newStyle()
+            const badge = (zz.Style{})
                 .fg(level_color)
                 .bold(true)
                 .inline_style(true)
@@ -111,7 +111,7 @@ const Model = struct {
             }
 
             // Sample text with the actual colors
-            const sample = zz.newStyle()
+            const sample = (zz.Style{})
                 .fg(pair.fg)
                 .bg(pair.bg)
                 .inline_style(true)
@@ -138,7 +138,7 @@ const Model = struct {
             },
         };
         const label_text = a11y_label.format(ctx.allocator) catch "?";
-        const label = zz.newStyle()
+        const label = (zz.Style{})
             .fg(.gray(14))
             .inline_style(true)
             .render(ctx.allocator, label_text) catch label_text;
@@ -151,7 +151,7 @@ const Model = struct {
 
         // Help
         w.writeAll("\n") catch {};
-        const help = zz.newStyle()
+        const help = (zz.Style{})
             .fg(.gray(12))
             .inline_style(true)
             .render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -156,7 +156,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
         const title_str = title.render(alloc, "ActionRegistry — one source of truth") catch "";
 

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -88,7 +88,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
 
@@ -101,7 +101,7 @@ const Model = struct {
         for (&self.tweens, self.easing_names) |*tw, name| {
             // Label
             var label_style = zz.Style{};
-            label_style = label_style.fg(zz.Color.cyan());
+            label_style = label_style.fg(zz.Color.cyan);
             label_style = label_style.inline_style(true);
             const label = std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name}) catch "";
             const styled_label = label_style.render(ctx.allocator, label) catch label;
@@ -112,7 +112,7 @@ const Model = struct {
             for (0..30) |i| {
                 if (i == pos) {
                     var dot_style = zz.Style{};
-                    dot_style = dot_style.fg(zz.Color.green());
+                    dot_style = dot_style.fg(zz.Color.green);
                     dot_style = dot_style.bold(true);
                     dot_style = dot_style.inline_style(true);
                     const dot = dot_style.render(ctx.allocator, "●") catch "o";
@@ -131,13 +131,13 @@ const Model = struct {
         // Color tween demo
         writer.writeAll("\n") catch {};
         var color_label_style = zz.Style{};
-        color_label_style = color_label_style.fg(zz.Color.cyan());
+        color_label_style = color_label_style.fg(zz.Color.cyan);
         color_label_style = color_label_style.inline_style(true);
         const color_label = color_label_style.render(ctx.allocator, "     Color tween: ") catch "";
         writer.writeAll(color_label) catch {};
 
         const ct = self.color_tween.value();
-        const color = zz.tweenColor(zz.Color.red(), zz.Color.cyan(), ct);
+        const color = zz.tweenColor(zz.Color.red, zz.Color.cyan, ct);
         var cs = zz.Style{};
         cs = cs.fg(color);
         cs = cs.bold(true);

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -100,16 +100,16 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var status_s = zz.Style{};
-        status_s = status_s.fg(zz.Color.yellow());
+        status_s = status_s.fg(zz.Color.yellow);
         status_s = status_s.inline_style(true);
 
         var box_s = zz.Style{};
         box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderForeground(zz.Color.cyan);
         box_s = box_s.paddingAll(1);
         box_s = box_s.width(45);
 

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -91,12 +91,12 @@ const Model = struct {
         const ty: i32 = @intFromFloat(self.ball_y);
 
         var trail_style = zz.Style{};
-        trail_style = trail_style.fg(zz.Color.cyan());
+        trail_style = trail_style.fg(zz.Color.cyan);
         trail_style = trail_style.inline_style(true);
         c.drawCircleStyled(tx, ty, 3, trail_style);
 
         var ball_style = zz.Style{};
-        ball_style = ball_style.fg(zz.Color.magenta());
+        ball_style = ball_style.fg(zz.Color.magenta);
         ball_style = ball_style.bold(true);
         ball_style = ball_style.inline_style(true);
         c.drawCircleStyled(tx, ty, 1, ball_style);
@@ -105,7 +105,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "BrailleCanvas — bouncing ball") catch "";
 

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -22,9 +22,9 @@ const Model = struct {
             .today_year = 2026,
         };
         // Mark some dates
-        self.cal.addMarkedDate(25, zz.Color.red());
-        self.cal.addMarkedDate(1, zz.Color.green());
-        self.cal.addMarkedDate(14, zz.Color.magenta());
+        self.cal.addMarkedDate(25, zz.Color.red);
+        self.cal.addMarkedDate(1, zz.Color.green);
+        self.cal.addMarkedDate(14, zz.Color.magenta);
         return .none;
     }
 
@@ -47,12 +47,12 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderForeground(zz.Color.cyan);
         box_style = box_style.paddingAll(1);
 
         const cal_view = self.cal.view(alloc);

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -33,18 +33,18 @@ const Model = struct {
         };
 
         var cpu = zz.ChartDataset.init(ctx.persistent_allocator, "CPU") catch unreachable;
-        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan).bold(true));
         cpu.setShowPoints(true);
         cpu.setInterpolation(.monotone_cubic);
         cpu.setInterpolationSteps(10);
 
         var mem = zz.ChartDataset.init(ctx.persistent_allocator, "Memory") catch unreachable;
-        mem.setStyle((zz.Style{}).fg(zz.Color.magenta()));
+        mem.setStyle((zz.Style{}).fg(zz.Color.magenta));
         mem.setInterpolation(.catmull_rom);
         mem.setInterpolationSteps(10);
 
         var backlog = zz.ChartDataset.init(ctx.persistent_allocator, "Backlog") catch unreachable;
-        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow()));
+        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow));
         backlog.setGraphType(.area);
         backlog.setInterpolation(.step_center);
         backlog.setFillBaseline(18.0);
@@ -66,8 +66,8 @@ const Model = struct {
         self.bars.setGap(0);
         self.bars.show_values = false;
         self.bars.label_style = (zz.Style{}).fg(zz.Color.gray(18)).inline_style(true);
-        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green()).inline_style(true);
-        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red()).inline_style(true);
+        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green).inline_style(true);
+        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red).inline_style(true);
         self.bars.axis_style = (zz.Style{}).fg(zz.Color.gray(10)).inline_style(true);
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "api", 31) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "db", -12) catch unreachable) catch unreachable;
@@ -225,7 +225,7 @@ const Model = struct {
         canvas.setRanges(.{ .min = -1.2, .max = 1.2 }, .{ .min = -1.2, .max = 1.2 });
 
         var point_style = zz.Style{};
-        point_style = point_style.fg(zz.Color.yellow());
+        point_style = point_style.fg(zz.Color.yellow);
         point_style = point_style.inline_style(true);
 
         for (0..64) |i| {
@@ -286,7 +286,7 @@ fn box(ctx: *const zz.Context, title: []const u8, body: []const u8) ![]const u8 
 
     var header_style = zz.Style{};
     header_style = header_style.bold(true);
-    header_style = header_style.fg(zz.Color.cyan());
+    header_style = header_style.fg(zz.Color.cyan);
     header_style = header_style.inline_style(true);
     const header = try header_style.render(ctx.allocator, title);
 
@@ -302,7 +302,7 @@ fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]c
 
     var value_style = zz.Style{};
     value_style = value_style.bold(true);
-    value_style = value_style.fg(zz.Color.white());
+    value_style = value_style.fg(zz.Color.white);
     value_style = value_style.inline_style(true);
     const rendered_value = try value_style.render(ctx.allocator, value);
 

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -83,12 +83,12 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
 
         var section_style = zz.Style{};
         section_style = section_style.bold(true);
-        section_style = section_style.fg(zz.Color.cyan());
+        section_style = section_style.fg(zz.Color.cyan);
         section_style = section_style.inline_style(true);
 
         const title = title_style.render(ctx.allocator, "Checkbox & Radio Example") catch "Title";

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -153,7 +153,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
 
         var info_style = zz.Style{};

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -75,7 +75,7 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var cv = zz.components.code_view.CodeView{};

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -85,7 +85,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Context Menu Example") catch "Context Menu";
 
@@ -97,7 +97,7 @@ const Model = struct {
             if (i == self.selected) {
                 var sel_style = zz.Style{};
                 sel_style = sel_style.bold(true);
-                sel_style = sel_style.fg(zz.Color.cyan());
+                sel_style = sel_style.fg(zz.Color.cyan);
                 sel_style = sel_style.inline_style(true);
                 const line = std.fmt.allocPrint(ctx.allocator, "  > {s}", .{item}) catch "";
                 const styled = sel_style.render(ctx.allocator, line) catch line;
@@ -111,7 +111,7 @@ const Model = struct {
 
         // Status
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.green());
+        status_style = status_style.fg(zz.Color.green);
         status_style = status_style.inline_style(true);
         const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;
 

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -41,7 +41,7 @@ const Model = struct {
         // Title style
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
 
         // Counter value style - changes color based on value
@@ -49,16 +49,16 @@ const Model = struct {
         counter_style = counter_style.bold(true);
         counter_style = counter_style.inline_style(true);
         counter_style = counter_style.fg(if (self.count > 0)
-            zz.Color.green()
+            zz.Color.green
         else if (self.count < 0)
-            zz.Color.red()
+            zz.Color.red
         else
-            zz.Color.white());
+            zz.Color.white);
 
         // Border style
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderForeground(zz.Color.cyan);
         box_style = box_style.paddingAll(1);
         box_style = box_style.alignH(.center);
 

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -142,18 +142,18 @@ const Model = struct {
     fn renderStats(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderForeground(zz.Color.cyan);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(25);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.cyan());
+        header_style = header_style.fg(zz.Color.cyan);
         header_style = header_style.inline_style(true);
 
         var value_style = zz.Style{};
         value_style = value_style.bold(true);
-        value_style = value_style.fg(zz.Color.white());
+        value_style = value_style.fg(zz.Color.white);
         value_style = value_style.inline_style(true);
 
         var label_style = zz.Style{};
@@ -183,13 +183,13 @@ const Model = struct {
     fn renderProgress(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.magenta());
+        box_style = box_style.borderForeground(zz.Color.magenta);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(40);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.magenta());
+        header_style = header_style.fg(zz.Color.magenta);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Progress");
 
@@ -203,7 +203,7 @@ const Model = struct {
 
         // Show paused indicator
         var paused_style = zz.Style{};
-        paused_style = paused_style.fg(zz.Color.yellow());
+        paused_style = paused_style.fg(zz.Color.yellow);
         paused_style = paused_style.inline_style(true);
         const paused_indicator = if (!self.timer.running)
             paused_style.render(ctx.allocator, " (PAUSED)") catch ""
@@ -222,21 +222,21 @@ const Model = struct {
     fn renderActivity(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.green());
+        box_style = box_style.borderForeground(zz.Color.green);
         box_style = box_style.paddingAll(1);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.green());
+        header_style = header_style.fg(zz.Color.green);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Activity");
 
         var complete_style = zz.Style{};
-        complete_style = complete_style.fg(zz.Color.green());
+        complete_style = complete_style.fg(zz.Color.green);
         complete_style = complete_style.inline_style(true);
 
         var progress_style = zz.Style{};
-        progress_style = progress_style.fg(zz.Color.yellow());
+        progress_style = progress_style.fg(zz.Color.yellow);
         progress_style = progress_style.inline_style(true);
 
         const is_complete = self.task_progress >= 100;

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -66,7 +66,7 @@ const Model = struct {
 
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(alloc, "DataTable — frozen columns + cell cursor") catch "";
 

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -63,7 +63,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "DevConsole — log streamer") catch "";
 

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -63,7 +63,7 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var dv = zz.components.diff_view.DiffView{};

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -82,7 +82,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Dropdown Example") catch "Dropdown Example";
 

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -88,7 +88,7 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "File Browser") catch "File Browser";
 
@@ -99,7 +99,7 @@ const Model = struct {
         var preview_section: []const u8 = "";
         if (self.file_picker.getSelected()) |path| {
             var path_style = zz.Style{};
-            path_style = path_style.fg(zz.Color.green());
+            path_style = path_style.fg(zz.Color.green);
             path_style = path_style.inline_style(true);
             const path_display = path_style.render(ctx.allocator, path) catch path;
 

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -58,14 +58,14 @@ const Model = struct {
         // -- Render each panel into styled boxes --
 
         // Header
-        const header = renderPanel(alloc, "Dashboard", rows[0].width, rows[0].height, zz.Color.cyan(), true);
+        const header = renderPanel(alloc, "Dashboard", rows[0].width, rows[0].height, zz.Color.cyan, true);
 
         // Sidebar
         const sidebar_items =
             "  [1] Overview\n" ++
             "  [2] Metrics\n" ++
             "  [3] Settings";
-        const sidebar = renderPanel(alloc, sidebar_items, cols[0].width, cols[0].height, zz.Color.magenta(), self.selected_panel == 0);
+        const sidebar = renderPanel(alloc, sidebar_items, cols[0].width, cols[0].height, zz.Color.magenta, self.selected_panel == 0);
 
         // Main content area
         const main_text = switch (self.selected_panel) {
@@ -74,7 +74,7 @@ const Model = struct {
             2 => "Theme: Dark\nRefresh: 5s\nNotifications: On",
             else => "",
         };
-        const main_panel = renderPanel(alloc, main_text, cols[1].width, cols[1].height, zz.Color.green(), self.selected_panel == 1);
+        const main_panel = renderPanel(alloc, main_text, cols[1].width, cols[1].height, zz.Color.green, self.selected_panel == 1);
 
         // Footer
         var help_style = zz.Style{};

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -102,7 +102,7 @@ const Model = struct {
 
         var focused_label = zz.Style{};
         focused_label = focused_label.bold(true);
-        focused_label = focused_label.fg(zz.Color.cyan());
+        focused_label = focused_label.fg(zz.Color.cyan);
         focused_label = focused_label.inline_style(true);
 
         // Render each field with focus indicator
@@ -135,7 +135,7 @@ const Model = struct {
         const status = if (self.submitted) blk: {
             var success_style = zz.Style{};
             success_style = success_style.bold(true);
-            success_style = success_style.fg(zz.Color.green());
+            success_style = success_style.fg(zz.Color.green);
             success_style = success_style.inline_style(true);
 
             const name_val = self.name_input.getValue();

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -60,7 +60,7 @@ const Model = struct {
         const form_view = self.form.view(ctx.allocator) catch "error";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.green());
+        status_style = status_style.fg(zz.Color.green);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
         const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -48,13 +48,13 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
         const title = title_s.render(alloc, "Gauge Component Demo") catch "Gauge Demo";
 
         const thresholds = &[_]zz.Gauge.Threshold{
-            .{ .value = 70, .color = zz.Color.yellow() },
-            .{ .value = 90, .color = zz.Color.red() },
+            .{ .value = 70, .color = zz.Color.yellow },
+            .{ .value = 90, .color = zz.Color.red },
         };
 
         // Bar gauge
@@ -83,7 +83,7 @@ const Model = struct {
         blocks.display_style = .blocks;
         blocks.show_percent = true;
         blocks.label = "DSK";
-        blocks.base_color = zz.Color.blue();
+        blocks.base_color = zz.Color.blue;
         const blocks_view = blocks.view(alloc);
 
         var help_s = zz.Style{};

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -203,7 +203,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
 
         var subtitle_style = zz.Style{};

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -67,7 +67,7 @@ const Model = struct {
         // Main info panel (z=1)
         var info_style = zz.Style{};
         info_style = info_style.borderAll(zz.Border.rounded);
-        info_style = info_style.borderForeground(zz.Color.cyan());
+        info_style = info_style.borderForeground(zz.Color.cyan);
         info_style = info_style.paddingAll(1);
         info_style = info_style.width(40);
         info_style = info_style.height(8);
@@ -80,7 +80,7 @@ const Model = struct {
         if (self.show_popup) {
             var popup_style = zz.Style{};
             popup_style = popup_style.borderAll(zz.Border.double);
-            popup_style = popup_style.borderForeground(zz.Color.yellow());
+            popup_style = popup_style.borderForeground(zz.Color.yellow);
             popup_style = popup_style.paddingAll(1);
             popup_style = popup_style.width(30);
             popup_style = popup_style.height(5);
@@ -96,7 +96,7 @@ const Model = struct {
         if (self.show_tooltip) {
             var tt_style = zz.Style{};
             tt_style = tt_style.borderAll(zz.Border.normal);
-            tt_style = tt_style.borderForeground(zz.Color.green());
+            tt_style = tt_style.borderForeground(zz.Color.green);
             tt_style = tt_style.width(20);
 
             const tt = tt_style.render(alloc, "Tooltip z=20") catch "tooltip";

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -136,7 +136,7 @@ const Model = struct {
         ) catch "";
 
         var status_style = zz.Style{};
-        status_style = status_style.fg(zz.Color.cyan());
+        status_style = status_style.fg(zz.Color.cyan);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
         const status = std.fmt.allocPrint(ctx.allocator, "Status: {s}", .{self.status}) catch "?";

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -86,10 +86,10 @@ const Model = struct {
                             self.modal.footer = "Use Tab/arrows to navigate, Enter to select";
                             self.modal.width = .{ .fixed = 50 };
                             self.modal.border_chars = zz.Border.double;
-                            self.modal.border_fg = zz.Color.magenta();
+                            self.modal.border_fg = zz.Color.magenta;
                             self.modal.title_style = blk: {
                                 var s = zz.Style{};
-                                s = s.bold(true).fg(zz.Color.magenta()).inline_style(true);
+                                s = s.bold(true).fg(zz.Color.magenta).inline_style(true);
                                 break :blk s;
                             };
                             self.modal.content_bg = zz.Color.gray(2);
@@ -126,7 +126,7 @@ const Model = struct {
         hint_s = hint_s.fg(zz.Color.gray(14)).inline_style(true);
 
         var result_s = zz.Style{};
-        result_s = result_s.fg(zz.Color.cyan()).inline_style(true);
+        result_s = result_s.fg(zz.Color.cyan).inline_style(true);
 
         var status_s = zz.Style{};
         status_s = status_s.fg(zz.Color.gray(12)).inline_style(true);

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -25,9 +25,9 @@ const Model = struct {
 
     pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
         self.buttons = .{
-            .{ .label = "  Click Me  ", .color = zz.Color.cyan(), .mouse = .{} },
-            .{ .label = "  Count++   ", .color = zz.Color.green(), .mouse = .{} },
-            .{ .label = "   Reset    ", .color = zz.Color.red(), .mouse = .{} },
+            .{ .label = "  Click Me  ", .color = zz.Color.cyan, .mouse = .{} },
+            .{ .label = "  Count++   ", .color = zz.Color.green, .mouse = .{} },
+            .{ .label = "   Reset    ", .color = zz.Color.red, .mouse = .{} },
         };
         self.click_count = 0;
         self.last_event = "Move the mouse or click a button";
@@ -90,7 +90,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.white());
+        title_style = title_style.fg(zz.Color.white);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Mouse Demo") catch "Mouse Demo";
 
@@ -114,7 +114,7 @@ const Model = struct {
             var s = zz.Style{};
             s = s.borderAll(zz.Border.rounded);
             if (btn.mouse.hover) {
-                s = s.borderForeground(zz.Color.white());
+                s = s.borderForeground(zz.Color.white);
                 s = s.bold(true);
             } else {
                 s = s.borderForeground(btn.color);

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -128,7 +128,7 @@ const Model = struct {
 
         var title = zz.Style{};
         title = title.bold(true);
-        title = title.fg(zz.Color.cyan());
+        title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
         const t = title.render(alloc, "RichLog — append-only with level filter & search") catch "";
 

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -104,18 +104,18 @@ const Model = struct {
         };
 
         var cpu = zz.ChartDataset.init(ctx.persistent_allocator, "CPU") catch unreachable;
-        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan()).bold(true));
+        cpu.setStyle((zz.Style{}).fg(zz.Color.cyan).bold(true));
         cpu.setShowPoints(true);
         cpu.setInterpolation(.monotone_cubic);
         cpu.setInterpolationSteps(10);
 
         var mem = zz.ChartDataset.init(ctx.persistent_allocator, "Memory") catch unreachable;
-        mem.setStyle((zz.Style{}).fg(zz.Color.magenta()));
+        mem.setStyle((zz.Style{}).fg(zz.Color.magenta));
         mem.setInterpolation(.catmull_rom);
         mem.setInterpolationSteps(10);
 
         var backlog = zz.ChartDataset.init(ctx.persistent_allocator, "Backlog") catch unreachable;
-        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow()));
+        backlog.setStyle((zz.Style{}).fg(zz.Color.yellow));
         backlog.setGraphType(.area);
         backlog.setInterpolation(.step_center);
         backlog.setFillBaseline(18.0);
@@ -136,8 +136,8 @@ const Model = struct {
         self.bars.setOrientation(.horizontal);
         self.bars.show_values = true;
         self.bars.label_style = (zz.Style{}).fg(zz.Color.gray(18)).inline_style(true);
-        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green()).inline_style(true);
-        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red()).inline_style(true);
+        self.bars.positive_style = (zz.Style{}).fg(zz.Color.green).inline_style(true);
+        self.bars.negative_style = (zz.Style{}).fg(zz.Color.red).inline_style(true);
         self.bars.axis_style = (zz.Style{}).fg(zz.Color.gray(10)).inline_style(true);
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "api", 22) catch unreachable) catch unreachable;
         self.bars.addBar(zz.Bar.init(ctx.persistent_allocator, "db", -10) catch unreachable) catch unreachable;
@@ -581,7 +581,7 @@ const Model = struct {
         // Spinner
         const spinner_view = if (self.progress.isComplete()) blk: {
             var done_style = zz.Style{};
-            done_style = done_style.fg(zz.Color.green());
+            done_style = done_style.fg(zz.Color.green);
             done_style = done_style.inline_style(true);
             break :blk try done_style.render(ctx.allocator, "* All tasks complete!");
         } else try self.spinner.viewWithTitle(ctx.allocator, "Processing...");
@@ -593,7 +593,7 @@ const Model = struct {
         // Bottom box
         var bottom_style = zz.Style{};
         bottom_style = bottom_style.borderAll(zz.Border.rounded);
-        bottom_style = bottom_style.borderForeground(zz.Color.green());
+        bottom_style = bottom_style.borderForeground(zz.Color.green);
         bottom_style = bottom_style.paddingAll(1);
 
         const bottom_content = if (has_notifs)
@@ -609,19 +609,19 @@ const Model = struct {
     fn renderDashboardStats(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.rounded);
-        box_style = box_style.borderForeground(zz.Color.cyan());
+        box_style = box_style.borderForeground(zz.Color.cyan);
         box_style = box_style.borderTopForeground(zz.Color.hex("#4ECDC4"));
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(25);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.cyan());
+        header_style = header_style.fg(zz.Color.cyan);
         header_style = header_style.inline_style(true);
 
         var value_style = zz.Style{};
         value_style = value_style.bold(true);
-        value_style = value_style.fg(zz.Color.white());
+        value_style = value_style.fg(zz.Color.white);
         value_style = value_style.inline_style(true);
 
         var label_style = zz.Style{};
@@ -635,13 +635,13 @@ const Model = struct {
         const fps_label = try label_style.render(ctx.allocator, " FPS");
 
         var paused_style = zz.Style{};
-        paused_style = paused_style.fg(zz.Color.yellow());
+        paused_style = paused_style.fg(zz.Color.yellow);
         paused_style = paused_style.inline_style(true);
         const status = if (self.paused)
             try paused_style.render(ctx.allocator, "PAUSED")
         else blk: {
             var run_style = zz.Style{};
-            run_style = run_style.fg(zz.Color.green());
+            run_style = run_style.fg(zz.Color.green);
             run_style = run_style.inline_style(true);
             break :blk try run_style.render(ctx.allocator, "RUNNING");
         };
@@ -656,13 +656,13 @@ const Model = struct {
     fn renderDashboardProgress(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.double);
-        box_style = box_style.borderForeground(zz.Color.magenta());
+        box_style = box_style.borderForeground(zz.Color.magenta);
         box_style = box_style.paddingAll(1);
         box_style = box_style.width(35);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.magenta());
+        header_style = header_style.fg(zz.Color.magenta);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "Progress");
 
@@ -687,7 +687,7 @@ const Model = struct {
         var table_box_style = zz.Style{};
         table_box_style = table_box_style.borderAll(zz.Border.normal);
         if (self.data_focus == .table_focus) {
-            table_box_style = table_box_style.borderForeground(zz.Color.cyan());
+            table_box_style = table_box_style.borderForeground(zz.Color.cyan);
         } else {
             table_box_style = table_box_style.borderForeground(zz.Color.gray(8));
         }
@@ -699,7 +699,7 @@ const Model = struct {
         var tree_box_style = zz.Style{};
         tree_box_style = tree_box_style.borderAll(zz.Border.rounded);
         if (self.data_focus == .tree_focus) {
-            tree_box_style = tree_box_style.borderForeground(zz.Color.cyan());
+            tree_box_style = tree_box_style.borderForeground(zz.Color.cyan);
         } else {
             tree_box_style = tree_box_style.borderForeground(zz.Color.gray(8));
         }
@@ -707,7 +707,7 @@ const Model = struct {
 
         var tree_header_style = zz.Style{};
         tree_header_style = tree_header_style.bold(true);
-        tree_header_style = tree_header_style.fg(zz.Color.yellow());
+        tree_header_style = tree_header_style.fg(zz.Color.yellow);
         tree_header_style = tree_header_style.inline_style(true);
         const tree_header = try tree_header_style.render(ctx.allocator, "Project Structure");
         const tree_content = try std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ tree_header, tree_view });
@@ -722,7 +722,7 @@ const Model = struct {
 
         var list_header_style = zz.Style{};
         list_header_style = list_header_style.bold(true);
-        list_header_style = list_header_style.fg(zz.Color.green());
+        list_header_style = list_header_style.fg(zz.Color.green);
         list_header_style = list_header_style.inline_style(true);
         const list_header = try list_header_style.render(ctx.allocator, "TODO Items");
         const list_content = try std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ list_header, list_view });
@@ -756,17 +756,17 @@ const Model = struct {
 
         var trend_style = zz.Style{};
         trend_style = trend_style.borderAll(zz.Border.rounded);
-        trend_style = trend_style.borderForeground(zz.Color.cyan());
+        trend_style = trend_style.borderForeground(zz.Color.cyan);
         trend_style = trend_style.paddingLeft(1).paddingRight(1);
 
         var bars_style = zz.Style{};
         bars_style = bars_style.borderAll(zz.Border.rounded);
-        bars_style = bars_style.borderForeground(zz.Color.green());
+        bars_style = bars_style.borderForeground(zz.Color.green);
         bars_style = bars_style.paddingLeft(1).paddingRight(1);
 
         var aux_style = zz.Style{};
         aux_style = aux_style.borderAll(zz.Border.rounded);
-        aux_style = aux_style.borderForeground(zz.Color.yellow());
+        aux_style = aux_style.borderForeground(zz.Color.yellow);
         aux_style = aux_style.paddingLeft(1).paddingRight(1);
 
         const trend_box = try trend_style.render(ctx.allocator, try self.section(ctx, "Interpolated Lines + Area", trend_view));
@@ -791,12 +791,12 @@ const Model = struct {
 
         var box_style = zz.Style{};
         box_style = box_style.borderAll(zz.Border.thick);
-        box_style = box_style.borderForeground(zz.Color.blue());
+        box_style = box_style.borderForeground(zz.Color.blue);
         box_style = box_style.paddingAll(1);
 
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.blue());
+        header_style = header_style.fg(zz.Color.blue);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, "File Browser");
 
@@ -817,7 +817,7 @@ const Model = struct {
         canvas.setRanges(.{ .min = -1.2, .max = 1.2 }, .{ .min = -1.2, .max = 1.2 });
 
         var style = zz.Style{};
-        style = style.fg(zz.Color.yellow());
+        style = style.fg(zz.Color.yellow);
         style = style.inline_style(true);
 
         for (0..64) |i| {
@@ -870,7 +870,7 @@ const Model = struct {
         _ = self;
         var header_style = zz.Style{};
         header_style = header_style.bold(true);
-        header_style = header_style.fg(zz.Color.white());
+        header_style = header_style.fg(zz.Color.white);
         header_style = header_style.inline_style(true);
         const header = try header_style.render(ctx.allocator, title);
         return try std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ header, body });
@@ -944,13 +944,13 @@ const Model = struct {
         // -- Fullwidth/Halfwidth comparison box --
         var fw_header_style = zz.Style{};
         fw_header_style = fw_header_style.bold(true);
-        fw_header_style = fw_header_style.fg(zz.Color.yellow());
+        fw_header_style = fw_header_style.fg(zz.Color.yellow);
         fw_header_style = fw_header_style.inline_style(true);
         const fw_header = try fw_header_style.render(alloc, "Width Comparison");
 
         var fw_style = zz.Style{};
         fw_style = fw_style.borderAll(zz.Border.rounded);
-        fw_style = fw_style.borderForeground(zz.Color.yellow());
+        fw_style = fw_style.borderForeground(zz.Color.yellow);
         fw_style = fw_style.paddingLeft(1).paddingRight(1);
 
         const fw_content = try std.fmt.allocPrint(alloc, "{s}\n\n  Fullwidth : \u{FF21}\u{FF22}\u{FF23}\u{FF24}\u{FF25}   (5 chars = 10 cols)\n  Halfwidth : ABCDE        (5 chars =  5 cols)\n  Mixed     : A\u{FF22}C\u{FF24}E        (5 chars =  7 cols)", .{fw_header});
@@ -960,13 +960,13 @@ const Model = struct {
         // -- Combining characters box --
         var comb_header_style = zz.Style{};
         comb_header_style = comb_header_style.bold(true);
-        comb_header_style = comb_header_style.fg(zz.Color.magenta());
+        comb_header_style = comb_header_style.fg(zz.Color.magenta);
         comb_header_style = comb_header_style.inline_style(true);
         const comb_header = try comb_header_style.render(alloc, "Combining Characters");
 
         var comb_style = zz.Style{};
         comb_style = comb_style.borderAll(zz.Border.rounded);
-        comb_style = comb_style.borderForeground(zz.Color.magenta());
+        comb_style = comb_style.borderForeground(zz.Color.magenta);
         comb_style = comb_style.paddingLeft(1).paddingRight(1);
 
         const comb_content = try std.fmt.allocPrint(alloc, "{s}\n\n  e\u{0301} = e + combining acute   (1 col)\n  a\u{030A} = a + combining ring     (1 col)\n  o\u{0308} = o + combining diaeresis (1 col)\n  n\u{0303} = n + combining tilde     (1 col)", .{comb_header});
@@ -976,13 +976,13 @@ const Model = struct {
         // -- Alignment demo --
         var align_header_style = zz.Style{};
         align_header_style = align_header_style.bold(true);
-        align_header_style = align_header_style.fg(zz.Color.green());
+        align_header_style = align_header_style.fg(zz.Color.green);
         align_header_style = align_header_style.inline_style(true);
         const align_header = try align_header_style.render(alloc, "Alignment Demo");
 
         var align_style = zz.Style{};
         align_style = align_style.borderAll(zz.Border.double);
-        align_style = align_style.borderForeground(zz.Color.green());
+        align_style = align_style.borderForeground(zz.Color.green);
         align_style = align_style.paddingLeft(1).paddingRight(1);
 
         const align_content = try std.fmt.allocPrint(alloc, "{s}\n\n  |hello     |  5 cols\n  |\u{4F60}\u{597D}      |  4 cols (2 wide chars)\n  |\u{03B1}\u{03B2}\u{03B3}\u{03B4}      |  4 cols (Greek)\n  |caf\u{00E9}      |  4 cols (precomposed)\n  |cafe\u{0301}      |  4 cols (combining)", .{align_header});

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -27,7 +27,7 @@ const Model = struct {
         self.brightness.label = "Brightness:";
         self.brightness.value = 75;
         self.brightness.show_value = true;
-        self.brightness.setGradient(zz.Color.fromRgb(50, 50, 50), zz.Color.yellow());
+        self.brightness.setGradient(zz.Color.fromRgb(50, 50, 50), zz.Color.yellow);
 
         // Thin style with decimal precision
         self.temperature = zz.SliderStyle.thin();
@@ -79,7 +79,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Slider Example") catch "Slider Example";
 

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -44,12 +44,12 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var box_s = zz.Style{};
         box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderForeground(zz.Color.cyan);
         box_s = box_s.paddingAll(1);
 
         const table_view = self.table.view(alloc);

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -90,19 +90,19 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         // Sub-program views
         var box_a = zz.Style{};
         box_a = box_a.borderAll(zz.Border.rounded);
-        box_a = box_a.borderForeground(if (self.active == 0) zz.Color.green() else zz.Color.gray(8));
+        box_a = box_a.borderForeground(if (self.active == 0) zz.Color.green else zz.Color.gray(8));
         box_a = box_a.paddingAll(1);
         box_a = box_a.width(30);
 
         var box_b = zz.Style{};
         box_b = box_b.borderAll(zz.Border.rounded);
-        box_b = box_b.borderForeground(if (self.active == 1) zz.Color.green() else zz.Color.gray(8));
+        box_b = box_b.borderForeground(if (self.active == 1) zz.Color.green else zz.Color.gray(8));
         box_b = box_b.paddingAll(1);
         box_b = box_b.width(30);
 

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -76,7 +76,7 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "ZigZag Text Editor") catch "Text Editor";
 
@@ -102,7 +102,7 @@ const Model = struct {
 
         // Status message
         var msg_style = zz.Style{};
-        msg_style = msg_style.fg(zz.Color.green());
+        msg_style = msg_style.fg(zz.Color.green);
         msg_style = msg_style.inline_style(true);
         const msg = msg_style.render(ctx.allocator, self.status_message) catch "";
 

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -33,7 +33,7 @@ const Model = struct {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
         const title = title_style.render(alloc, "Text Overflow Policies") catch "Text Overflow Policies";
 
@@ -49,7 +49,7 @@ const Model = struct {
         var clip_style = zz.Style{};
         clip_style = clip_style.width(box_width);
         clip_style = clip_style.borderAll(zz.Border.rounded);
-        clip_style = clip_style.borderForeground(zz.Color.yellow());
+        clip_style = clip_style.borderForeground(zz.Color.yellow);
         clip_style = clip_style.overflow(.hidden);
         const clip = clip_style.render(alloc, long_text) catch "";
 
@@ -57,7 +57,7 @@ const Model = struct {
         var ell_style = zz.Style{};
         ell_style = ell_style.width(box_width);
         ell_style = ell_style.borderAll(zz.Border.rounded);
-        ell_style = ell_style.borderForeground(zz.Color.green());
+        ell_style = ell_style.borderForeground(zz.Color.green);
         ell_style = ell_style.overflow(.ellipsis);
         const ell = ell_style.render(alloc, long_text) catch "";
 
@@ -65,7 +65,7 @@ const Model = struct {
         var ww_style = zz.Style{};
         ww_style = ww_style.width(box_width);
         ww_style = ww_style.borderAll(zz.Border.rounded);
-        ww_style = ww_style.borderForeground(zz.Color.blue());
+        ww_style = ww_style.borderForeground(zz.Color.blue);
         ww_style = ww_style.overflow(.word_wrap);
         const ww = ww_style.render(alloc, long_text) catch "";
 
@@ -73,7 +73,7 @@ const Model = struct {
         var cw_style = zz.Style{};
         cw_style = cw_style.width(box_width);
         cw_style = cw_style.borderAll(zz.Border.rounded);
-        cw_style = cw_style.borderForeground(zz.Color.magenta());
+        cw_style = cw_style.borderForeground(zz.Color.magenta);
         cw_style = cw_style.overflow(.char_wrap);
         const cw = cw_style.render(alloc, long_text) catch "";
 

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -106,7 +106,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.magenta());
+        title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
         const title = title_style.render(ctx.allocator, "Toast Notifications") catch "Toast";
 
@@ -119,7 +119,7 @@ const Model = struct {
         };
 
         var info_style = zz.Style{};
-        info_style = info_style.fg(zz.Color.cyan());
+        info_style = info_style.fg(zz.Color.cyan);
         info_style = info_style.inline_style(true);
         const info = std.fmt.allocPrint(
             ctx.allocator,

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -138,7 +138,7 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
-        title_style = title_style.fg(zz.Color.cyan());
+        title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
 
         var box_style = zz.Style{};
@@ -155,7 +155,7 @@ const Model = struct {
         // Show filter if enabled
         if (self.list.filter_enabled) {
             var filter_style = zz.Style{};
-            filter_style = filter_style.fg(zz.Color.yellow());
+            filter_style = filter_style.fg(zz.Color.yellow);
             filter_style = filter_style.inline_style(true);
             const filter_text = std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{self.list.filter_text.items}) catch "Filter:";
             const styled_filter = filter_style.render(ctx.allocator, filter_text) catch filter_text;
@@ -195,7 +195,7 @@ const Model = struct {
             } else if (i == self.list.cursor) {
                 var selected_style = zz.Style{};
                 selected_style = selected_style.bold(true);
-                selected_style = selected_style.fg(zz.Color.magenta());
+                selected_style = selected_style.fg(zz.Color.magenta);
                 selected_style = selected_style.inline_style(true);
                 const styled = selected_style.render(ctx.allocator, item.title) catch item.title;
                 writer.writeAll(styled) catch {};

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -141,7 +141,7 @@ const Model = struct {
 
         // Render buttons in a row
         var btn_s = zz.Style{};
-        btn_s = btn_s.fg(zz.Color.white()).inline_style(true);
+        btn_s = btn_s.fg(zz.Color.white).inline_style(true);
 
         var btn_parts: [7][]const u8 = undefined;
         for (labels, 0..) |label, i| {

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -40,12 +40,12 @@ const Model = struct {
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
 
         var box_s = zz.Style{};
         box_s = box_s.borderAll(zz.Border.rounded);
-        box_s = box_s.borderForeground(zz.Color.cyan());
+        box_s = box_s.borderForeground(zz.Color.cyan);
 
         const list_view = self.vlist.view(alloc);
         const boxed = box_s.render(alloc, list_view) catch list_view;

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -59,12 +59,12 @@ const Model = struct {
     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
-        title_s = title_s.fg(zz.Color.cyan());
+        title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
         const title = title_s.render(ctx.allocator, "ZigZag WASM Demo") catch "ZigZag WASM";
 
         var count_s = zz.Style{};
-        count_s = count_s.fg(zz.Color.green());
+        count_s = count_s.fg(zz.Color.green);
         count_s = count_s.bold(true);
         count_s = count_s.inline_style(true);
         const count_text = std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count}) catch "?";

--- a/src/accessibility.zig
+++ b/src/accessibility.zig
@@ -40,8 +40,8 @@ pub fn meetsAAA(fg: Color, bg: Color) bool {
 /// Suggest a foreground color (white or black) that has better contrast
 /// against the given background.
 pub fn suggestForeground(bg: Color) Color {
-    const white = Color.white();
-    const black = Color.black();
+    const white = Color.white;
+    const black = Color.black;
     const white_ratio = white.contrastRatio(bg);
     const black_ratio = black.contrastRatio(bg);
     return if (white_ratio >= black_ratio) white else black;

--- a/src/components/breadcrumb.zig
+++ b/src/components/breadcrumb.zig
@@ -32,16 +32,16 @@ pub const Breadcrumb = struct {
 
     pub fn init(allocator: std.mem.Allocator) Breadcrumb {
         var seg = style_mod.Style{};
-        seg = seg.fg(Color.gray(12));
+        seg = seg.fg(.gray(12));
         seg = seg.inline_style(true);
 
         var active = style_mod.Style{};
-        active = active.fg(Color.cyan());
+        active = active.fg(.cyan);
         active = active.bold(true);
         active = active.inline_style(true);
 
         var sep = style_mod.Style{};
-        sep = sep.fg(Color.gray(8));
+        sep = sep.fg(.gray(8));
         sep = sep.inline_style(true);
 
         return .{

--- a/src/components/calendar.zig
+++ b/src/components/calendar.zig
@@ -59,34 +59,34 @@ pub const Calendar = struct {
     today_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.inline_style(true);
         break :blk s;
     },
     selected_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.fg(Color.blue());
+        s = s.fg(.blue);
         s = s.inline_style(true);
         break :blk s;
     },
     cursor_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
         s = s.bold(true);
-        s = s.bg(Color.blue());
-        s = s.fg(Color.white());
+        s = s.bg(.blue);
+        s = s.fg(.white);
         s = s.inline_style(true);
         break :blk s;
     },
     weekend_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.inline_style(true);
         break :blk s;
     },
     header_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.yellow());
+        s = s.fg(.yellow);
         s = s.inline_style(true);
         break :blk s;
     },
@@ -98,7 +98,7 @@ pub const Calendar = struct {
     /// Style for the prev/next symbols in the title.
     nav_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/checkbox.zig
+++ b/src/components/checkbox.zig
@@ -40,28 +40,28 @@ pub const Checkbox = struct {
             },
             .checked_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.bold(true);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .unchecked_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .focused_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.magenta());
+                s = s.fg(.magenta);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .disabled_style = blk: {
                 var s = style_mod.Style{};
                 s = s.dim(true);
-                s = s.fg(Color.gray(10));
+                s = s.fg(.gray(10));
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -198,21 +198,21 @@ pub fn CheckboxGroup(comptime T: type) type {
                 },
                 .checked_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/code_view.zig
+++ b/src/components/code_view.zig
@@ -22,7 +22,7 @@ pub const CodeView = struct {
     /// Operator style.
     operator_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.white());
+        s = s.fg(.white);
         s = s.inline_style(true);
         break :blk s;
     },
@@ -30,52 +30,52 @@ pub const CodeView = struct {
     // Styles
     keyword_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.magenta());
+        s = s.fg(.magenta);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     string_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.green());
+        s = s.fg(.green);
         s = s.inline_style(true);
         break :blk s;
     },
     comment_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(10));
+        s = s.fg(.gray(10));
         s = s.italic(true);
         s = s.inline_style(true);
         break :blk s;
     },
     number_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.inline_style(true);
         break :blk s;
     },
     type_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.yellow());
+        s = s.fg(.yellow);
         s = s.inline_style(true);
         break :blk s;
     },
     builtin_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     line_number_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(8));
+        s = s.fg(.gray(8));
         s = s.inline_style(true);
         break :blk s;
     },
     highlight_bg: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.bg(Color.fromRgb(40, 40, 60));
+        s = s.bg(.fromRgb(40, 40, 60));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/command_palette.zig
+++ b/src/components/command_palette.zig
@@ -62,7 +62,7 @@ pub const CommandPalette = struct {
 
     pub fn init(allocator: std.mem.Allocator) !CommandPalette {
         var prompt_s = style_mod.Style{};
-        prompt_s = prompt_s.fg(Color.cyan());
+        prompt_s = prompt_s.fg(.cyan);
         prompt_s = prompt_s.bold(true);
         prompt_s = prompt_s.inline_style(true);
 
@@ -70,32 +70,32 @@ pub const CommandPalette = struct {
         input_s = input_s.inline_style(true);
 
         var placeholder_s = style_mod.Style{};
-        placeholder_s = placeholder_s.fg(Color.gray(8));
+        placeholder_s = placeholder_s.fg(.gray(8));
         placeholder_s = placeholder_s.inline_style(true);
 
         var label_s = style_mod.Style{};
         label_s = label_s.inline_style(true);
 
         var desc_s = style_mod.Style{};
-        desc_s = desc_s.fg(Color.gray(10));
+        desc_s = desc_s.fg(.gray(10));
         desc_s = desc_s.inline_style(true);
 
         var shortcut_s = style_mod.Style{};
-        shortcut_s = shortcut_s.fg(Color.gray(8));
+        shortcut_s = shortcut_s.fg(.gray(8));
         shortcut_s = shortcut_s.inline_style(true);
 
         var selected_s = style_mod.Style{};
-        selected_s = selected_s.bg(Color.gray(4));
+        selected_s = selected_s.bg(.gray(4));
         selected_s = selected_s.inline_style(true);
 
         var selected_label_s = style_mod.Style{};
-        selected_label_s = selected_label_s.bg(Color.gray(4));
-        selected_label_s = selected_label_s.fg(Color.cyan());
+        selected_label_s = selected_label_s.bg(.gray(4));
+        selected_label_s = selected_label_s.fg(.cyan);
         selected_label_s = selected_label_s.bold(true);
         selected_label_s = selected_label_s.inline_style(true);
 
         var empty_s = style_mod.Style{};
-        empty_s = empty_s.fg(Color.gray(8));
+        empty_s = empty_s.fg(.gray(8));
         empty_s = empty_s.italic(true);
         empty_s = empty_s.inline_style(true);
 
@@ -109,7 +109,7 @@ pub const CommandPalette = struct {
             .width = 60,
             .prompt = "> ",
             .placeholder = "Type a command…",
-            .border_chars = border_mod.Border.rounded,
+            .border_chars = .rounded,
             .prompt_style = prompt_s,
             .input_style = input_s,
             .placeholder_style = placeholder_s,

--- a/src/components/confirm.zig
+++ b/src/components/confirm.zig
@@ -40,13 +40,13 @@ pub const Confirm = struct {
             .active_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .inactive_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -60,39 +60,39 @@ pub fn ContextMenu(comptime Action: type) type {
                 .y = 0,
                 .item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.cyan());
+                    s = s.fg(.white);
+                    s = s.bg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .separator_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(8));
+                    s = s.fg(.gray(8));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .shortcut_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(14),
+                .border_chars = .rounded,
+                .border_fg = .gray(14),
             };
         }
 

--- a/src/components/data_table.zig
+++ b/src/components/data_table.zig
@@ -69,16 +69,16 @@ pub const DataTable = struct {
         cell_s = cell_s.inline_style(true);
 
         var cursor_cell = style_mod.Style{};
-        cursor_cell = cursor_cell.bg(Color.cyan());
-        cursor_cell = cursor_cell.fg(Color.black());
+        cursor_cell = cursor_cell.bg(.cyan);
+        cursor_cell = cursor_cell.fg(.black);
         cursor_cell = cursor_cell.inline_style(true);
 
         var cursor_row = style_mod.Style{};
-        cursor_row = cursor_row.bg(Color.gray(4));
+        cursor_row = cursor_row.bg(.gray(4));
         cursor_row = cursor_row.inline_style(true);
 
         var frozen_sep = style_mod.Style{};
-        frozen_sep = frozen_sep.fg(Color.gray(8));
+        frozen_sep = frozen_sep.fg(.gray(8));
         frozen_sep = frozen_sep.inline_style(true);
 
         return .{
@@ -99,7 +99,7 @@ pub const DataTable = struct {
             .cursor_cell_style = cursor_cell,
             .cursor_row_style = cursor_row,
             .frozen_separator_style = frozen_sep,
-            .border_chars = border_mod.Border.normal,
+            .border_chars = .normal,
         };
     }
 

--- a/src/components/diff_view.zig
+++ b/src/components/diff_view.zig
@@ -28,38 +28,38 @@ pub const DiffView = struct {
     // Styles
     add_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.green());
+        s = s.fg(.green);
         s = s.inline_style(true);
         break :blk s;
     },
     remove_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.red());
+        s = s.fg(.red);
         s = s.inline_style(true);
         break :blk s;
     },
     context_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(12));
+        s = s.fg(.gray(12));
         s = s.inline_style(true);
         break :blk s;
     },
     header_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.cyan());
+        s = s.fg(.cyan);
         s = s.bold(true);
         s = s.inline_style(true);
         break :blk s;
     },
     line_num_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(8));
+        s = s.fg(.gray(8));
         s = s.inline_style(true);
         break :blk s;
     },
     separator_style: style_mod.Style = blk: {
         var s = style_mod.Style{};
-        s = s.fg(Color.gray(6));
+        s = s.fg(.gray(6));
         s = s.inline_style(true);
         break :blk s;
     },

--- a/src/components/dropdown.zig
+++ b/src/components/dropdown.zig
@@ -124,14 +124,14 @@ pub fn Dropdown(comptime T: type) type {
                 },
                 .trigger_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.white());
+                    s = s.fg(.white);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .trigger_focused_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -143,31 +143,31 @@ pub fn Dropdown(comptime T: type) type {
                 .cursor_item_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .selected_item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.green());
+                    s = s.fg(.green);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .filter_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.yellow());
+                    s = s.fg(.yellow);
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(14),
+                .border_chars = .rounded,
+                .border_fg = .gray(14),
             };
         }
 

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -79,7 +79,7 @@ pub const FilePicker = struct {
             .dir_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.blue());
+                s = s.fg(.blue);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -91,20 +91,20 @@ pub const FilePicker = struct {
             .cursor_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .size_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .path_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/focus.zig
+++ b/src/components/focus.zig
@@ -302,11 +302,11 @@ pub fn FocusGroup(comptime max_items: usize) type {
 /// ```
 pub const FocusStyle = struct {
     /// Border color when focused (default: cyan).
-    focused_border_fg: Color = Color.cyan(),
+    focused_border_fg: Color = .cyan,
     /// Border color when not focused (default: dark gray).
-    blurred_border_fg: Color = Color.gray(12),
+    blurred_border_fg: Color = .gray(12),
     /// Border character set (default: rounded).
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
+    border_chars: border_mod.BorderChars = .rounded,
 
     /// Apply focus-aware border styling to `base`.
     /// Returns a new Style with the appropriate border and color.

--- a/src/components/form.zig
+++ b/src/components/form.zig
@@ -95,24 +95,24 @@ pub fn Form(comptime max_fields: usize) type {
                 },
                 .required_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.red());
+                    s = s.fg(.red);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .error_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.red());
+                    s = s.fg(.red);
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.rounded,
-                .border_fg = Color.gray(10),
-                .border_focus_fg = Color.cyan(),
+                .border_chars = .rounded,
+                .border_fg = .gray(10),
+                .border_focus_fg = .cyan,
                 .title = "",
                 .title_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -288,7 +288,7 @@ pub fn Form(comptime max_fields: usize) type {
             // Footer
             try writer.writeAll("\n\n");
             var hint_style = style_mod.Style{};
-            hint_style = hint_style.fg(Color.gray(12));
+            hint_style = hint_style.fg(.gray(12));
             hint_style = hint_style.inline_style(true);
             const hint = try hint_style.render(allocator, self.hint_text);
             try writer.writeAll(hint);

--- a/src/components/gauge.zig
+++ b/src/components/gauge.zig
@@ -26,9 +26,9 @@ pub const Gauge = struct {
     /// Thresholds for color changes.
     thresholds: []const Threshold = &.{},
     /// Base color (used when below all thresholds).
-    base_color: Color = Color.green(),
+    base_color: Color = .green,
     /// Empty/background color.
-    empty_color: Color = Color.gray(6),
+    empty_color: Color = .gray(6),
     /// Label style.
     label_style: style_mod.Style = .{},
     /// Value/percent label style.

--- a/src/components/heatmap.zig
+++ b/src/components/heatmap.zig
@@ -105,33 +105,33 @@ pub const Heatmap = struct {
     fn scaleColor(self: *const Heatmap, t: f64) Color {
         return switch (self.color_scale) {
             .green_scale => {
-                if (t < 0.01) return Color.gray(2);
+                if (t < 0.01) return .gray(2);
                 const g: u8 = @intFromFloat(80 + 175 * t);
-                return Color.fromRgb(0, g, 0);
+                return .fromRgb(0, g, 0);
             },
             .cool_to_hot => {
                 if (t < 0.25) {
                     const lt = t * 4;
-                    return Color.fromRgb(0, @intFromFloat(lt * 255), 255);
+                    return .fromRgb(0, @intFromFloat(lt * 255), 255);
                 } else if (t < 0.5) {
                     const lt = (t - 0.25) * 4;
-                    return Color.fromRgb(0, 255, @intFromFloat(255 - lt * 255));
+                    return .fromRgb(0, 255, @intFromFloat(255 - lt * 255));
                 } else if (t < 0.75) {
                     const lt = (t - 0.5) * 4;
-                    return Color.fromRgb(@intFromFloat(lt * 255), 255, 0);
+                    return .fromRgb(@intFromFloat(lt * 255), 255, 0);
                 } else {
                     const lt = (t - 0.75) * 4;
-                    return Color.fromRgb(255, @intFromFloat(255 - lt * 255), 0);
+                    return .fromRgb(255, @intFromFloat(255 - lt * 255), 0);
                 }
             },
             .grayscale => {
                 const v: u8 = @intFromFloat(t * 255);
-                return Color.fromRgb(v, v, v);
+                return .fromRgb(v, v, v);
             },
             .blue_red => {
                 const r: u8 = @intFromFloat(t * 255);
                 const b: u8 = @intFromFloat((1 - t) * 255);
-                return Color.fromRgb(r, 0, b);
+                return .fromRgb(r, 0, b);
             },
         };
     }
@@ -197,7 +197,7 @@ pub const Heatmap = struct {
                     const val_str = std.fmt.allocPrint(allocator, "{d:.0}", .{val}) catch " ";
                     const padded = padCenter(allocator, val_str, self.cell_width);
                     // Choose foreground for contrast
-                    cs = cs.fg(if (t > 0.5) Color.black() else Color.white());
+                    cs = cs.fg(if (t > 0.5) .black else .white);
                     writer.writeAll(cs.render(allocator, padded) catch padded) catch {};
                 } else {
                     var cell_buf: [8]u8 = undefined;

--- a/src/components/help.zig
+++ b/src/components/help.zig
@@ -42,19 +42,19 @@ pub const Help = struct {
             .key_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .desc_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(18));
+                s = s.fg(.gray(18));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .sep_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -95,20 +95,20 @@ pub fn List(comptime T: type) type {
                 },
                 .selected_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .filter_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.yellow());
+                    s = s.fg(.yellow);
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -33,7 +33,7 @@ pub const Markdown = struct {
             .h1_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.magenta());
+                s = s.fg(.magenta);
                 s = s.underline(true);
                 s = s.inline_style(true);
                 break :blk s;
@@ -41,14 +41,14 @@ pub const Markdown = struct {
             .h2_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .h3_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -66,26 +66,26 @@ pub const Markdown = struct {
             },
             .code_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
-                s = s.bg(Color.fromRgb(40, 40, 40));
+                s = s.fg(.yellow);
+                s = s.bg(.fromRgb(40, 40, 40));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .code_block_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .code_block_border = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .link_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.underline(true);
                 s = s.inline_style(true);
                 break :blk s;
@@ -93,25 +93,25 @@ pub const Markdown = struct {
             .blockquote_style = blk: {
                 var s = style_mod.Style{};
                 s = s.italic(true);
-                s = s.fg(Color.gray(14));
+                s = s.fg(.gray(14));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .blockquote_bar = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(10));
+                s = s.fg(.gray(10));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .list_bullet_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .hr_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -312,7 +312,7 @@ pub const Markdown = struct {
                             const styled_text = try self.link_style.render(allocator, link_text);
                             try writer.writeAll(styled_text);
                             var dim = style_mod.Style{};
-                            dim = dim.fg(Color.gray(10));
+                            dim = dim.fg(.gray(10));
                             dim = dim.inline_style(true);
                             const url_str = try std.fmt.allocPrint(allocator, " ({s})", .{url});
                             const styled_url = try dim.render(allocator, url_str);

--- a/src/components/menu_bar.zig
+++ b/src/components/menu_bar.zig
@@ -79,59 +79,59 @@ pub fn MenuBar(comptime Action: type) type {
                 .selected_action = null,
                 .bar_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.bg(Color.fromRgb(40, 40, 50));
+                    s = s.bg(.fromRgb(40, 40, 50));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .bar_item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .bar_active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.fromRgb(60, 60, 80));
+                    s = s.fg(.white);
+                    s = s.bg(.fromRgb(60, 60, 80));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(18));
+                    s = s.fg(.gray(18));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_active_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.white());
-                    s = s.bg(Color.cyan());
+                    s = s.fg(.white);
+                    s = s.bg(.cyan);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .item_disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .separator_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .shortcut_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
-                .border_chars = border_mod.Border.normal,
-                .border_fg = Color.gray(14),
+                .border_chars = .normal,
+                .border_fg = .gray(14),
                 .gap = 2,
             };
         }

--- a/src/components/modal.zig
+++ b/src/components/modal.zig
@@ -83,14 +83,14 @@ pub const Modal = struct {
 
     // ── Styling ────────────────────────────────────────────────────────
 
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
-    border_fg: Color = Color.gray(18),
+    border_chars: border_mod.BorderChars = .rounded,
+    border_fg: Color = .gray(18),
     content_bg: Color = .none,
-    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white() }),
-    body_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(20) }),
-    footer_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(12), .italic_v = true }),
-    button_active_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white(), .bg_color = Color.cyan() }),
-    button_inactive_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(14) }),
+    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white }),
+    body_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(20) }),
+    footer_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(12), .italic_v = true }),
+    button_active_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white, .bg_color = .cyan }),
+    button_inactive_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(14) }),
     backdrop: ?Backdrop = null,
 
     // ── Types ──────────────────────────────────────────────────────────
@@ -132,19 +132,19 @@ pub const Modal = struct {
         /// Fill character (UTF-8 string, e.g. " ", "░", "▒", "▓", "█").
         char: []const u8 = " ",
         /// Style applied to the backdrop fill.
-        style: style_mod.Style = makeStyle(.{ .bg_color = Color.gray(3) }),
+        style: style_mod.Style = makeStyle(.{ .bg_color = .gray(3) }),
 
         /// Dark semi-transparent backdrop (default).
         pub const dark = Backdrop{};
 
         /// Slightly lighter backdrop.
         pub const medium = Backdrop{
-            .style = makeStyle(.{ .bg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .bg_color = .gray(5) }),
         };
 
         /// Light backdrop.
         pub const light = Backdrop{
-            .style = makeStyle(.{ .bg_color = Color.gray(8) }),
+            .style = makeStyle(.{ .bg_color = .gray(8) }),
         };
 
         /// Clear backdrop — uses the terminal's default background color.
@@ -155,19 +155,19 @@ pub const Modal = struct {
         /// Light shade fill character (░).
         pub const shade_light = Backdrop{
             .char = "░",
-            .style = makeStyle(.{ .fg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .fg_color = .gray(5) }),
         };
 
         /// Medium shade fill character (▒).
         pub const shade_medium = Backdrop{
             .char = "▒",
-            .style = makeStyle(.{ .fg_color = Color.gray(5) }),
+            .style = makeStyle(.{ .fg_color = .gray(5) }),
         };
 
         /// Dense shade fill character (▓).
         pub const shade_dense = Backdrop{
             .char = "▓",
-            .style = makeStyle(.{ .fg_color = Color.gray(4) }),
+            .style = makeStyle(.{ .fg_color = .gray(4) }),
         };
 
         /// Create a solid-color backdrop.
@@ -191,8 +191,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.cyan(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.cyan() }),
+            .border_fg = .cyan,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .cyan }),
         };
         m.addButton("OK", .enter);
         return m;
@@ -203,8 +203,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.yellow(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.yellow() }),
+            .border_fg = .yellow,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .yellow }),
         };
         m.addButton("Yes", .{ .char = 'y' });
         m.addButton("No", .{ .char = 'n' });
@@ -216,8 +216,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.yellow(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.yellow() }),
+            .border_fg = .yellow,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .yellow }),
         };
         m.addButton("OK", .enter);
         return m;
@@ -228,8 +228,8 @@ pub const Modal = struct {
         var m: Modal = .{
             .title = title,
             .body = body,
-            .border_fg = Color.red(),
-            .title_style = makeStyle(.{ .bold_v = true, .fg_color = Color.red() }),
+            .border_fg = .red,
+            .title_style = makeStyle(.{ .bold_v = true, .fg_color = .red }),
         };
         m.addButton("OK", .enter);
         return m;

--- a/src/components/notification.zig
+++ b/src/components/notification.zig
@@ -38,25 +38,25 @@ pub const Notification = struct {
             .max_visible = 5,
             .info_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .success_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .warning_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .err_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/paginator.zig
+++ b/src/components/paginator.zig
@@ -40,13 +40,13 @@ pub const Paginator = struct {
             .inactive_dot = "○",
             .active_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .inactive_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/progress.zig
+++ b/src/components/progress.zig
@@ -42,13 +42,13 @@ pub const Progress = struct {
             .head_char = null,
             .full_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .empty_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -240,11 +240,11 @@ pub const ProgressStyle = struct {
     pub fn colored() Progress {
         var p = Progress.init();
         var full_s = style.Style{};
-        full_s = full_s.fg(Color.green());
+        full_s = full_s.fg(.green);
         full_s = full_s.inline_style(true);
         p.full_style = full_s;
         var empty_s = style.Style{};
-        empty_s = empty_s.fg(Color.red());
+        empty_s = empty_s.fg(.red);
         empty_s = empty_s.inline_style(true);
         p.empty_style = empty_s;
         return p;
@@ -260,5 +260,5 @@ pub fn interpolateColor(start: Color, end: Color, t: f64) Color {
     const g: u8 = @intFromFloat(@as(f64, @floatFromInt(start_rgb.g)) * (1.0 - t) + @as(f64, @floatFromInt(end_rgb.g)) * t);
     const b: u8 = @intFromFloat(@as(f64, @floatFromInt(start_rgb.b)) * (1.0 - t) + @as(f64, @floatFromInt(end_rgb.b)) * t);
 
-    return Color.fromRgb(r, g, b);
+    return .fromRgb(r, g, b);
 }

--- a/src/components/radio_group.zig
+++ b/src/components/radio_group.zig
@@ -71,7 +71,7 @@ pub fn RadioGroup(comptime T: type) type {
                 },
                 .selected_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.cyan());
+                    s = s.fg(.cyan);
                     s = s.bold(true);
                     s = s.inline_style(true);
                     break :blk s;
@@ -79,14 +79,14 @@ pub fn RadioGroup(comptime T: type) type {
                 .cursor_style = blk: {
                     var s = style_mod.Style{};
                     s = s.bold(true);
-                    s = s.fg(Color.magenta());
+                    s = s.fg(.magenta);
                     s = s.inline_style(true);
                     break :blk s;
                 },
                 .disabled_style = blk: {
                     var s = style_mod.Style{};
                     s = s.dim(true);
-                    s = s.fg(Color.gray(10));
+                    s = s.fg(.gray(10));
                     s = s.inline_style(true);
                     break :blk s;
                 },

--- a/src/components/rich_log.zig
+++ b/src/components/rich_log.zig
@@ -87,23 +87,23 @@ pub const RichLog = struct {
 
     pub fn init(allocator: std.mem.Allocator, capacity: usize) RichLog {
         var ts = Style{};
-        ts = ts.fg(Color.gray(8));
+        ts = ts.fg(.gray(8));
         ts = ts.inline_style(true);
 
         var trace_s = Style{};
-        trace_s = trace_s.fg(Color.gray(6));
+        trace_s = trace_s.fg(.gray(6));
         trace_s = trace_s.inline_style(true);
         var debug_s = Style{};
-        debug_s = debug_s.fg(Color.gray(10));
+        debug_s = debug_s.fg(.gray(10));
         debug_s = debug_s.inline_style(true);
         var info_s = Style{};
-        info_s = info_s.fg(Color.cyan());
+        info_s = info_s.fg(.cyan);
         info_s = info_s.inline_style(true);
         var warn_s = Style{};
-        warn_s = warn_s.fg(Color.yellow());
+        warn_s = warn_s.fg(.yellow);
         warn_s = warn_s.inline_style(true);
         var err_s = Style{};
-        err_s = err_s.fg(Color.red());
+        err_s = err_s.fg(.red);
         err_s = err_s.bold(true);
         err_s = err_s.inline_style(true);
 
@@ -111,8 +111,8 @@ pub const RichLog = struct {
         text = text.inline_style(true);
 
         var hi = Style{};
-        hi = hi.bg(Color.yellow());
-        hi = hi.fg(Color.black());
+        hi = hi.bg(.yellow);
+        hi = hi.fg(.black);
         hi = hi.inline_style(true);
 
         return .{

--- a/src/components/slider.zig
+++ b/src/components/slider.zig
@@ -61,20 +61,20 @@ pub const Slider = struct {
             .filled_char = "━",
             .track_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(8));
+                s = s.fg(.gray(8));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .filled_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .thumb_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.white());
+                s = s.fg(.white);
                 s = s.inline_style(true);
                 break :blk s;
             },
@@ -86,7 +86,7 @@ pub const Slider = struct {
             },
             .value_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/sortable_table.zig
+++ b/src/components/sortable_table.zig
@@ -31,7 +31,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
         col_aligns: [num_cols]Align = .{.left} ** num_cols,
         show_header: bool = true,
         show_border: bool = true,
-        border_chars: border_mod.BorderChars = border_mod.Border.normal,
+        border_chars: border_mod.BorderChars = .normal,
 
         // Interactive
         cursor_row: usize = 0,
@@ -53,8 +53,8 @@ pub fn SortableTable(comptime num_cols: usize) type {
         },
         cursor_row_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.bg(Color.blue());
-            s = s.fg(Color.white());
+            s = s.bg(.blue);
+            s = s.fg(.white);
             s = s.inline_style(true);
             break :blk s;
         },
@@ -277,7 +277,7 @@ pub fn SortableTable(comptime num_cols: usize) type {
             writer.writeByte('\n') catch {};
             const count = std.fmt.allocPrint(allocator, " {d}/{d} rows", .{ self.view_indices.items.len, self.rows.items.len }) catch "";
             var cs = style_mod.Style{};
-            cs = cs.fg(Color.gray(10));
+            cs = cs.fg(.gray(10));
             cs = cs.inline_style(true);
             writer.writeAll(cs.render(allocator, count) catch count) catch {};
 

--- a/src/components/sparkline.zig
+++ b/src/components/sparkline.zig
@@ -35,7 +35,7 @@ pub const Sparkline = struct {
             .retention_limit = 40,
             .spark_style = blk: {
                 var s = Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 break :blk charting.inlineStyle(s);
             },
             .empty_char = " ",

--- a/src/components/spinner.zig
+++ b/src/components/spinner.zig
@@ -45,7 +45,7 @@ pub const Spinner = struct {
             .fps = 10,
             .spinner_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/split_pane.zig
+++ b/src/components/split_pane.zig
@@ -49,7 +49,7 @@ pub const SplitPane = struct {
 
     pub fn init(orientation: Orientation) SplitPane {
         var ds = style_mod.Style{};
-        ds = ds.fg(Color.gray(6));
+        ds = ds.fg(.gray(6));
         ds = ds.inline_style(true);
         return .{
             .orientation = orientation,

--- a/src/components/status_bar.zig
+++ b/src/components/status_bar.zig
@@ -30,8 +30,8 @@ pub const StatusBar = struct {
 
     pub fn init(allocator: std.mem.Allocator) StatusBar {
         var base = style_mod.Style{};
-        base = base.bg(Color.gray(4));
-        base = base.fg(Color.gray(14));
+        base = base.bg(.gray(4));
+        base = base.fg(.gray(14));
         base = base.inline_style(true);
 
         return .{

--- a/src/components/stepper.zig
+++ b/src/components/stepper.zig
@@ -41,27 +41,27 @@ pub const Stepper = struct {
 
     pub fn init(allocator: std.mem.Allocator) Stepper {
         var completed = style_mod.Style{};
-        completed = completed.fg(Color.green());
+        completed = completed.fg(.green);
         completed = completed.inline_style(true);
 
         var current = style_mod.Style{};
-        current = current.fg(Color.cyan());
+        current = current.fg(.cyan);
         current = current.bold(true);
         current = current.inline_style(true);
 
         var pending = style_mod.Style{};
-        pending = pending.fg(Color.gray(8));
+        pending = pending.fg(.gray(8));
         pending = pending.inline_style(true);
 
         var connector = style_mod.Style{};
-        connector = connector.fg(Color.gray(6));
+        connector = connector.fg(.gray(6));
         connector = connector.inline_style(true);
 
         var title = style_mod.Style{};
         title = title.inline_style(true);
 
         var desc = style_mod.Style{};
-        desc = desc.fg(Color.gray(10));
+        desc = desc.fg(.gray(10));
         desc = desc.inline_style(true);
 
         return .{

--- a/src/components/tab_group.zig
+++ b/src/components/tab_group.zig
@@ -205,30 +205,30 @@ pub const TabGroup = struct {
 
     pub fn init(allocator: std.mem.Allocator) Self {
         var tab_style = style_mod.Style{};
-        tab_style = tab_style.fg(Color.gray(15));
+        tab_style = tab_style.fg(.gray(15));
         tab_style = tab_style.inline_style(true);
 
         var active_style = style_mod.Style{};
-        active_style = active_style.fg(Color.cyan());
+        active_style = active_style.fg(.cyan);
         active_style = active_style.bold(true);
         active_style = active_style.inline_style(true);
 
         var focused_style = style_mod.Style{};
-        focused_style = focused_style.fg(Color.yellow());
+        focused_style = focused_style.fg(.yellow);
         focused_style = focused_style.bold(true);
         focused_style = focused_style.inline_style(true);
 
         var disabled_style = style_mod.Style{};
-        disabled_style = disabled_style.fg(Color.gray(9));
+        disabled_style = disabled_style.fg(.gray(9));
         disabled_style = disabled_style.dim(true);
         disabled_style = disabled_style.inline_style(true);
 
         var sep_style = style_mod.Style{};
-        sep_style = sep_style.fg(Color.gray(11));
+        sep_style = sep_style.fg(.gray(11));
         sep_style = sep_style.inline_style(true);
 
         var overflow_style = style_mod.Style{};
-        overflow_style = overflow_style.fg(Color.gray(12));
+        overflow_style = overflow_style.fg(.gray(12));
         overflow_style = overflow_style.inline_style(true);
 
         return .{

--- a/src/components/table.zig
+++ b/src/components/table.zig
@@ -58,7 +58,7 @@ pub fn Table(comptime num_cols: usize) type {
                 .rows = std.array_list.Managed([num_cols][]const u8).init(allocator),
                 .col_widths = .{null} ** num_cols,
                 .col_aligns = .{.left} ** num_cols,
-                .border_chars = border_mod.Border.normal,
+                .border_chars = .normal,
                 .show_header = true,
                 .show_border = true,
                 .header_style = blk: {
@@ -74,7 +74,7 @@ pub fn Table(comptime num_cols: usize) type {
                 },
                 .border_style = blk: {
                     var s = style_mod.Style{};
-                    s = s.fg(Color.gray(12));
+                    s = s.fg(.gray(12));
                     s = s.inline_style(true);
                     break :blk s;
                 },
@@ -442,7 +442,7 @@ pub const DynamicTableType = struct {
             .allocator = allocator,
             .headers = std.array_list.Managed([]const u8).init(allocator),
             .rows = std.array_list.Managed(std.array_list.Managed([]const u8)).init(allocator),
-            .border_chars = border_mod.Border.normal,
+            .border_chars = .normal,
             .show_header = true,
             .show_border = true,
         };

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -92,13 +92,13 @@ pub const TextArea = struct {
             },
             .line_number_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },
             .placeholder_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/text_input.zig
+++ b/src/components/text_input.zig
@@ -62,7 +62,7 @@ pub const TextInput = struct {
             },
             .placeholder_style = blk: {
                 var s = style.Style{};
-                s = s.fg(Color.gray(12));
+                s = s.fg(.gray(12));
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/timer.zig
+++ b/src/components/timer.zig
@@ -55,14 +55,14 @@ pub const Timer = struct {
             .warning_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .danger_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },

--- a/src/components/toast.zig
+++ b/src/components/toast.zig
@@ -83,40 +83,40 @@ pub const Toast = struct {
             .show_icons = true,
             .show_border = true,
             .show_countdown = false,
-            .border_chars = border_mod.Border.rounded,
+            .border_chars = .rounded,
             .info_icon = "\u{2139}  ",
             .success_icon = "\u{2713} ",
             .warning_icon = "\u{26a0} ",
             .err_icon = "\u{2717} ",
             .info_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.cyan());
+                s = s.fg(.cyan);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .success_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.green());
+                s = s.fg(.green);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .warning_style = blk: {
                 var s = style_mod.Style{};
-                s = s.fg(Color.yellow());
+                s = s.fg(.yellow);
                 s = s.inline_style(true);
                 break :blk s;
             },
             .err_style = blk: {
                 var s = style_mod.Style{};
                 s = s.bold(true);
-                s = s.fg(Color.red());
+                s = s.fg(.red);
                 s = s.inline_style(true);
                 break :blk s;
             },
-            .info_border_fg = Color.cyan(),
-            .success_border_fg = Color.green(),
-            .warning_border_fg = Color.yellow(),
-            .err_border_fg = Color.red(),
+            .info_border_fg = .cyan,
+            .success_border_fg = .green,
+            .warning_border_fg = .yellow,
+            .err_border_fg = .red,
         };
     }
 
@@ -240,7 +240,7 @@ pub const Toast = struct {
             const overflow_text = try std.fmt.allocPrint(allocator, "  +{d} more", .{total - self.max_visible});
             defer allocator.free(overflow_text);
             var dim_style = style_mod.Style{};
-            dim_style = dim_style.fg(Color.gray(10));
+            dim_style = dim_style.fg(.gray(10));
             dim_style = dim_style.inline_style(true);
             const styled = try dim_style.render(allocator, overflow_text);
             defer allocator.free(styled);
@@ -328,7 +328,7 @@ pub const Toast = struct {
         // Countdown
         if (countdown_text.len > 0) {
             var dim_style = style_mod.Style{};
-            dim_style = dim_style.fg(Color.gray(10));
+            dim_style = dim_style.fg(.gray(10));
             dim_style = dim_style.inline_style(true);
             const styled_cd = try dim_style.render(allocator, countdown_text);
             defer allocator.free(styled_cd);

--- a/src/components/tooltip.zig
+++ b/src/components/tooltip.zig
@@ -71,8 +71,8 @@ pub const Tooltip = struct {
 
     // ── Styling ────────────────────────────────────────────────────────
 
-    border_chars: border_mod.BorderChars = border_mod.Border.rounded,
-    border_fg: Color = Color.gray(14),
+    border_chars: border_mod.BorderChars = .rounded,
+    border_fg: Color = .gray(14),
     /// Background for the content area (padding + text) inside the border.
     content_bg: Color = .none,
     /// Background for border characters. Three-state via `?Color`:
@@ -80,13 +80,13 @@ pub const Tooltip = struct {
     /// - `.none` — explicitly no bg; with `inherit_bg` the base shows through.
     /// - any color — use that color for borders only.
     border_bg: ?Color = null,
-    text_style: style_mod.Style = makeStyle(.{ .fg_color = Color.gray(20) }),
-    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = Color.white() }),
+    text_style: style_mod.Style = makeStyle(.{ .fg_color = .gray(20) }),
+    title_style: style_mod.Style = makeStyle(.{ .bold_v = true, .fg_color = .white }),
 
     /// Show an arrow pointing from tooltip toward the target.
     show_arrow: bool = true,
     /// Color of the arrow character.
-    arrow_fg: Color = Color.gray(14),
+    arrow_fg: Color = .gray(14),
     /// Background for the arrow character. Three-state via `?Color`:
     /// - `null` (default) — no bg; with `inherit_bg` the base shows through.
     /// - `.none` — explicitly no bg, even when `inherit_bg` is on.
@@ -141,9 +141,9 @@ pub const Tooltip = struct {
     pub fn help(text: []const u8) Tooltip {
         return .{
             .text = text,
-            .text_style = makeStyle(.{ .dim_v = true, .italic_v = true, .fg_color = Color.gray(16) }),
-            .border_fg = Color.gray(10),
-            .arrow_fg = Color.gray(10),
+            .text_style = makeStyle(.{ .dim_v = true, .italic_v = true, .fg_color = .gray(16) }),
+            .border_fg = .gray(10),
+            .arrow_fg = .gray(10),
         };
     }
 
@@ -152,8 +152,8 @@ pub const Tooltip = struct {
         return .{
             .text = key,
             .title = label,
-            .title_style = makeStyle(.{ .fg_color = Color.gray(18) }),
-            .text_style = makeStyle(.{ .bold_v = true, .fg_color = Color.cyan() }),
+            .title_style = makeStyle(.{ .fg_color = .gray(18) }),
+            .text_style = makeStyle(.{ .bold_v = true, .fg_color = .cyan }),
         };
     }
 

--- a/src/components/virtual_list.zig
+++ b/src/components/virtual_list.zig
@@ -36,8 +36,8 @@ pub fn VirtualList(comptime T: type) type {
         // Styling
         cursor_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.bg(Color.blue());
-            s = s.fg(Color.white());
+            s = s.bg(.blue);
+            s = s.fg(.white);
             s = s.inline_style(true);
             break :blk s;
         },
@@ -48,13 +48,13 @@ pub fn VirtualList(comptime T: type) type {
         },
         selected_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.fg(Color.green());
+            s = s.fg(.green);
             s = s.inline_style(true);
             break :blk s;
         },
         scrollbar_style: style_mod.Style = blk: {
             var s = style_mod.Style{};
-            s = s.fg(Color.gray(8));
+            s = s.fg(.gray(8));
             s = s.inline_style(true);
             break :blk s;
         },
@@ -195,7 +195,7 @@ pub fn VirtualList(comptime T: type) type {
                 writer.writeByte('\n') catch {};
                 const count_str = std.fmt.allocPrint(allocator, " {d}/{d}", .{ self.cursor + 1, total }) catch "";
                 var cs = style_mod.Style{};
-                cs = cs.fg(Color.gray(10));
+                cs = cs.fg(.gray(10));
                 cs = cs.inline_style(true);
                 writer.writeAll(cs.render(allocator, count_str) catch count_str) catch {};
             }

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -237,14 +237,14 @@ pub const Footer = struct {
 
     pub fn init(registry: *const ActionRegistry) Footer {
         var key_s = style_mod.Style{};
-        key_s = key_s.fg(Color.cyan());
+        key_s = key_s.fg(.cyan);
         key_s = key_s.bold(true);
         key_s = key_s.inline_style(true);
         var label_s = style_mod.Style{};
-        label_s = label_s.fg(Color.gray(12));
+        label_s = label_s.fg(.gray(12));
         label_s = label_s.inline_style(true);
         var base = style_mod.Style{};
-        base = base.bg(Color.gray(3));
+        base = base.bg(.gray(3));
         base = base.inline_style(true);
         return .{
             .registry = registry,

--- a/src/root.zig
+++ b/src/root.zig
@@ -107,13 +107,12 @@ pub const MouseState = hitbox.MouseState;
 pub const MouseInteraction = hitbox.Interaction;
 
 // Style
-pub const newStyle = style.newStyle;
 pub const style = @import("style/style.zig");
 pub const Style = style.Style;
 pub const color = @import("style/color.zig");
 pub const Color = color.Color;
-pub const Border = border.BorderChars;
 pub const border = @import("style/border.zig");
+pub const Border = border.BorderChars;
 pub const theme = @import("style/theme.zig");
 pub const Theme = theme.Theme;
 pub const Palette = theme.Palette;

--- a/src/root.zig
+++ b/src/root.zig
@@ -107,12 +107,13 @@ pub const MouseState = hitbox.MouseState;
 pub const MouseInteraction = hitbox.Interaction;
 
 // Style
+pub const newStyle = style.newStyle;
 pub const style = @import("style/style.zig");
 pub const Style = style.Style;
 pub const color = @import("style/color.zig");
 pub const Color = color.Color;
+pub const Border = border.BorderChars;
 pub const border = @import("style/border.zig");
-pub const Border = border.Border;
 pub const theme = @import("style/theme.zig");
 pub const Theme = theme.Theme;
 pub const Palette = theme.Palette;

--- a/src/style/border.zig
+++ b/src/style/border.zig
@@ -18,10 +18,7 @@ pub const BorderChars = struct {
     middle_top: []const u8,
     middle_bottom: []const u8,
     cross: []const u8,
-};
 
-/// Predefined border styles
-pub const Border = struct {
     /// No border
     pub const none = BorderChars{
         .top_left = "",

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -27,56 +27,24 @@ pub const Color = union(enum) {
     };
 
     // Basic ANSI colors
-    pub fn black() Color {
-        return .{ .ansi = .black };
-    }
-    pub fn red() Color {
-        return .{ .ansi = .red };
-    }
-    pub fn green() Color {
-        return .{ .ansi = .green };
-    }
-    pub fn yellow() Color {
-        return .{ .ansi = .yellow };
-    }
-    pub fn blue() Color {
-        return .{ .ansi = .blue };
-    }
-    pub fn magenta() Color {
-        return .{ .ansi = .magenta };
-    }
-    pub fn cyan() Color {
-        return .{ .ansi = .cyan };
-    }
-    pub fn white() Color {
-        return .{ .ansi = .white };
-    }
+    pub const black: Color = .{ .ansi = .black };
+    pub const red: Color = .{ .ansi = .red };
+    pub const green: Color = .{ .ansi = .green };
+    pub const yellow: Color = .{ .ansi = .yellow };
+    pub const blue: Color = .{ .ansi = .blue };
+    pub const magenta: Color = .{ .ansi = .magenta };
+    pub const cyan: Color = .{ .ansi = .cyan };
+    pub const white: Color = .{ .ansi = .white };
 
     // Bright ANSI colors
-    pub fn brightBlack() Color {
-        return .{ .ansi = .bright_black };
-    }
-    pub fn brightRed() Color {
-        return .{ .ansi = .bright_red };
-    }
-    pub fn brightGreen() Color {
-        return .{ .ansi = .bright_green };
-    }
-    pub fn brightYellow() Color {
-        return .{ .ansi = .bright_yellow };
-    }
-    pub fn brightBlue() Color {
-        return .{ .ansi = .bright_blue };
-    }
-    pub fn brightMagenta() Color {
-        return .{ .ansi = .bright_magenta };
-    }
-    pub fn brightCyan() Color {
-        return .{ .ansi = .bright_cyan };
-    }
-    pub fn brightWhite() Color {
-        return .{ .ansi = .bright_white };
-    }
+    pub const brightBlack: Color = .{ .ansi = .bright_black };
+    pub const brightRed: Color = .{ .ansi = .bright_red };
+    pub const brightGreen: Color = .{ .ansi = .bright_green };
+    pub const brightYellow: Color = .{ .ansi = .bright_yellow };
+    pub const brightBlue: Color = .{ .ansi = .bright_blue };
+    pub const brightMagenta: Color = .{ .ansi = .bright_magenta };
+    pub const brightCyan: Color = .{ .ansi = .bright_cyan };
+    pub const brightWhite: Color = .{ .ansi = .bright_white };
 
     /// Create a color from RGB values
     pub fn fromRgb(r: u8, g: u8, b: u8) Color {

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -972,11 +972,6 @@ pub const Style = struct {
     }
 };
 
-/// Create a new empty style
-pub fn newStyle() Style {
-    return Style{};
-}
-
 /// Style range for applying different styles to byte ranges
 pub const StyleRange = struct {
     start: usize,

--- a/src/style/style.zig
+++ b/src/style/style.zig
@@ -11,7 +11,6 @@ const overflow_mod = @import("overflow.zig");
 pub const Overflow = overflow_mod.Overflow;
 
 pub const Color = color_mod.Color;
-pub const Border = border_mod.Border;
 pub const BorderChars = border_mod.BorderChars;
 pub const Sides = border_mod.Sides;
 
@@ -92,8 +91,8 @@ pub const Style = struct {
     margin_val: Spacing = .{},
 
     // Border
-    border_style: BorderChars = Border.none,
-    border_sides: Sides = Sides.none,
+    border_style: BorderChars = .none,
+    border_sides: Sides = .none,
     border_fg: Color = .none,
     border_bg: Color = .none,
 
@@ -272,8 +271,8 @@ pub const Style = struct {
 
     pub fn unsetBorder(self: Self) Self {
         var s = self;
-        s.border_style = Border.none;
-        s.border_sides = Sides.none;
+        s.border_style = .none;
+        s.border_sides = .none;
         s.border_fg = .none;
         s.border_bg = .none;
         s.border_top_fg = .none;
@@ -319,7 +318,7 @@ pub const Style = struct {
     }
 
     pub fn paddingAll(self: Self, n: u16) Self {
-        return self.padding(Spacing.all(n));
+        return self.padding(.all(n));
     }
 
     pub fn paddingLeft(self: Self, n: u16) Self {
@@ -353,7 +352,7 @@ pub const Style = struct {
     }
 
     pub fn marginAll(self: Self, n: u16) Self {
-        return self.margin(Spacing.all(n));
+        return self.margin(.all(n));
     }
 
     pub fn marginLeft(self: Self, n: u16) Self {
@@ -389,7 +388,7 @@ pub const Style = struct {
     }
 
     pub fn borderAll(self: Self, chars: BorderChars) Self {
-        return self.border(chars, Sides.all);
+        return self.border(chars, .all);
     }
 
     pub fn borderForeground(self: Self, c: Color) Self {

--- a/src/style/theme.zig
+++ b/src/style/theme.zig
@@ -38,223 +38,223 @@ pub const Palette = struct {
     // ── Built-in presets ──────────────────────────────
 
     pub const default_dark = Palette{
-        .primary = Color.cyan(),
-        .secondary = Color.magenta(),
-        .accent = Color.yellow(),
-        .background = Color.fromRgb(24, 24, 32),
-        .surface = Color.fromRgb(32, 32, 42),
-        .overlay = Color.fromRgb(40, 40, 52),
-        .foreground = Color.white(),
-        .muted = Color.gray(14),
-        .subtle = Color.gray(10),
-        .success = Color.green(),
-        .warning = Color.yellow(),
-        .danger = Color.red(),
-        .info = Color.cyan(),
-        .border_color = Color.gray(12),
-        .border_focus = Color.cyan(),
-        .highlight = Color.fromRgb(60, 60, 80),
-        .highlight_text = Color.white(),
+        .primary = .cyan,
+        .secondary = .magenta,
+        .accent = .yellow,
+        .background = .fromRgb(24, 24, 32),
+        .surface = .fromRgb(32, 32, 42),
+        .overlay = .fromRgb(40, 40, 52),
+        .foreground = .white,
+        .muted = .gray(14),
+        .subtle = .gray(10),
+        .success = .green,
+        .warning = .yellow,
+        .danger = .red,
+        .info = .cyan,
+        .border_color = .gray(12),
+        .border_focus = .cyan,
+        .highlight = .fromRgb(60, 60, 80),
+        .highlight_text = .white,
     };
 
     pub const default_light = Palette{
-        .primary = Color.fromRgb(0, 120, 180),
-        .secondary = Color.fromRgb(140, 60, 160),
-        .accent = Color.fromRgb(180, 120, 0),
-        .background = Color.fromRgb(250, 250, 250),
-        .surface = Color.fromRgb(240, 240, 240),
-        .overlay = Color.fromRgb(230, 230, 230),
-        .foreground = Color.fromRgb(30, 30, 30),
-        .muted = Color.fromRgb(100, 100, 100),
-        .subtle = Color.fromRgb(160, 160, 160),
-        .success = Color.fromRgb(40, 160, 40),
-        .warning = Color.fromRgb(200, 150, 0),
-        .danger = Color.fromRgb(200, 40, 40),
-        .info = Color.fromRgb(0, 120, 180),
-        .border_color = Color.fromRgb(180, 180, 180),
-        .border_focus = Color.fromRgb(0, 120, 180),
-        .highlight = Color.fromRgb(200, 220, 240),
-        .highlight_text = Color.fromRgb(30, 30, 30),
+        .primary = .fromRgb(0, 120, 180),
+        .secondary = .fromRgb(140, 60, 160),
+        .accent = .fromRgb(180, 120, 0),
+        .background = .fromRgb(250, 250, 250),
+        .surface = .fromRgb(240, 240, 240),
+        .overlay = .fromRgb(230, 230, 230),
+        .foreground = .fromRgb(30, 30, 30),
+        .muted = .fromRgb(100, 100, 100),
+        .subtle = .fromRgb(160, 160, 160),
+        .success = .fromRgb(40, 160, 40),
+        .warning = .fromRgb(200, 150, 0),
+        .danger = .fromRgb(200, 40, 40),
+        .info = .fromRgb(0, 120, 180),
+        .border_color = .fromRgb(180, 180, 180),
+        .border_focus = .fromRgb(0, 120, 180),
+        .highlight = .fromRgb(200, 220, 240),
+        .highlight_text = .fromRgb(30, 30, 30),
     };
 
     pub const catppuccin_mocha = Palette{
-        .primary = Color.fromRgb(137, 180, 250), // blue
-        .secondary = Color.fromRgb(203, 166, 247), // mauve
-        .accent = Color.fromRgb(249, 226, 175), // yellow
-        .background = Color.fromRgb(30, 30, 46), // base
-        .surface = Color.fromRgb(49, 50, 68), // surface0
-        .overlay = Color.fromRgb(69, 71, 90), // surface1
-        .foreground = Color.fromRgb(205, 214, 244), // text
-        .muted = Color.fromRgb(166, 173, 200), // subtext0
-        .subtle = Color.fromRgb(127, 132, 156), // overlay1
-        .success = Color.fromRgb(166, 227, 161), // green
-        .warning = Color.fromRgb(249, 226, 175), // yellow
-        .danger = Color.fromRgb(243, 139, 168), // red
-        .info = Color.fromRgb(137, 180, 250), // blue
-        .border_color = Color.fromRgb(88, 91, 112), // overlay0
-        .border_focus = Color.fromRgb(137, 180, 250), // blue
-        .highlight = Color.fromRgb(49, 50, 68), // surface0
-        .highlight_text = Color.fromRgb(205, 214, 244), // text
+        .primary = .fromRgb(137, 180, 250), // blue
+        .secondary = .fromRgb(203, 166, 247), // mauve
+        .accent = .fromRgb(249, 226, 175), // yellow
+        .background = .fromRgb(30, 30, 46), // base
+        .surface = .fromRgb(49, 50, 68), // surface0
+        .overlay = .fromRgb(69, 71, 90), // surface1
+        .foreground = .fromRgb(205, 214, 244), // text
+        .muted = .fromRgb(166, 173, 200), // subtext0
+        .subtle = .fromRgb(127, 132, 156), // overlay1
+        .success = .fromRgb(166, 227, 161), // green
+        .warning = .fromRgb(249, 226, 175), // yellow
+        .danger = .fromRgb(243, 139, 168), // red
+        .info = .fromRgb(137, 180, 250), // blue
+        .border_color = .fromRgb(88, 91, 112), // overlay0
+        .border_focus = .fromRgb(137, 180, 250), // blue
+        .highlight = .fromRgb(49, 50, 68), // surface0
+        .highlight_text = .fromRgb(205, 214, 244), // text
     };
 
     pub const catppuccin_latte = Palette{
-        .primary = Color.fromRgb(30, 102, 245), // blue
-        .secondary = Color.fromRgb(136, 57, 239), // mauve
-        .accent = Color.fromRgb(223, 142, 29), // yellow
-        .background = Color.fromRgb(239, 241, 245), // base
-        .surface = Color.fromRgb(204, 208, 218), // surface0
-        .overlay = Color.fromRgb(188, 192, 204), // surface1
-        .foreground = Color.fromRgb(76, 79, 105), // text
-        .muted = Color.fromRgb(108, 111, 133), // subtext0
-        .subtle = Color.fromRgb(140, 143, 161), // overlay1
-        .success = Color.fromRgb(64, 160, 43), // green
-        .warning = Color.fromRgb(223, 142, 29), // yellow
-        .danger = Color.fromRgb(210, 15, 57), // red
-        .info = Color.fromRgb(30, 102, 245), // blue
-        .border_color = Color.fromRgb(156, 160, 176), // overlay0
-        .border_focus = Color.fromRgb(30, 102, 245), // blue
-        .highlight = Color.fromRgb(204, 208, 218), // surface0
-        .highlight_text = Color.fromRgb(76, 79, 105), // text
+        .primary = .fromRgb(30, 102, 245), // blue
+        .secondary = .fromRgb(136, 57, 239), // mauve
+        .accent = .fromRgb(223, 142, 29), // yellow
+        .background = .fromRgb(239, 241, 245), // base
+        .surface = .fromRgb(204, 208, 218), // surface0
+        .overlay = .fromRgb(188, 192, 204), // surface1
+        .foreground = .fromRgb(76, 79, 105), // text
+        .muted = .fromRgb(108, 111, 133), // subtext0
+        .subtle = .fromRgb(140, 143, 161), // overlay1
+        .success = .fromRgb(64, 160, 43), // green
+        .warning = .fromRgb(223, 142, 29), // yellow
+        .danger = .fromRgb(210, 15, 57), // red
+        .info = .fromRgb(30, 102, 245), // blue
+        .border_color = .fromRgb(156, 160, 176), // overlay0
+        .border_focus = .fromRgb(30, 102, 245), // blue
+        .highlight = .fromRgb(204, 208, 218), // surface0
+        .highlight_text = .fromRgb(76, 79, 105), // text
     };
 
     pub const dracula = Palette{
-        .primary = Color.fromRgb(189, 147, 249), // purple
-        .secondary = Color.fromRgb(255, 121, 198), // pink
-        .accent = Color.fromRgb(241, 250, 140), // yellow
-        .background = Color.fromRgb(40, 42, 54), // background
-        .surface = Color.fromRgb(68, 71, 90), // current line
-        .overlay = Color.fromRgb(68, 71, 90), // current line
-        .foreground = Color.fromRgb(248, 248, 242), // foreground
-        .muted = Color.fromRgb(98, 114, 164), // comment
-        .subtle = Color.fromRgb(98, 114, 164), // comment
-        .success = Color.fromRgb(80, 250, 123), // green
-        .warning = Color.fromRgb(255, 184, 108), // orange
-        .danger = Color.fromRgb(255, 85, 85), // red
-        .info = Color.fromRgb(139, 233, 253), // cyan
-        .border_color = Color.fromRgb(98, 114, 164), // comment
-        .border_focus = Color.fromRgb(189, 147, 249), // purple
-        .highlight = Color.fromRgb(68, 71, 90), // current line
-        .highlight_text = Color.fromRgb(248, 248, 242), // foreground
+        .primary = .fromRgb(189, 147, 249), // purple
+        .secondary = .fromRgb(255, 121, 198), // pink
+        .accent = .fromRgb(241, 250, 140), // yellow
+        .background = .fromRgb(40, 42, 54), // background
+        .surface = .fromRgb(68, 71, 90), // current line
+        .overlay = .fromRgb(68, 71, 90), // current line
+        .foreground = .fromRgb(248, 248, 242), // foreground
+        .muted = .fromRgb(98, 114, 164), // comment
+        .subtle = .fromRgb(98, 114, 164), // comment
+        .success = .fromRgb(80, 250, 123), // green
+        .warning = .fromRgb(255, 184, 108), // orange
+        .danger = .fromRgb(255, 85, 85), // red
+        .info = .fromRgb(139, 233, 253), // cyan
+        .border_color = .fromRgb(98, 114, 164), // comment
+        .border_focus = .fromRgb(189, 147, 249), // purple
+        .highlight = .fromRgb(68, 71, 90), // current line
+        .highlight_text = .fromRgb(248, 248, 242), // foreground
     };
 
     pub const nord = Palette{
-        .primary = Color.fromRgb(136, 192, 208), // nord8 frost
-        .secondary = Color.fromRgb(129, 161, 193), // nord9
-        .accent = Color.fromRgb(235, 203, 139), // nord13 aurora yellow
-        .background = Color.fromRgb(46, 52, 64), // nord0 polar night
-        .surface = Color.fromRgb(59, 66, 82), // nord1
-        .overlay = Color.fromRgb(67, 76, 94), // nord2
-        .foreground = Color.fromRgb(236, 239, 244), // nord6 snow storm
-        .muted = Color.fromRgb(216, 222, 233), // nord4
-        .subtle = Color.fromRgb(76, 86, 106), // nord3
-        .success = Color.fromRgb(163, 190, 140), // nord14 aurora green
-        .warning = Color.fromRgb(235, 203, 139), // nord13
-        .danger = Color.fromRgb(191, 97, 106), // nord11 aurora red
-        .info = Color.fromRgb(136, 192, 208), // nord8
-        .border_color = Color.fromRgb(76, 86, 106), // nord3
-        .border_focus = Color.fromRgb(136, 192, 208), // nord8
-        .highlight = Color.fromRgb(59, 66, 82), // nord1
-        .highlight_text = Color.fromRgb(236, 239, 244), // nord6
+        .primary = .fromRgb(136, 192, 208), // nord8 frost
+        .secondary = .fromRgb(129, 161, 193), // nord9
+        .accent = .fromRgb(235, 203, 139), // nord13 aurora yellow
+        .background = .fromRgb(46, 52, 64), // nord0 polar night
+        .surface = .fromRgb(59, 66, 82), // nord1
+        .overlay = .fromRgb(67, 76, 94), // nord2
+        .foreground = .fromRgb(236, 239, 244), // nord6 snow storm
+        .muted = .fromRgb(216, 222, 233), // nord4
+        .subtle = .fromRgb(76, 86, 106), // nord3
+        .success = .fromRgb(163, 190, 140), // nord14 aurora green
+        .warning = .fromRgb(235, 203, 139), // nord13
+        .danger = .fromRgb(191, 97, 106), // nord11 aurora red
+        .info = .fromRgb(136, 192, 208), // nord8
+        .border_color = .fromRgb(76, 86, 106), // nord3
+        .border_focus = .fromRgb(136, 192, 208), // nord8
+        .highlight = .fromRgb(59, 66, 82), // nord1
+        .highlight_text = .fromRgb(236, 239, 244), // nord6
     };
 
     pub const high_contrast = Palette{
-        .primary = Color.fromRgb(0, 200, 255),
-        .secondary = Color.fromRgb(255, 100, 255),
-        .accent = Color.fromRgb(255, 255, 0),
-        .background = Color.fromRgb(0, 0, 0),
-        .surface = Color.fromRgb(20, 20, 20),
-        .overlay = Color.fromRgb(40, 40, 40),
-        .foreground = Color.fromRgb(255, 255, 255),
-        .muted = Color.fromRgb(200, 200, 200),
-        .subtle = Color.fromRgb(150, 150, 150),
-        .success = Color.fromRgb(0, 255, 0),
-        .warning = Color.fromRgb(255, 255, 0),
-        .danger = Color.fromRgb(255, 0, 0),
-        .info = Color.fromRgb(0, 200, 255),
-        .border_color = Color.fromRgb(200, 200, 200),
-        .border_focus = Color.fromRgb(0, 200, 255),
-        .highlight = Color.fromRgb(0, 80, 120),
-        .highlight_text = Color.fromRgb(255, 255, 255),
+        .primary = .fromRgb(0, 200, 255),
+        .secondary = .fromRgb(255, 100, 255),
+        .accent = .fromRgb(255, 255, 0),
+        .background = .fromRgb(0, 0, 0),
+        .surface = .fromRgb(20, 20, 20),
+        .overlay = .fromRgb(40, 40, 40),
+        .foreground = .fromRgb(255, 255, 255),
+        .muted = .fromRgb(200, 200, 200),
+        .subtle = .fromRgb(150, 150, 150),
+        .success = .fromRgb(0, 255, 0),
+        .warning = .fromRgb(255, 255, 0),
+        .danger = .fromRgb(255, 0, 0),
+        .info = .fromRgb(0, 200, 255),
+        .border_color = .fromRgb(200, 200, 200),
+        .border_focus = .fromRgb(0, 200, 255),
+        .highlight = .fromRgb(0, 80, 120),
+        .highlight_text = .fromRgb(255, 255, 255),
     };
 
     pub const tokyo_night = Palette{
-        .primary = Color.fromRgb(122, 162, 247), // blue
-        .secondary = Color.fromRgb(187, 154, 247), // purple
-        .accent = Color.fromRgb(224, 175, 104), // yellow
-        .background = Color.fromRgb(26, 27, 38), // bg
-        .surface = Color.fromRgb(36, 40, 59), // bg_highlight
-        .overlay = Color.fromRgb(41, 46, 66), // terminal_black
-        .foreground = Color.fromRgb(192, 202, 245), // fg
-        .muted = Color.fromRgb(144, 153, 191), // comment
-        .subtle = Color.fromRgb(86, 95, 137), // dark5
-        .success = Color.fromRgb(158, 206, 106), // green
-        .warning = Color.fromRgb(224, 175, 104), // yellow
-        .danger = Color.fromRgb(247, 118, 142), // red
-        .info = Color.fromRgb(125, 207, 255), // cyan
-        .border_color = Color.fromRgb(41, 46, 66),
-        .border_focus = Color.fromRgb(122, 162, 247),
-        .highlight = Color.fromRgb(41, 46, 66),
-        .highlight_text = Color.fromRgb(192, 202, 245),
+        .primary = .fromRgb(122, 162, 247), // blue
+        .secondary = .fromRgb(187, 154, 247), // purple
+        .accent = .fromRgb(224, 175, 104), // yellow
+        .background = .fromRgb(26, 27, 38), // bg
+        .surface = .fromRgb(36, 40, 59), // bg_highlight
+        .overlay = .fromRgb(41, 46, 66), // terminal_black
+        .foreground = .fromRgb(192, 202, 245), // fg
+        .muted = .fromRgb(144, 153, 191), // comment
+        .subtle = .fromRgb(86, 95, 137), // dark5
+        .success = .fromRgb(158, 206, 106), // green
+        .warning = .fromRgb(224, 175, 104), // yellow
+        .danger = .fromRgb(247, 118, 142), // red
+        .info = .fromRgb(125, 207, 255), // cyan
+        .border_color = .fromRgb(41, 46, 66),
+        .border_focus = .fromRgb(122, 162, 247),
+        .highlight = .fromRgb(41, 46, 66),
+        .highlight_text = .fromRgb(192, 202, 245),
     };
 
     pub const gruvbox_dark = Palette{
-        .primary = Color.fromRgb(131, 165, 152), // aqua
-        .secondary = Color.fromRgb(211, 134, 155), // purple
-        .accent = Color.fromRgb(250, 189, 47), // yellow
-        .background = Color.fromRgb(40, 40, 40), // bg
-        .surface = Color.fromRgb(60, 56, 54), // bg1
-        .overlay = Color.fromRgb(80, 73, 69), // bg2
-        .foreground = Color.fromRgb(235, 219, 178), // fg
-        .muted = Color.fromRgb(168, 153, 132), // gray
-        .subtle = Color.fromRgb(124, 111, 100), // bg4
-        .success = Color.fromRgb(184, 187, 38), // green
-        .warning = Color.fromRgb(250, 189, 47), // yellow
-        .danger = Color.fromRgb(251, 73, 52), // red
-        .info = Color.fromRgb(131, 165, 152), // aqua
-        .border_color = Color.fromRgb(80, 73, 69),
-        .border_focus = Color.fromRgb(131, 165, 152),
-        .highlight = Color.fromRgb(80, 73, 69),
-        .highlight_text = Color.fromRgb(235, 219, 178),
+        .primary = .fromRgb(131, 165, 152), // aqua
+        .secondary = .fromRgb(211, 134, 155), // purple
+        .accent = .fromRgb(250, 189, 47), // yellow
+        .background = .fromRgb(40, 40, 40), // bg
+        .surface = .fromRgb(60, 56, 54), // bg1
+        .overlay = .fromRgb(80, 73, 69), // bg2
+        .foreground = .fromRgb(235, 219, 178), // fg
+        .muted = .fromRgb(168, 153, 132), // gray
+        .subtle = .fromRgb(124, 111, 100), // bg4
+        .success = .fromRgb(184, 187, 38), // green
+        .warning = .fromRgb(250, 189, 47), // yellow
+        .danger = .fromRgb(251, 73, 52), // red
+        .info = .fromRgb(131, 165, 152), // aqua
+        .border_color = .fromRgb(80, 73, 69),
+        .border_focus = .fromRgb(131, 165, 152),
+        .highlight = .fromRgb(80, 73, 69),
+        .highlight_text = .fromRgb(235, 219, 178),
     };
 
     pub const solarized_dark = Palette{
-        .primary = Color.fromRgb(38, 139, 210), // blue
-        .secondary = Color.fromRgb(108, 113, 196), // violet
-        .accent = Color.fromRgb(181, 137, 0), // yellow
-        .background = Color.fromRgb(0, 43, 54), // base03
-        .surface = Color.fromRgb(7, 54, 66), // base02
-        .overlay = Color.fromRgb(88, 110, 117), // base01
-        .foreground = Color.fromRgb(131, 148, 150), // base0
-        .muted = Color.fromRgb(101, 123, 131), // base00
-        .subtle = Color.fromRgb(88, 110, 117), // base01
-        .success = Color.fromRgb(133, 153, 0), // green
-        .warning = Color.fromRgb(181, 137, 0), // yellow
-        .danger = Color.fromRgb(220, 50, 47), // red
-        .info = Color.fromRgb(42, 161, 152), // cyan
-        .border_color = Color.fromRgb(88, 110, 117),
-        .border_focus = Color.fromRgb(38, 139, 210),
-        .highlight = Color.fromRgb(7, 54, 66),
-        .highlight_text = Color.fromRgb(147, 161, 161),
+        .primary = .fromRgb(38, 139, 210), // blue
+        .secondary = .fromRgb(108, 113, 196), // violet
+        .accent = .fromRgb(181, 137, 0), // yellow
+        .background = .fromRgb(0, 43, 54), // base03
+        .surface = .fromRgb(7, 54, 66), // base02
+        .overlay = .fromRgb(88, 110, 117), // base01
+        .foreground = .fromRgb(131, 148, 150), // base0
+        .muted = .fromRgb(101, 123, 131), // base00
+        .subtle = .fromRgb(88, 110, 117), // base01
+        .success = .fromRgb(133, 153, 0), // green
+        .warning = .fromRgb(181, 137, 0), // yellow
+        .danger = .fromRgb(220, 50, 47), // red
+        .info = .fromRgb(42, 161, 152), // cyan
+        .border_color = .fromRgb(88, 110, 117),
+        .border_focus = .fromRgb(38, 139, 210),
+        .highlight = .fromRgb(7, 54, 66),
+        .highlight_text = .fromRgb(147, 161, 161),
     };
 
     pub const solarized_light = Palette{
-        .primary = Color.fromRgb(38, 139, 210), // blue
-        .secondary = Color.fromRgb(108, 113, 196), // violet
-        .accent = Color.fromRgb(181, 137, 0), // yellow
-        .background = Color.fromRgb(253, 246, 227), // base3
-        .surface = Color.fromRgb(238, 232, 213), // base2
-        .overlay = Color.fromRgb(147, 161, 161), // base1
-        .foreground = Color.fromRgb(101, 123, 131), // base00
-        .muted = Color.fromRgb(131, 148, 150), // base0
-        .subtle = Color.fromRgb(147, 161, 161), // base1
-        .success = Color.fromRgb(133, 153, 0), // green
-        .warning = Color.fromRgb(181, 137, 0), // yellow
-        .danger = Color.fromRgb(220, 50, 47), // red
-        .info = Color.fromRgb(42, 161, 152), // cyan
-        .border_color = Color.fromRgb(147, 161, 161),
-        .border_focus = Color.fromRgb(38, 139, 210),
-        .highlight = Color.fromRgb(238, 232, 213),
-        .highlight_text = Color.fromRgb(88, 110, 117),
+        .primary = .fromRgb(38, 139, 210), // blue
+        .secondary = .fromRgb(108, 113, 196), // violet
+        .accent = .fromRgb(181, 137, 0), // yellow
+        .background = .fromRgb(253, 246, 227), // base3
+        .surface = .fromRgb(238, 232, 213), // base2
+        .overlay = .fromRgb(147, 161, 161), // base1
+        .foreground = .fromRgb(101, 123, 131), // base00
+        .muted = .fromRgb(131, 148, 150), // base0
+        .subtle = .fromRgb(147, 161, 161), // base1
+        .success = .fromRgb(133, 153, 0), // green
+        .warning = .fromRgb(181, 137, 0), // yellow
+        .danger = .fromRgb(220, 50, 47), // red
+        .info = .fromRgb(42, 161, 152), // cyan
+        .border_color = .fromRgb(147, 161, 161),
+        .border_focus = .fromRgb(38, 139, 210),
+        .highlight = .fromRgb(238, 232, 213),
+        .highlight_text = .fromRgb(88, 110, 117),
     };
 
     /// List of all built-in palette names for iteration.
@@ -283,18 +283,18 @@ pub const AdaptivePalette = struct {
     }
 
     pub const catppuccin = AdaptivePalette{
-        .light = Palette.catppuccin_latte,
-        .dark = Palette.catppuccin_mocha,
+        .light = .catppuccin_latte,
+        .dark = .catppuccin_mocha,
     };
 
     pub const default = AdaptivePalette{
-        .light = Palette.default_light,
-        .dark = Palette.default_dark,
+        .light = .default_light,
+        .dark = .default_dark,
     };
 
     pub const solarized = AdaptivePalette{
-        .light = Palette.solarized_light,
-        .dark = Palette.solarized_dark,
+        .light = .solarized_light,
+        .dark = .solarized_dark,
     };
 };
 
@@ -310,7 +310,7 @@ pub const ThemeManager = struct {
         const is_dark = @import("color.zig").hasDarkBackground();
         const palette = AdaptivePalette.default.resolve(is_dark);
         return .{
-            .current = Theme.fromPalette(palette),
+            .current = .fromPalette(palette),
             .is_dark = is_dark,
             .palette_index = 0,
         };
@@ -320,7 +320,7 @@ pub const ThemeManager = struct {
     pub fn initWithPalette(palette: Palette) ThemeManager {
         const is_dark = @import("color.zig").hasDarkBackground();
         return .{
-            .current = Theme.fromPalette(palette),
+            .current = .fromPalette(palette),
             .is_dark = is_dark,
             .palette_index = 0,
         };
@@ -328,27 +328,27 @@ pub const ThemeManager = struct {
 
     /// Switch to a specific palette.
     pub fn setPalette(self: *ThemeManager, palette: Palette) void {
-        self.current = Theme.fromPalette(palette);
+        self.current = .fromPalette(palette);
     }
 
     /// Switch to a named built-in palette by index.
     pub fn setBuiltinByIndex(self: *ThemeManager, index: usize) void {
         if (index < Palette.builtins.len) {
             self.palette_index = index;
-            self.current = Theme.fromPalette(Palette.builtins[index].palette);
+            self.current = .fromPalette(Palette.builtins[index].palette);
         }
     }
 
     /// Cycle to the next built-in palette.
     pub fn nextBuiltin(self: *ThemeManager) void {
         self.palette_index = (self.palette_index + 1) % Palette.builtins.len;
-        self.current = Theme.fromPalette(Palette.builtins[self.palette_index].palette);
+        self.current = .fromPalette(Palette.builtins[self.palette_index].palette);
     }
 
     /// Cycle to the previous built-in palette.
     pub fn prevBuiltin(self: *ThemeManager) void {
         self.palette_index = if (self.palette_index == 0) Palette.builtins.len - 1 else self.palette_index - 1;
-        self.current = Theme.fromPalette(Palette.builtins[self.palette_index].palette);
+        self.current = .fromPalette(Palette.builtins[self.palette_index].palette);
     }
 
     /// Get the name of the current built-in palette.

--- a/tests/accessibility_tests.zig
+++ b/tests/accessibility_tests.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 const zz = @import("zigzag");
 
 test "checkContrast white on black is AAA" {
-    const level = zz.a11y.checkContrast(zz.Color.white(), zz.Color.black());
+    const level = zz.a11y.checkContrast(.white, .black);
     try testing.expectEqual(zz.ContrastLevel.aaa, level);
 }
 
@@ -15,25 +15,25 @@ test "checkContrast similar colors fail" {
 }
 
 test "meetsAA white on dark blue" {
-    const fg = zz.Color.white();
+    const fg = zz.Color.white;
     const bg = zz.Color.fromRgb(0, 0, 100);
     try testing.expect(zz.a11y.meetsAA(fg, bg));
 }
 
 test "meetsAAA white on black" {
-    try testing.expect(zz.a11y.meetsAAA(zz.Color.white(), zz.Color.black()));
+    try testing.expect(zz.a11y.meetsAAA(.white, .black));
 }
 
 test "suggestForeground picks white for dark bg" {
     const bg = zz.Color.fromRgb(20, 20, 20);
     const suggested = zz.a11y.suggestForeground(bg);
-    try testing.expectEqual(zz.Color.white(), suggested);
+    try testing.expectEqual(zz.Color.white, suggested);
 }
 
 test "suggestForeground picks black for light bg" {
     const bg = zz.Color.fromRgb(240, 240, 240);
     const suggested = zz.a11y.suggestForeground(bg);
-    try testing.expectEqual(zz.Color.black(), suggested);
+    try testing.expectEqual(zz.Color.black, suggested);
 }
 
 test "Role label" {

--- a/tests/animation_tests.zig
+++ b/tests/animation_tests.zig
@@ -22,8 +22,8 @@ test "Easing ease_out ends slow" {
 
 test "Easing boundaries" {
     const easings = [_]zz.Easing{
-        .linear,     .ease_in,         .ease_out,
-        .ease_in_out, .ease_in_cubic, .ease_out_cubic,
+        .linear,            .ease_in,       .ease_out,
+        .ease_in_out,       .ease_in_cubic, .ease_out_cubic,
         .ease_in_out_cubic, .bounce,
     };
     for (easings) |e| {
@@ -148,7 +148,7 @@ test "lerp clamps t" {
 }
 
 test "tweenColor interpolates" {
-    const c = zz.tweenColor(zz.Color.red(), zz.Color.blue(), 0.5);
+    const c = zz.tweenColor(.red, .blue, 0.5);
     const rgb = c.toRgb();
     try testing.expect(rgb != null);
 }

--- a/tests/modal_tests.zig
+++ b/tests/modal_tests.zig
@@ -328,8 +328,8 @@ test "backdrop presets render without error" {
         Modal.Backdrop.shade_light,
         Modal.Backdrop.shade_medium,
         Modal.Backdrop.shade_dense,
-        Modal.Backdrop.solid(zz.Color.blue()),
-        Modal.Backdrop.custom("*", zz.Color.red(), zz.Color.black()),
+        Modal.Backdrop.solid(.blue),
+        Modal.Backdrop.custom("*", .red, .black),
     };
 
     for (presets) |preset| {

--- a/tests/slider_tests.zig
+++ b/tests/slider_tests.zig
@@ -99,7 +99,7 @@ test "Slider view renders" {
 test "Slider view with gradient" {
     var s = zz.Slider.init(0, 100);
     s.setValue(50);
-    s.setGradient(zz.Color.red(), zz.Color.green());
+    s.setGradient(.red, .green);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/style_tests.zig
+++ b/tests/style_tests.zig
@@ -22,10 +22,10 @@ test "Color.hex parsing" {
 }
 
 test "Color basic colors" {
-    const red = zz.Color.red();
+    const red = zz.Color.red;
     try testing.expect(red == .ansi);
 
-    const cyan = zz.Color.cyan();
+    const cyan = zz.Color.cyan;
     try testing.expect(cyan == .ansi);
 
     const rgb = zz.Color.fromRgb(100, 150, 200);
@@ -38,8 +38,8 @@ test "Color basic colors" {
 test "Style builder pattern" {
     var style = zz.Style{};
     style = style.bold(true);
-    style = style.fg(zz.Color.red());
-    style = style.bg(zz.Color.black());
+    style = style.fg(.red);
+    style = style.bg(.black);
     style = style.paddingAll(1);
     style = style.marginAll(2);
 
@@ -55,7 +55,7 @@ test "Style render" {
 
     var style = zz.Style{};
     style = style.bold(true);
-    style = style.fg(zz.Color.cyan());
+    style = style.fg(.cyan);
 
     const result = try style.render(allocator, "Hello");
     defer allocator.free(result);
@@ -70,7 +70,7 @@ test "Style render keeps internal newlines but no trailing newline" {
     const allocator = testing.allocator;
 
     var style = zz.Style{};
-    style = style.fg(zz.Color.cyan());
+    style = style.fg(.cyan);
 
     const result = try style.render(allocator, "A\nB");
     defer allocator.free(result);
@@ -80,18 +80,18 @@ test "Style render keeps internal newlines but no trailing newline" {
 }
 
 test "Border styles exist" {
-    _ = zz.Border.normal;
-    _ = zz.Border.rounded;
-    _ = zz.Border.double;
-    _ = zz.Border.thick;
-    _ = zz.Border.ascii;
-    _ = zz.Border.none;
+    _ = zz.border.BorderChars.normal;
+    _ = zz.border.BorderChars.rounded;
+    _ = zz.border.BorderChars.double;
+    _ = zz.border.BorderChars.thick;
+    _ = zz.border.BorderChars.ascii;
+    _ = zz.border.BorderChars.none;
 }
 
 test "Style with border" {
     var style = zz.Style{};
-    style = style.borderAll(zz.Border.rounded);
-    style = style.borderForeground(zz.Color.cyan());
+    style = style.borderAll(.rounded);
+    style = style.borderForeground(.cyan);
 
     try testing.expect(style.border_sides.top);
     try testing.expect(style.border_sides.bottom);

--- a/tests/theme_tests.zig
+++ b/tests/theme_tests.zig
@@ -32,7 +32,7 @@ test "Palette all presets are valid" {
 }
 
 test "Theme fromPalette derives component themes" {
-    const t = zz.Theme.fromPalette(zz.Palette.dracula);
+    const t = zz.Theme.fromPalette(.dracula);
 
     // Text theme inherits from palette
     const p = zz.Palette.dracula;
@@ -63,7 +63,7 @@ test "AdaptivePalette resolves correctly" {
 }
 
 test "Theme styleWith creates inline style" {
-    const s = zz.Theme.styleWith(zz.Color.red());
+    const s = zz.Theme.styleWith(.red);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -73,7 +73,7 @@ test "Theme styleWith creates inline style" {
 }
 
 test "Theme boldStyleWith creates bold inline style" {
-    const s = zz.Theme.boldStyleWith(zz.Color.green());
+    const s = zz.Theme.boldStyleWith(.green);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -111,27 +111,27 @@ test "ThemeManager setPalette with custom palette" {
     var tm = zz.ThemeManager.init();
 
     const custom = zz.Palette{
-        .primary = zz.Color.red(),
-        .secondary = zz.Color.blue(),
-        .accent = zz.Color.green(),
-        .background = zz.Color.black(),
-        .surface = zz.Color.black(),
-        .overlay = zz.Color.black(),
-        .foreground = zz.Color.white(),
-        .muted = zz.Color.gray(14),
-        .subtle = zz.Color.gray(10),
-        .success = zz.Color.green(),
-        .warning = zz.Color.yellow(),
-        .danger = zz.Color.red(),
-        .info = zz.Color.cyan(),
-        .border_color = zz.Color.gray(12),
-        .border_focus = zz.Color.red(),
-        .highlight = zz.Color.gray(5),
-        .highlight_text = zz.Color.white(),
+        .primary = .red,
+        .secondary = .blue,
+        .accent = .green,
+        .background = .black,
+        .surface = .black,
+        .overlay = .black,
+        .foreground = .white,
+        .muted = .gray(14),
+        .subtle = .gray(10),
+        .success = .green,
+        .warning = .yellow,
+        .danger = .red,
+        .info = .cyan,
+        .border_color = .gray(12),
+        .border_focus = .red,
+        .highlight = .gray(5),
+        .highlight_text = .white,
     };
 
     tm.setPalette(custom);
-    try testing.expectEqual(zz.Color.red(), tm.current.palette.primary);
+    try testing.expectEqual(zz.Color.red, tm.current.palette.primary);
 }
 
 test "ThemeManager builtinCount" {
@@ -159,8 +159,8 @@ test "Theme can be overridden per-component" {
     var t = zz.Theme.fromPalette(zz.Palette.nord);
 
     // Override list cursor color
-    t.list.cursor_fg = zz.Color.red();
-    try testing.expectEqual(zz.Color.red(), t.list.cursor_fg);
+    t.list.cursor_fg = zz.Color.red;
+    try testing.expectEqual(zz.Color.red, t.list.cursor_fg);
 
     // Other fields unchanged
     try testing.expectEqual(zz.Palette.nord.foreground, t.list.item_fg);

--- a/tests/viewport_tests.zig
+++ b/tests/viewport_tests.zig
@@ -49,7 +49,7 @@ test "viewport slices ANSI styled content without corrupting output" {
     defer viewport.deinit();
 
     var s = zz.Style{};
-    s = s.fg(zz.Color.cyan());
+    s = s.fg(.cyan);
     s = s.inline_style(true);
     const styled = try s.render(allocator, "abcdef");
     defer allocator.free(styled);


### PR DESCRIPTION
Basic colors are now comptime known values and border defaults have been moved into the border struct itself, allowing them be resolved through result location semantics.

Just realized that Style.zig had a newStyle() func that didn't appear to be used anywhere, exposed that in root.zig.