### PR TITLE
Update to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ZIG_VERSION: "0.15.2"
+  ZIG_VERSION: "0.16.0"
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to ZigZag! This document provides gu
 
 ### Prerequisites
 
-- [Zig](https://ziglang.org/download/) 0.15.0 or later, it needs to be compatible with the latest version
+- [Zig](https://ziglang.org/download/) 0.16.0 or later, it needs to be compatible with the latest version
 - Git
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -80,11 +80,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
     try program.run();
 }
@@ -180,7 +177,7 @@ const output = try style.render(allocator, "Hello, World!");
 // render() does not append an implicit trailing '\n'
 
 // Text transforms
-const upper_style = (zz.Style{}).transform(.uppercase);
+const upper_style = (zz.Style{}).transform(zz.transforms.uppercase); // Pass a function to perform transformations
 const shouting = try upper_style.render(allocator, "hello"); // "HELLO"
 
 // Inline mode is useful when embedding block-styled output in a single line
@@ -886,7 +883,7 @@ const fs = zz.FocusStyle{
 Configure the program with custom options:
 
 ```zig
-var program = try zz.Program(Model).initWithOptions(gpa.allocator(), .{
+var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
     .fps = 60,                  // Target frame rate
     .alt_screen = true,         // Use alternate screen buffer
     .mouse = false,             // Enable mouse tracking
@@ -931,7 +928,7 @@ For model state that must live across frames, allocate with `ctx.persistent_allo
 For applications that need to do other work between frames (network polling, background processing, etc.), use `start()` + `tick()` instead of `run()`:
 
 ```zig
-var program = try zz.Program(Model).init(gpa.allocator());
+var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 defer program.deinit();
 
 try program.start();
@@ -958,7 +955,7 @@ pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
 Intercept and transform messages before they reach your model:
 
 ```zig
-var program = try zz.Program(Model).init(gpa.allocator());
+var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 program.setFilter(&myFilter);
 
 fn myFilter(msg: Model.Msg) ?Model.Msg {

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ const output = try style.render(allocator, "Hello, World!");
 // render() does not append an implicit trailing '\n'
 
 // Text transforms
-const upper_style = (zz.Style{}).transform(zz.transforms.uppercase); // Pass a function to perform transformations
+const upper_style = (zz.Style{}).transform(.uppercase);
 const shouting = try upper_style.render(allocator, "hello"); // "HELLO"
 
 // Inline mode is useful when embedding block-styled output in a single line

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zigzag,
     .version = "0.1.2",
     .fingerprint = 0xdffe16194b187c61,
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -162,7 +162,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -162,7 +162,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -161,11 +161,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
-    defer std.debug.assert(gpa.deinit() == .ok);
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -204,7 +204,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -204,7 +204,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -203,11 +203,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -158,7 +158,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -157,11 +157,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -158,7 +158,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -80,18 +80,26 @@ const Model = struct {
         return .none;
     }
 
+    fn sleepNs(ns: u64) void {
+        const duration: std.Io.Clock.Duration = .{
+            .raw = std.Io.Duration.fromNanoseconds(@intCast(ns)),
+            .clock = .boot,
+        };
+        duration.sleep(std.Io.Threaded.global_single_threaded.io()) catch {};
+    }
+
     fn task1() ?Msg {
-        std.Thread.sleep(500_000_000); // 500ms
+        sleepNs(500_000_000); // 500ms
         return .{ .task_complete = .{ .id = 0, .value = "Task 1: computed pi = 3.14159" } };
     }
 
     fn task2() ?Msg {
-        std.Thread.sleep(1_000_000_000); // 1s
+        sleepNs(1_000_000_000); // 1s
         return .{ .task_complete = .{ .id = 1, .value = "Task 2: fetched 42 records" } };
     }
 
     fn task3() ?Msg {
-        std.Thread.sleep(750_000_000); // 750ms
+        sleepNs(750_000_000); // 750ms
         return .{ .task_complete = .{ .id = 2, .value = "Task 3: file processed OK" } };
     }
 

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -137,7 +137,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -136,11 +136,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -29,7 +29,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+    pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
         switch (msg) {
             .key => |k| switch (k.key) {
                 .char => |c| switch (c) {
@@ -40,9 +40,9 @@ const Model = struct {
                         if (self.tasks_launched != 0) return .none;
                         self.status = "Tasks running...";
                         self.results = .{ "pending...", "pending...", "pending..." };
-                        _ = self.async_runner.spawn(&task1);
-                        _ = self.async_runner.spawn(&task2);
-                        _ = self.async_runner.spawn(&task3);
+                        _ = self.async_runner.spawnWithArg(std.Io, ctx.io, &task1);
+                        _ = self.async_runner.spawnWithArg(std.Io, ctx.io, &task2);
+                        _ = self.async_runner.spawnWithArg(std.Io, ctx.io, &task3);
                         self.tasks_launched = 3;
                         return zz.Cmd(Msg).everyMs(100);
                     },
@@ -80,26 +80,26 @@ const Model = struct {
         return .none;
     }
 
-    fn sleepNs(ns: u64) void {
+    fn sleepNs(io: std.Io, ns: u64) void {
         const duration: std.Io.Clock.Duration = .{
             .raw = std.Io.Duration.fromNanoseconds(@intCast(ns)),
             .clock = .boot,
         };
-        duration.sleep(std.Io.Threaded.global_single_threaded.io()) catch {};
+        duration.sleep(io) catch {};
     }
 
-    fn task1() ?Msg {
-        sleepNs(500_000_000); // 500ms
+    fn task1(io: std.Io) ?Msg {
+        sleepNs(io, 500_000_000); // 500ms
         return .{ .task_complete = .{ .id = 0, .value = "Task 1: computed pi = 3.14159" } };
     }
 
-    fn task2() ?Msg {
-        sleepNs(1_000_000_000); // 1s
+    fn task2(io: std.Io) ?Msg {
+        sleepNs(io, 1_000_000_000); // 1s
         return .{ .task_complete = .{ .id = 1, .value = "Task 2: fetched 42 records" } };
     }
 
-    fn task3() ?Msg {
-        sleepNs(750_000_000); // 750ms
+    fn task3(io: std.Io) ?Msg {
+        sleepNs(io, 750_000_000); // 750ms
         return .{ .task_complete = .{ .id = 2, .value = "Task 3: file processed OK" } };
     }
 

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -137,7 +137,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -89,17 +89,17 @@ const Model = struct {
     }
 
     fn task1(io: std.Io) ?Msg {
-        sleepNs(io, 500_000_000); // 500ms
+        std.Io.sleep(io, .fromMilliseconds(500), .boot) catch unreachable; // 500ms
         return .{ .task_complete = .{ .id = 0, .value = "Task 1: computed pi = 3.14159" } };
     }
 
     fn task2(io: std.Io) ?Msg {
-        sleepNs(io, 1_000_000_000); // 1s
+        std.Io.sleep(io, .fromMilliseconds(1000), .boot) catch unreachable; // 1s
         return .{ .task_complete = .{ .id = 1, .value = "Task 2: fetched 42 records" } };
     }
 
     fn task3(io: std.Io) ?Msg {
-        sleepNs(io, 750_000_000); // 750ms
+        std.Io.sleep(io, .fromMilliseconds(750), .boot) catch unreachable; // 750ms
         return .{ .task_complete = .{ .id = 2, .value = "Task 3: file processed OK" } };
     }
 
@@ -121,7 +121,8 @@ const Model = struct {
         box_s = box_s.paddingAll(1);
         box_s = box_s.width(45);
 
-        const results_text = std.fmt.allocPrint(alloc,
+        const results_text = std.fmt.allocPrint(
+            alloc,
             "1: {s}\n2: {s}\n3: {s}",
             .{ self.results[0], self.results[1], self.results[2] },
         ) catch "";
@@ -130,7 +131,8 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
                 title_s.render(alloc, "Async Tasks Demo") catch "Async Tasks",

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -134,7 +134,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -134,7 +134,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -133,11 +133,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -80,11 +80,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -81,7 +81,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -81,7 +81,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -310,7 +310,7 @@ fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]c
 }
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
     try program.run();
 }

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -310,7 +310,7 @@ fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]c
 }
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
     try program.run();
 }

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -309,11 +309,8 @@ fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]c
     return try std.fmt.allocPrint(ctx.allocator, "{s}: {s}", .{ rendered_label, rendered_value });
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
     try program.run();
 }

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -130,7 +130,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -130,7 +130,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -129,11 +129,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .title = "ZigZag OSC 52 Clipboard",
         .osc52 = .{
             .enabled = true,

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -184,11 +184,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).initWithOptions(gpa.allocator(), .{
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
         .title = "ZigZag OSC 52 Clipboard",
         .osc52 = .{
             .enabled = true,

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
         .title = "ZigZag OSC 52 Clipboard",
         .osc52 = .{
             .enabled = true,

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -7,11 +7,8 @@ const zz = @import("zigzag");
 const zig_source =
     \\const std = @import("std");
     \\
-    \\pub fn main() !void {
-    \\    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    \\    defer _ = gpa.deinit();
-    \\
-    \\    const allocator = gpa.allocator();
+    \\pub fn main(init: std.process.Init) !void {
+    \\    const allocator = init.gpa;
     \\    var list = std.std.array_list.Managed(u32).init(allocator);
     \\    defer list.deinit();
     \\
@@ -115,11 +112,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -113,7 +113,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -113,7 +113,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -139,11 +139,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -110,7 +110,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -110,7 +110,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -109,11 +109,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -262,7 +262,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -262,7 +262,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -261,11 +261,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -92,7 +92,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -92,7 +92,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -91,11 +91,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -99,16 +99,13 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    console = zz.DevConsole.init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    console = zz.DevConsole.init(init.gpa);
     defer console.deinit();
     try console.addSink(.{ .file = "dev_console.log" });
     try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });
 
-    var program = try zz.Program(Model).init(gpa.allocator());
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -100,7 +100,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    console = zz.DevConsole.init(init.gpa);
+    console = zz.DevConsole.init(init.gpa, init.io);
     defer console.deinit();
     try console.addSink(.{ .file = "dev_console.log" });
     try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -105,7 +105,7 @@ pub fn main(init: std.process.Init) !void {
     try console.addSink(.{ .file = "dev_console.log" });
     try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });
 
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -105,7 +105,7 @@ pub fn main(init: std.process.Init) !void {
     try console.addSink(.{ .file = "dev_console.log" });
     try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });
 
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -96,11 +96,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -97,7 +97,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -97,7 +97,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -120,7 +120,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -119,11 +119,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -120,7 +120,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -68,13 +68,10 @@ const Model = struct {
 
             // Read first 500 bytes
             var buf: [500]u8 = undefined;
-            const bytes_read = file.readStreaming(io, &.{&buf}) catch |err| switch (err) {
-                error.EndOfStream => 0,
-                else => {
-                    self.error_message = "Cannot read file";
-                    self.preview.clearRetainingCapacity();
-                    return;
-                },
+            const bytes_read = file.readPositionalAll(io, &buf, 0) catch {
+                self.error_message = "Cannot read file";
+                self.preview.clearRetainingCapacity();
+                return;
             };
 
             self.preview.clearRetainingCapacity();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -166,7 +166,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -166,7 +166,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -18,8 +18,8 @@ const Model = struct {
         self.file_picker.height = ctx.height -| 10;
 
         // Start at home directory
-        self.file_picker.navigateHome() catch {
-            self.file_picker.navigate("/") catch {};
+        self.file_picker.navigateHome(ctx.io, ctx.environ_map) catch {
+            self.file_picker.navigate(ctx.io, "/") catch {};
         };
 
         self.preview = std.array_list.Managed(u8).init(ctx.persistent_allocator);
@@ -34,17 +34,17 @@ const Model = struct {
                     .char => |c| switch (c) {
                         'q' => return .quit,
                         else => {
-                            const selected = self.file_picker.handleKey(k) catch false;
+                            const selected = self.file_picker.handleKey(ctx.io, ctx.environ_map, k) catch false;
                             if (selected) {
-                                self.loadPreview();
+                                self.loadPreview(ctx.io);
                             }
                         },
                     },
                     .escape => return .quit,
                     else => {
-                        const selected = self.file_picker.handleKey(k) catch false;
+                        const selected = self.file_picker.handleKey(ctx.io, ctx.environ_map, k) catch false;
                         if (selected) {
-                            self.loadPreview();
+                            self.loadPreview(ctx.io);
                         }
                     },
                 }
@@ -56,22 +56,25 @@ const Model = struct {
         return .none;
     }
 
-    fn loadPreview(self: *Model) void {
+    fn loadPreview(self: *Model, io: std.Io) void {
         if (self.file_picker.getSelected()) |path| {
             // Try to read file preview
-            const file = std.fs.openFileAbsolute(path, .{}) catch {
+            const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch {
                 self.error_message = "Cannot open file";
                 self.preview.clearRetainingCapacity();
                 return;
             };
-            defer file.close();
+            defer file.close(io);
 
             // Read first 500 bytes
             var buf: [500]u8 = undefined;
-            const bytes_read = file.read(&buf) catch {
-                self.error_message = "Cannot read file";
-                self.preview.clearRetainingCapacity();
-                return;
+            const bytes_read = file.readStreaming(io, &.{&buf}) catch |err| switch (err) {
+                error.EndOfStream => 0,
+                else => {
+                    self.error_message = "Cannot read file";
+                    self.preview.clearRetainingCapacity();
+                    return;
+                },
             };
 
             self.preview.clearRetainingCapacity();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -165,11 +165,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -107,11 +107,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -215,11 +215,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var prog = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var prog = try zz.Program(Model).init(init.gpa);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa);
+    var prog = try zz.Program(Model).init(init.gpa, init.io);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io);
+    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -78,11 +78,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -79,7 +79,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -79,7 +79,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -105,11 +105,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -106,7 +106,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -106,7 +106,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -79,11 +79,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -80,7 +80,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -80,7 +80,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -325,7 +325,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -324,11 +324,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -325,7 +325,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -107,11 +107,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -90,7 +90,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -89,11 +89,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -53,8 +53,13 @@ const Model = struct {
         self.md.width = @min(ctx.width -| 4, 80);
 
         self.viewport = zz.components.Viewport.init(ctx.persistent_allocator, self.md.width, ctx.height -| 4);
-        const rendered = self.md.render(ctx.persistent_allocator, sample_md) catch "render error";
-        self.viewport.setContent(rendered) catch {};
+        // Viewport.setContent dupes; render output is ephemeral.
+        if (self.md.render(ctx.persistent_allocator, sample_md)) |rendered| {
+            defer ctx.persistent_allocator.free(rendered);
+            self.viewport.setContent(rendered) catch {};
+        } else |_| {
+            self.viewport.setContent("render error") catch {};
+        }
 
         return .none;
     }

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -90,7 +90,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -156,7 +156,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -155,11 +155,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -156,7 +156,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -145,7 +145,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io);
+    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -144,11 +144,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var prog = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var prog = try zz.Program(Model).init(init.gpa);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -145,7 +145,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa);
+    var prog = try zz.Program(Model).init(init.gpa, init.io);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .mouse = true,
     });
     defer program.deinit();

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
         .mouse = true,
     });
     defer program.deinit();

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -139,11 +139,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).initWithOptions(gpa.allocator(), .{
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
         .mouse = true,
     });
     defer program.deinit();

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -21,10 +21,10 @@ const Model = struct {
         log.show_timestamps = true;
 
         // Seed with a few entries.
-        log.append(.info, "RichLog example started") catch {};
-        log.append(.debug, "buffer capacity = 500 entries") catch {};
-        log.append(.info, "follow-mode enabled — new entries scroll into view") catch {};
-        log.append(.warn, "press '/' to filter, 'l' to cycle min level") catch {};
+        log.append(ctx.io, .info, "RichLog example started") catch {};
+        log.append(ctx.io, .debug, "buffer capacity = 500 entries") catch {};
+        log.append(ctx.io, .info, "follow-mode enabled — new entries scroll into view") catch {};
+        log.append(ctx.io, .warn, "press '/' to filter, 'l' to cycle min level") catch {};
 
         self.* = .{
             .log = log,
@@ -40,11 +40,11 @@ const Model = struct {
         self.search_term.deinit();
     }
 
-    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
+    pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
         switch (msg) {
             .tick => {
                 self.counter += 1;
-                self.emit();
+                self.emit(ctx);
             },
             .key => |k| {
                 if (self.typing_search) return self.handleSearchKey(k);
@@ -104,15 +104,15 @@ const Model = struct {
         self.log.setMinLevel(next);
     }
 
-    fn emit(self: *Model) void {
+    fn emit(self: *Model, ctx: *zz.Context) void {
         // Generate one varied log entry per tick. Format strings must be
         // comptime, so dispatch in a switch.
         switch (self.counter % 5) {
-            0 => self.log.appendFmt(.trace, "trace: tick {d} fired", .{self.counter}) catch {},
-            1 => self.log.appendFmt(.debug, "debug: queue depth {d}", .{self.counter}) catch {},
-            2 => self.log.appendFmt(.info, "info: synced {d} records", .{self.counter}) catch {},
-            3 => self.log.appendFmt(.warn, "warn: retry {d} after backoff", .{self.counter}) catch {},
-            else => self.log.appendFmt(.err, "ERROR: timeout on request {d}", .{self.counter}) catch {},
+            0 => self.log.appendFmt(ctx.io, .trace, "trace: tick {d} fired", .{self.counter}) catch {},
+            1 => self.log.appendFmt(ctx.io, .debug, "debug: queue depth {d}", .{self.counter}) catch {},
+            2 => self.log.appendFmt(ctx.io, .info, "info: synced {d} records", .{self.counter}) catch {},
+            3 => self.log.appendFmt(ctx.io, .warn, "warn: retry {d} after backoff", .{self.counter}) catch {},
+            else => self.log.appendFmt(ctx.io, .err, "ERROR: timeout on request {d}", .{self.counter}) catch {},
         }
     }
 

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -161,7 +161,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -161,7 +161,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -160,11 +160,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -184,11 +184,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -1036,7 +1036,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
         .mouse = true,
         .title = "ZigZag Showcase",
     });

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -1035,11 +1035,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).initWithOptions(gpa.allocator(), .{
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).initWithOptions(init.gpa, .{
         .mouse = true,
         .title = "ZigZag Showcase",
     });

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -1036,7 +1036,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, .{
+    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .mouse = true,
         .title = "ZigZag Showcase",
     });

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -105,7 +105,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -105,7 +105,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -104,11 +104,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -72,11 +72,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -73,7 +73,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -73,7 +73,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -132,7 +132,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -131,11 +131,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -132,7 +132,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -132,11 +132,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -133,7 +133,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -133,7 +133,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -148,7 +148,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -148,7 +148,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -147,11 +147,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -104,7 +104,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -104,7 +104,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -103,11 +103,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -153,7 +153,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -15,7 +15,7 @@ const Model = struct {
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
-        self.tm = zz.ThemeManager.init();
+        self.tm = zz.ThemeManager.init(ctx.environ_map);
         self.progress_val = 35;
         // Also set the theme on the context so components can read it
         ctx.setTheme(self.tm.current.palette);
@@ -153,7 +153,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -152,11 +152,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -215,11 +215,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -289,11 +289,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -290,7 +290,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -290,7 +290,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -246,7 +246,7 @@ fn clearShortcut(label: []const u8, key: []const u8) zz.Tooltip {
 }
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa);
+    var prog = try zz.Program(Model).init(init.gpa, init.io);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -246,7 +246,7 @@ fn clearShortcut(label: []const u8, key: []const u8) zz.Tooltip {
 }
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io);
+    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -245,11 +245,8 @@ fn clearShortcut(label: []const u8, key: []const u8) zz.Tooltip {
     return t;
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var prog = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var prog = try zz.Program(Model).init(init.gpa);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -79,11 +79,8 @@ const items_array = blk: {
     break :blk arr;
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -80,7 +80,7 @@ const items_array = blk: {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -80,7 +80,7 @@ const items_array = blk: {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -90,7 +90,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io);
+    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -89,11 +89,8 @@ const Model = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var program = try zz.Program(Model).init(gpa.allocator());
+pub fn main(init: std.process.Init) !void {
+    var program = try zz.Program(Model).init(init.gpa);
     defer program.deinit();
 
     try program.run();

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -90,7 +90,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa);
+    var program = try zz.Program(Model).init(init.gpa, init.io);
     defer program.deinit();
 
     try program.run();

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -171,7 +171,7 @@ pub const FilePicker = struct {
             // Check extensions if specified
             if (self.allowed_extensions) |exts| {
                 if (entry.kind != .directory) {
-                    const ext = std.Io.Dir.path.extension(entry.name);
+                    const ext = std.fs.path.extension(entry.name);
                     var found = false;
                     for (exts) |allowed_ext| {
                         if (std.mem.eql(u8, ext, allowed_ext)) {
@@ -261,12 +261,12 @@ pub const FilePicker = struct {
         if (entry.entry_type == .directory or entry.entry_type == .parent) {
             // Navigate into directory
             if (entry.entry_type == .parent) {
-                const parent = std.Io.Dir.path.dirname(self.current_path.items) orelse "/";
+                const parent = std.fs.path.dirname(self.current_path.items) orelse "/";
                 const parent_copy = try self.allocator.dupe(u8, parent);
                 defer self.allocator.free(parent_copy);
                 try self.navigate(io, parent_copy);
             } else {
-                const new_path = try std.Io.Dir.path.join(self.allocator, &.{ self.current_path.items, entry.name });
+                const new_path = try std.fs.path.join(self.allocator, &.{ self.current_path.items, entry.name });
                 defer self.allocator.free(new_path);
                 try self.navigate(io, new_path);
             }
@@ -276,7 +276,7 @@ pub const FilePicker = struct {
             if (self.selected_path) |path| {
                 self.allocator.free(path);
             }
-            self.selected_path = try std.Io.Dir.path.join(self.allocator, &.{ self.current_path.items, entry.name });
+            self.selected_path = try std.fs.path.join(self.allocator, &.{ self.current_path.items, entry.name });
             return true;
         }
     }
@@ -304,7 +304,7 @@ pub const FilePicker = struct {
             .down => self.cursorDown(),
             .enter => return try self.selectCurrent(io),
             .backspace => {
-                const parent = std.Io.Dir.path.dirname(self.current_path.items) orelse "/";
+                const parent = std.fs.path.dirname(self.current_path.items) orelse "/";
                 const parent_copy = try self.allocator.dupe(u8, parent);
                 defer self.allocator.free(parent_copy);
                 try self.navigate(io, parent_copy);

--- a/src/components/file_picker.zig
+++ b/src/components/file_picker.zig
@@ -8,7 +8,7 @@ const keys = @import("../input/keys.zig");
 const style_mod = @import("../style/style.zig");
 const Color = @import("../style/color.zig").Color;
 const measure = @import("../layout/measure.zig");
-const fs = std.fs;
+const Dir = std.Io.Dir;
 
 pub const FilePicker = struct {
     allocator: std.mem.Allocator,
@@ -128,7 +128,7 @@ pub const FilePicker = struct {
     }
 
     /// Navigate to a directory
-    pub fn navigate(self: *FilePicker, path: []const u8) !void {
+    pub fn navigate(self: *FilePicker, io: std.Io, path: []const u8) !void {
         // Update current path
         self.current_path.clearRetainingCapacity();
         try self.current_path.appendSlice(path);
@@ -151,13 +151,13 @@ pub const FilePicker = struct {
         }
 
         // Read directory
-        var dir = fs.openDirAbsolute(path, .{ .iterate = true }) catch {
+        var dir = Dir.openDirAbsolute(io, path, .{ .iterate = true }) catch {
             return;
         };
-        defer dir.close();
+        defer dir.close(io);
 
         var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
+        while (iter.next(io) catch null) |entry| {
             // Skip hidden files if not showing them
             const is_hidden = entry.name.len > 0 and entry.name[0] == '.';
             if (is_hidden and !self.show_hidden) continue;
@@ -171,7 +171,7 @@ pub const FilePicker = struct {
             // Check extensions if specified
             if (self.allowed_extensions) |exts| {
                 if (entry.kind != .directory) {
-                    const ext = std.fs.path.extension(entry.name);
+                    const ext = std.Io.Dir.path.extension(entry.name);
                     var found = false;
                     for (exts) |allowed_ext| {
                         if (std.mem.eql(u8, ext, allowed_ext)) {
@@ -186,7 +186,7 @@ pub const FilePicker = struct {
             // Get file size
             var size: u64 = 0;
             if (entry.kind == .file) {
-                const stat = dir.statFile(entry.name) catch null;
+                const stat = dir.statFile(io, entry.name, .{}) catch null;
                 if (stat) |s| {
                     size = s.size;
                 }
@@ -225,16 +225,14 @@ pub const FilePicker = struct {
         self.y_offset = 0;
     }
 
-    /// Navigate to home directory
-    pub fn navigateHome(self: *FilePicker) !void {
+    /// Navigate to home directory using the supplied environment.
+    pub fn navigateHome(self: *FilePicker, io: std.Io, environ_map: *const std.process.Environ.Map) !void {
         if (comptime builtin.os.tag == .windows) {
-            var env_map = try std.process.getEnvMap(self.allocator);
-            defer env_map.deinit();
-            const home = env_map.get("USERPROFILE") orelse "C:\\";
-            try self.navigate(home);
+            const home = environ_map.get("USERPROFILE") orelse "C:\\";
+            try self.navigate(io, home);
         } else {
-            const home = std.posix.getenv("HOME") orelse "/";
-            try self.navigate(home);
+            const home = environ_map.get("HOME") orelse "/";
+            try self.navigate(io, home);
         }
     }
 
@@ -255,7 +253,7 @@ pub const FilePicker = struct {
     }
 
     /// Select current entry
-    pub fn selectCurrent(self: *FilePicker) !bool {
+    pub fn selectCurrent(self: *FilePicker, io: std.Io) !bool {
         if (self.cursor >= self.entries.items.len) return false;
 
         const entry = self.entries.items[self.cursor];
@@ -263,14 +261,14 @@ pub const FilePicker = struct {
         if (entry.entry_type == .directory or entry.entry_type == .parent) {
             // Navigate into directory
             if (entry.entry_type == .parent) {
-                const parent = std.fs.path.dirname(self.current_path.items) orelse "/";
+                const parent = std.Io.Dir.path.dirname(self.current_path.items) orelse "/";
                 const parent_copy = try self.allocator.dupe(u8, parent);
                 defer self.allocator.free(parent_copy);
-                try self.navigate(parent_copy);
+                try self.navigate(io, parent_copy);
             } else {
-                const new_path = try std.fs.path.join(self.allocator, &.{ self.current_path.items, entry.name });
+                const new_path = try std.Io.Dir.path.join(self.allocator, &.{ self.current_path.items, entry.name });
                 defer self.allocator.free(new_path);
-                try self.navigate(new_path);
+                try self.navigate(io, new_path);
             }
             return false;
         } else {
@@ -278,7 +276,7 @@ pub const FilePicker = struct {
             if (self.selected_path) |path| {
                 self.allocator.free(path);
             }
-            self.selected_path = try std.fs.path.join(self.allocator, &.{ self.current_path.items, entry.name });
+            self.selected_path = try std.Io.Dir.path.join(self.allocator, &.{ self.current_path.items, entry.name });
             return true;
         }
     }
@@ -294,24 +292,29 @@ pub const FilePicker = struct {
     }
 
     /// Handle key event
-    pub fn handleKey(self: *FilePicker, key: keys.KeyEvent) !bool {
+    pub fn handleKey(
+        self: *FilePicker,
+        io: std.Io,
+        environ_map: *const std.process.Environ.Map,
+        key: keys.KeyEvent,
+    ) !bool {
         if (!self.focused) return false;
         switch (key.key) {
             .up => self.cursorUp(),
             .down => self.cursorDown(),
-            .enter => return try self.selectCurrent(),
+            .enter => return try self.selectCurrent(io),
             .backspace => {
-                const parent = std.fs.path.dirname(self.current_path.items) orelse "/";
+                const parent = std.Io.Dir.path.dirname(self.current_path.items) orelse "/";
                 const parent_copy = try self.allocator.dupe(u8, parent);
                 defer self.allocator.free(parent_copy);
-                try self.navigate(parent_copy);
+                try self.navigate(io, parent_copy);
             },
             .char => |c| {
                 switch (c) {
                     'j' => self.cursorDown(),
                     'k' => self.cursorUp(),
-                    'h' => self.showHidden(),
-                    '~' => try self.navigateHome(),
+                    'h' => self.showHidden(io),
+                    '~' => try self.navigateHome(io, environ_map),
                     else => {},
                 }
             },
@@ -320,11 +323,11 @@ pub const FilePicker = struct {
         return false;
     }
 
-    fn showHidden(self: *FilePicker) void {
+    fn showHidden(self: *FilePicker, io: std.Io) void {
         self.show_hidden = !self.show_hidden;
         const path_copy = self.allocator.dupe(u8, self.current_path.items) catch return;
         defer self.allocator.free(path_copy);
-        self.navigate(path_copy) catch {};
+        self.navigate(io, path_copy) catch {};
     }
 
     fn ensureVisible(self: *FilePicker) void {

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -139,7 +139,7 @@ pub const Markdown = struct {
             first_line = false;
 
             // Code block toggle
-            if (std.mem.startsWith(u8, std.mem.trimLeft(u8, line, " "), "```")) {
+            if (std.mem.startsWith(u8, std.mem.trimStart(u8, line, " "), "```")) {
                 in_code_block = !in_code_block;
                 if (in_code_block) {
                     // Opening fence
@@ -173,7 +173,7 @@ pub const Markdown = struct {
                 continue;
             }
 
-            const trimmed = std.mem.trimLeft(u8, line, " ");
+            const trimmed = std.mem.trimStart(u8, line, " ");
 
             // Horizontal rule
             if (trimmed.len >= 3 and isAllChar(trimmed, '-')) {

--- a/src/components/markdown.zig
+++ b/src/components/markdown.zig
@@ -128,7 +128,13 @@ pub const Markdown = struct {
     /// Render markdown text to styled terminal output.
     pub fn render(self: *const Markdown, allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
         var result: Writer.Allocating = .init(allocator);
+        errdefer result.deinit();
         const writer = &result.writer;
+
+        // Intermediate styled spans get freed in bulk at end of render.
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const tmp = arena.allocator();
 
         var lines_iter = std.mem.splitScalar(u8, source, '\n');
         var in_code_block = false;
@@ -143,32 +149,32 @@ pub const Markdown = struct {
                 in_code_block = !in_code_block;
                 if (in_code_block) {
                     // Opening fence
-                    const bar = try self.code_block_border.render(allocator, "┌");
+                    const bar = try self.code_block_border.render(tmp, "┌");
                     try writer.writeAll(bar);
-                    const dash = try self.code_block_border.render(allocator, "─");
+                    const dash = try self.code_block_border.render(tmp, "─");
                     for (0..@min(self.width - 2, 40)) |_| {
                         try writer.writeAll(dash);
                     }
-                    const end = try self.code_block_border.render(allocator, "┐");
+                    const end = try self.code_block_border.render(tmp, "┐");
                     try writer.writeAll(end);
                 } else {
                     // Closing fence
-                    const bar = try self.code_block_border.render(allocator, "└");
+                    const bar = try self.code_block_border.render(tmp, "└");
                     try writer.writeAll(bar);
-                    const dash = try self.code_block_border.render(allocator, "─");
+                    const dash = try self.code_block_border.render(tmp, "─");
                     for (0..@min(self.width - 2, 40)) |_| {
                         try writer.writeAll(dash);
                     }
-                    const end = try self.code_block_border.render(allocator, "┘");
+                    const end = try self.code_block_border.render(tmp, "┘");
                     try writer.writeAll(end);
                 }
                 continue;
             }
 
             if (in_code_block) {
-                const bar = try self.code_block_border.render(allocator, "│ ");
+                const bar = try self.code_block_border.render(tmp, "│ ");
                 try writer.writeAll(bar);
-                const styled = try self.code_block_style.render(allocator, line);
+                const styled = try self.code_block_style.render(tmp, line);
                 try writer.writeAll(styled);
                 continue;
             }
@@ -177,7 +183,7 @@ pub const Markdown = struct {
 
             // Horizontal rule
             if (trimmed.len >= 3 and isAllChar(trimmed, '-')) {
-                const dash = try self.hr_style.render(allocator, self.hr_char);
+                const dash = try self.hr_style.render(tmp, self.hr_char);
                 for (0..@min(self.width, 60)) |_| {
                     try writer.writeAll(dash);
                 }
@@ -185,7 +191,7 @@ pub const Markdown = struct {
             }
 
             if (trimmed.len >= 3 and isAllChar(trimmed, '*') and !std.mem.startsWith(u8, trimmed, "**")) {
-                const dash = try self.hr_style.render(allocator, self.hr_char);
+                const dash = try self.hr_style.render(tmp, self.hr_char);
                 for (0..@min(self.width, 60)) |_| {
                     try writer.writeAll(dash);
                 }
@@ -195,19 +201,19 @@ pub const Markdown = struct {
             // Headers
             if (std.mem.startsWith(u8, trimmed, "### ")) {
                 const content = trimmed[4..];
-                const styled = try self.h3_style.render(allocator, content);
+                const styled = try self.h3_style.render(tmp, content);
                 try writer.writeAll(styled);
                 continue;
             }
             if (std.mem.startsWith(u8, trimmed, "## ")) {
                 const content = trimmed[3..];
-                const styled = try self.h2_style.render(allocator, content);
+                const styled = try self.h2_style.render(tmp, content);
                 try writer.writeAll(styled);
                 continue;
             }
             if (std.mem.startsWith(u8, trimmed, "# ")) {
                 const content = trimmed[2..];
-                const styled = try self.h1_style.render(allocator, content);
+                const styled = try self.h1_style.render(tmp, content);
                 try writer.writeAll(styled);
                 continue;
             }
@@ -215,9 +221,9 @@ pub const Markdown = struct {
             // Blockquote
             if (std.mem.startsWith(u8, trimmed, "> ")) {
                 const content = trimmed[2..];
-                const bar = try self.blockquote_bar.render(allocator, "│ ");
+                const bar = try self.blockquote_bar.render(tmp, "│ ");
                 try writer.writeAll(bar);
-                const styled = try self.blockquote_style.render(allocator, content);
+                const styled = try self.blockquote_style.render(tmp, content);
                 try writer.writeAll(styled);
                 continue;
             }
@@ -226,10 +232,10 @@ pub const Markdown = struct {
             if (std.mem.startsWith(u8, trimmed, "- ") or std.mem.startsWith(u8, trimmed, "* ")) {
                 const indent = line.len - trimmed.len;
                 for (0..indent) |_| try writer.writeByte(' ');
-                const bullet = try self.list_bullet_style.render(allocator, "• ");
+                const bullet = try self.list_bullet_style.render(tmp, "• ");
                 try writer.writeAll(bullet);
                 const content = trimmed[2..];
-                const styled = try self.renderInline(allocator, content);
+                const styled = try self.renderInline(tmp, content);
                 try writer.writeAll(styled);
                 continue;
             }
@@ -239,10 +245,10 @@ pub const Markdown = struct {
                 if (std.mem.indexOf(u8, trimmed[0..@min(4, trimmed.len)], ". ")) |dot_pos| {
                     const indent = line.len - trimmed.len;
                     for (0..indent) |_| try writer.writeByte(' ');
-                    const num = try self.list_bullet_style.render(allocator, trimmed[0 .. dot_pos + 2]);
+                    const num = try self.list_bullet_style.render(tmp, trimmed[0 .. dot_pos + 2]);
                     try writer.writeAll(num);
                     const content = trimmed[dot_pos + 2 ..];
-                    const styled = try self.renderInline(allocator, content);
+                    const styled = try self.renderInline(tmp, content);
                     try writer.writeAll(styled);
                     continue;
                 }
@@ -254,7 +260,7 @@ pub const Markdown = struct {
             }
 
             // Regular paragraph with inline formatting
-            const styled = try self.renderInline(allocator, line);
+            const styled = try self.renderInline(tmp, line);
             try writer.writeAll(styled);
         }
 
@@ -262,8 +268,11 @@ pub const Markdown = struct {
     }
 
     /// Render inline formatting: **bold**, *italic*, `code`, [links](url)
+    /// `allocator` should be a short-lived/arena allocator: intermediate styled
+    /// spans are leaked into it (freed in bulk when the arena is reset).
     fn renderInline(self: *const Markdown, allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
         var result: Writer.Allocating = .init(allocator);
+        errdefer result.deinit();
         const writer = &result.writer;
 
         var i: usize = 0;

--- a/src/components/rich_log.zig
+++ b/src/components/rich_log.zig
@@ -47,7 +47,7 @@ pub const Level = enum {
 
 pub const Entry = struct {
     level: Level,
-    /// Unix nanoseconds, populated by `append` from `std.time.nanoTimestamp()`.
+    /// Unix nanoseconds, populated by `append` from `std.Io.Timestamp.now(io, .real)`.
     timestamp_ns: i128,
     text: []u8,
 };
@@ -165,7 +165,7 @@ pub const RichLog = struct {
     }
 
     /// Append an entry, dropping the oldest if at capacity.
-    pub fn append(self: *RichLog, level: Level, text: []const u8) !void {
+    pub fn append(self: *RichLog, io: std.Io, level: Level, text: []const u8) !void {
         const owned = try self.allocator.dupe(u8, text);
         if (self.entries.items.len >= self.capacity) {
             const oldest = self.entries.orderedRemove(0);
@@ -173,7 +173,7 @@ pub const RichLog = struct {
         }
         try self.entries.append(.{
             .level = level,
-            .timestamp_ns = std.time.nanoTimestamp(),
+            .timestamp_ns = std.Io.Timestamp.now(io, .real).toNanoseconds(),
             .text = owned,
         });
         self.visible_dirty = true;
@@ -181,10 +181,10 @@ pub const RichLog = struct {
     }
 
     /// Append using std.fmt-style formatting.
-    pub fn appendFmt(self: *RichLog, level: Level, comptime fmt: []const u8, args: anytype) !void {
+    pub fn appendFmt(self: *RichLog, io: std.Io, level: Level, comptime fmt: []const u8, args: anytype) !void {
         const formatted = try std.fmt.allocPrint(self.allocator, fmt, args);
         defer self.allocator.free(formatted);
-        try self.append(level, formatted);
+        try self.append(io, level, formatted);
     }
 
     pub fn clear(self: *RichLog) void {
@@ -349,10 +349,10 @@ test "append respects capacity" {
     const allocator = std.testing.allocator;
     var log = RichLog.init(allocator, 3);
     defer log.deinit();
-    try log.append(.info, "a");
-    try log.append(.info, "b");
-    try log.append(.info, "c");
-    try log.append(.info, "d");
+    try log.append(std.testing.io, .info, "a");
+    try log.append(std.testing.io, .info, "b");
+    try log.append(std.testing.io, .info, "c");
+    try log.append(std.testing.io, .info, "d");
     try std.testing.expectEqual(@as(usize, 3), log.entries.items.len);
     try std.testing.expectEqualStrings("b", log.entries.items[0].text);
     try std.testing.expectEqualStrings("d", log.entries.items[2].text);
@@ -362,8 +362,8 @@ test "min level filters entries" {
     const allocator = std.testing.allocator;
     var log = RichLog.init(allocator, 100);
     defer log.deinit();
-    try log.append(.debug, "noise");
-    try log.append(.warn, "important");
+    try log.append(std.testing.io, .debug, "noise");
+    try log.append(std.testing.io, .warn, "important");
     log.setMinLevel(.warn);
     try log.refresh();
     try std.testing.expectEqual(@as(usize, 1), log.visible.items.len);
@@ -373,8 +373,8 @@ test "search filter matches substring" {
     const allocator = std.testing.allocator;
     var log = RichLog.init(allocator, 10);
     defer log.deinit();
-    try log.append(.info, "hello world");
-    try log.append(.info, "goodbye");
+    try log.append(std.testing.io, .info, "hello world");
+    try log.append(std.testing.io, .info, "goodbye");
     try log.setSearch("hello");
     try log.refresh();
     try std.testing.expectEqual(@as(usize, 1), log.visible.items.len);
@@ -387,7 +387,7 @@ test "follow mode auto-scrolls" {
     log.setSize(80, 2);
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        try log.appendFmt(.info, "line {d}", .{i});
+        try log.appendFmt(std.testing.io, .info, "line {d}", .{i});
     }
     try log.refresh();
     // Last two entries should fit; offset should be 3.
@@ -398,7 +398,7 @@ test "scrollUp disables follow" {
     const allocator = std.testing.allocator;
     var log = RichLog.init(allocator, 100);
     defer log.deinit();
-    try log.append(.info, "a");
+    try log.append(std.testing.io, .info, "a");
     log.scrollUp(1);
     try std.testing.expect(!log.follow);
 }
@@ -410,7 +410,7 @@ test "view emits at most height lines" {
     log.setSize(80, 3);
     var i: usize = 0;
     while (i < 10) : (i += 1) {
-        try log.appendFmt(.info, "line {d}", .{i});
+        try log.appendFmt(std.testing.io, .info, "line {d}", .{i});
     }
     const out = try log.view(allocator);
     defer allocator.free(out);

--- a/src/core/context.zig
+++ b/src/core/context.zig
@@ -347,10 +347,10 @@ pub const Options = struct {
     title: ?[]const u8 = null,
 
     /// Custom input file (default: stdin)
-    input: ?std.fs.File = null,
+    input: ?std.Io.File = null,
 
     /// Custom output file (default: stdout)
-    output: ?std.fs.File = null,
+    output: ?std.Io.File = null,
 
     /// Log file path for debug output
     log_file: ?[]const u8 = null,

--- a/src/core/context.zig
+++ b/src/core/context.zig
@@ -21,6 +21,9 @@ pub const Context = struct {
     /// Process environment for env-driven detection (color, multiplexer, locale).
     environ_map: *const std.process.Environ.Map,
 
+    /// Asynchronous I/O facilities (file, network, time, sleep).
+    io: std.Io,
+
     /// Terminal width in columns
     width: u16,
 
@@ -76,12 +79,14 @@ pub const Context = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         persistent_allocator: std.mem.Allocator,
+        io: std.Io,
         environ_map: *const std.process.Environ.Map,
     ) Context {
         const profile = color_mod.ColorProfile.detect(environ_map);
         return .{
             .allocator = allocator,
             .persistent_allocator = persistent_allocator,
+            .io = io,
             .environ_map = environ_map,
             .width = 80,
             .height = 24,

--- a/src/core/context.zig
+++ b/src/core/context.zig
@@ -18,6 +18,9 @@ pub const Context = struct {
     /// Persistent allocator for model state (not reset between frames)
     persistent_allocator: std.mem.Allocator,
 
+    /// Process environment for env-driven detection (color, multiplexer, locale).
+    environ_map: *const std.process.Environ.Map,
+
     /// Terminal width in columns
     width: u16,
 
@@ -70,11 +73,16 @@ pub const Context = struct {
         }
     }
 
-    pub fn init(allocator: std.mem.Allocator, persistent_allocator: std.mem.Allocator) Context {
-        const profile = color_mod.ColorProfile.detect();
+    pub fn init(
+        allocator: std.mem.Allocator,
+        persistent_allocator: std.mem.Allocator,
+        environ_map: *const std.process.Environ.Map,
+    ) Context {
+        const profile = color_mod.ColorProfile.detect(environ_map);
         return .{
             .allocator = allocator,
             .persistent_allocator = persistent_allocator,
+            .environ_map = environ_map,
             .width = 80,
             .height = 24,
             .frame = 0,
@@ -83,7 +91,7 @@ pub const Context = struct {
             .true_color = profile.supportsTrueColor(),
             .color_256 = profile.supports256(),
             .color_profile = profile,
-            .is_dark_background = color_mod.hasDarkBackground(),
+            .is_dark_background = color_mod.hasDarkBackground(environ_map),
             .unicode_width_strategy = unicode_mod.getWidthStrategy(),
             .terminal_mode_2027 = false,
             .kitty_text_sizing = false,

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -63,7 +63,7 @@ pub const SinkConfig = union(enum) {
 pub const DevConsole = struct {
     allocator: std.mem.Allocator,
     sinks: std.array_list.Managed(Sink),
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
     /// Filter: events below this level are dropped.
     min_level: Level,
     /// Whether to prefix each line with a timestamp.
@@ -81,7 +81,7 @@ pub const DevConsole = struct {
         server: std.net.Server,
         thread: std.Thread,
         connections: std.array_list.Managed(std.net.Stream),
-        mutex: std.Thread.Mutex,
+        mutex: std.Io.Mutex,
         /// Set to true to signal the accept thread to stop.
         stopping: std.atomic.Value(bool),
     };

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -73,6 +73,10 @@ pub const DevConsole = struct {
     const Sink = union(enum) {
         file: struct {
             file: std.Io.File,
+            /// Append cursor. Only advanced after a successful flush — a failed
+            /// write leaves it pointing at the truncated record's start, so the
+            /// next entry overwrites the partial one. Not safe under concurrent
+            /// writers to the same file.
             end_pos: u64,
         },
         tcp: *TcpSink,

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -110,7 +110,7 @@ pub const DevConsole = struct {
                 .tcp => |tcp| {
                     tcp.stopping.store(true, .seq_cst);
                     // Wake the listener by connecting once.
-                    if (tcp.listen_address.connect(io, .{})) |conn| {
+                    if (tcp.listen_address.connect(io, .{ .mode = .stream })) |conn| {
                         conn.close(io);
                     } else |_| {}
                     tcp.thread.join();
@@ -141,7 +141,7 @@ pub const DevConsole = struct {
                 try self.sinks.append(.stderr);
             },
             .tcp => |t| {
-                const addr = try std.Io.net.IpAddress.parseIp(t.host, t.port);
+                const addr = try std.Io.net.IpAddress.parse(t.host, t.port);
                 var server = try addr.listen(io, .{ .reuse_address = true });
                 errdefer server.deinit(io);
 

--- a/src/core/dev_console.zig
+++ b/src/core/dev_console.zig
@@ -62,6 +62,7 @@ pub const SinkConfig = union(enum) {
 
 pub const DevConsole = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     sinks: std.array_list.Managed(Sink),
     mutex: std.Io.Mutex,
     /// Filter: events below this level are dropped.
@@ -71,44 +72,50 @@ pub const DevConsole = struct {
 
     const Sink = union(enum) {
         file: struct {
-            file: std.fs.File,
+            file: std.Io.File,
+            end_pos: u64,
         },
-        tcp: TcpSink,
+        tcp: *TcpSink,
         stderr,
     };
 
     const TcpSink = struct {
-        server: std.net.Server,
+        io: std.Io,
+        allocator: std.mem.Allocator,
+        listen_address: std.Io.net.IpAddress,
+        server: std.Io.net.Server,
         thread: std.Thread,
-        connections: std.array_list.Managed(std.net.Stream),
+        connections: std.array_list.Managed(std.Io.net.Stream),
         mutex: std.Io.Mutex,
         /// Set to true to signal the accept thread to stop.
         stopping: std.atomic.Value(bool),
     };
 
-    pub fn init(allocator: std.mem.Allocator) DevConsole {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) DevConsole {
         return .{
             .allocator = allocator,
+            .io = io,
             .sinks = std.array_list.Managed(Sink).init(allocator),
-            .mutex = .{},
+            .mutex = .init,
             .min_level = .trace,
             .show_timestamps = true,
         };
     }
 
     pub fn deinit(self: *DevConsole) void {
+        const io = self.io;
         for (self.sinks.items) |*sink| {
             switch (sink.*) {
-                .file => |*f| f.file.close(),
-                .tcp => |*tcp| {
+                .file => |*f| f.file.close(io),
+                .tcp => |tcp| {
                     tcp.stopping.store(true, .seq_cst);
                     // Wake the listener by connecting once.
-                    if (std.net.tcpConnectToAddress(tcp.server.listen_address)) |conn| {
-                        conn.close();
+                    if (tcp.listen_address.connect(io, .{})) |conn| {
+                        conn.close(io);
                     } else |_| {}
                     tcp.thread.join();
-                    tcp.server.deinit();
-                    for (tcp.connections.items) |c| c.close();
+                    tcp.server.deinit(io);
+                    for (tcp.connections.items) |*c| c.close(io);
                     tcp.connections.deinit();
                     self.allocator.destroy(tcp);
                 },
@@ -123,55 +130,55 @@ pub const DevConsole = struct {
     }
 
     pub fn addSink(self: *DevConsole, cfg: SinkConfig) !void {
+        const io = self.io;
         switch (cfg) {
             .file => |path| {
-                const file = try std.fs.cwd().createFile(path, .{ .truncate = false });
-                file.seekFromEnd(0) catch {};
-                try self.sinks.append(.{ .file = .{ .file = file } });
+                const file = try std.Io.Dir.cwd().createFile(io, path, .{ .truncate = false });
+                const end_pos = std.Io.File.length(file, io) catch 0;
+                try self.sinks.append(.{ .file = .{ .file = file, .end_pos = end_pos } });
             },
             .stderr => {
                 try self.sinks.append(.stderr);
             },
             .tcp => |t| {
-                const addr = try std.net.Address.parseIp(t.host, t.port);
-                var server = try addr.listen(.{ .reuse_address = true });
-                errdefer server.deinit();
+                const addr = try std.Io.net.IpAddress.parseIp(t.host, t.port);
+                var server = try addr.listen(io, .{ .reuse_address = true });
+                errdefer server.deinit(io);
 
                 const tcp_ptr = try self.allocator.create(TcpSink);
                 errdefer self.allocator.destroy(tcp_ptr);
                 tcp_ptr.* = .{
+                    .io = io,
+                    .allocator = self.allocator,
+                    .listen_address = addr,
                     .server = server,
                     .thread = undefined,
-                    .connections = std.array_list.Managed(std.net.Stream).init(self.allocator),
-                    .mutex = .{},
+                    .connections = std.array_list.Managed(std.Io.net.Stream).init(self.allocator),
+                    .mutex = .init,
                     .stopping = std.atomic.Value(bool).init(false),
                 };
 
                 tcp_ptr.thread = try std.Thread.spawn(.{}, acceptLoop, .{tcp_ptr});
-                try self.sinks.append(.{ .tcp = tcp_ptr.* });
-                // Note: the `tcp` variant of Sink stores the TcpSink by value.
-                // We allocated the heap copy for the thread to reference; the
-                // sink's value copy is independent. Replace the value-stored
-                // field with one that points at the heap to keep them in sync.
-                // (We accept the slight indirection cost for clarity.)
+                try self.sinks.append(.{ .tcp = tcp_ptr });
             },
         }
     }
 
     fn acceptLoop(tcp: *TcpSink) void {
+        const io = tcp.io;
         while (!tcp.stopping.load(.seq_cst)) {
-            const conn = tcp.server.accept() catch break;
+            const conn = tcp.server.accept(io) catch break;
             if (tcp.stopping.load(.seq_cst)) {
-                conn.stream.close();
+                conn.close(io);
                 break;
             }
-            tcp.mutex.lock();
-            tcp.connections.append(conn.stream) catch {
-                conn.stream.close();
-                tcp.mutex.unlock();
+            tcp.mutex.lockUncancelable(io);
+            tcp.connections.append(conn) catch {
+                conn.close(io);
+                tcp.mutex.unlock(io);
                 continue;
             };
-            tcp.mutex.unlock();
+            tcp.mutex.unlock(io);
         }
     }
 
@@ -182,42 +189,52 @@ pub const DevConsole = struct {
         var stack_buf: [4096]u8 = undefined;
         const line = self.format(stack_buf[0..], level, fmt, args) catch return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = self.io;
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         for (self.sinks.items) |*sink| {
             switch (sink.*) {
                 .file => |*f| {
-                    f.file.writeAll(line) catch {};
+                    var write_buf: [1024]u8 = undefined;
+                    var w = f.file.writer(io, &write_buf);
+                    w.seekTo(f.end_pos) catch continue;
+                    w.interface.writeAll(line) catch continue;
+                    w.interface.flush() catch continue;
+                    f.end_pos = w.logicalPos();
                 },
                 .stderr => {
                     std.debug.print("{s}", .{line});
                 },
-                .tcp => |*tcp_val| {
-                    // We only ever read tcp_val.connections (and its mutex).
-                    var keep = std.array_list.Managed(std.net.Stream).init(self.allocator);
+                .tcp => |tcp| {
+                    var keep = std.array_list.Managed(std.Io.net.Stream).init(self.allocator);
                     defer keep.deinit();
 
-                    tcp_val.mutex.lock();
-                    defer tcp_val.mutex.unlock();
-                    for (tcp_val.connections.items) |conn| {
-                        conn.writeAll(line) catch continue;
-                        keep.append(conn) catch continue;
+                    tcp.mutex.lockUncancelable(io);
+                    defer tcp.mutex.unlock(io);
+                    for (tcp.connections.items) |conn| {
+                        var write_buf: [1024]u8 = undefined;
+                        var w = conn.writer(io, &write_buf);
+                        if (w.interface.writeAll(line)) |_| {
+                            if (w.interface.flush()) |_| {
+                                keep.append(conn) catch continue;
+                            } else |_| {}
+                        } else |_| {}
                     }
                     // Drop dead connections.
-                    if (keep.items.len != tcp_val.connections.items.len) {
-                        for (tcp_val.connections.items) |conn| {
+                    if (keep.items.len != tcp.connections.items.len) {
+                        for (tcp.connections.items) |conn| {
                             var still_alive = false;
                             for (keep.items) |k| {
-                                if (k.handle == conn.handle) {
+                                if (k.socket.handle == conn.socket.handle) {
                                     still_alive = true;
                                     break;
                                 }
                             }
-                            if (!still_alive) conn.close();
+                            if (!still_alive) conn.close(io);
                         }
-                        tcp_val.connections.clearRetainingCapacity();
-                        tcp_val.connections.appendSlice(keep.items) catch {};
+                        tcp.connections.clearRetainingCapacity();
+                        tcp.connections.appendSlice(keep.items) catch {};
                     }
                 },
             }
@@ -227,7 +244,7 @@ pub const DevConsole = struct {
     fn format(self: *const DevConsole, buf: []u8, level: Level, comptime fmt: []const u8, args: anytype) ![]u8 {
         var writer: Writer = .fixed(buf);
         if (self.show_timestamps) {
-            const now = std.time.timestamp();
+            const now = std.Io.Timestamp.now(self.io, .real).toSeconds();
             const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(now) };
             const day = epoch.getDaySeconds();
             try writer.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
@@ -266,23 +283,24 @@ const testing = std.testing;
 
 test "file sink writes formatted log lines" {
     const allocator = testing.allocator;
+    const io = testing.io;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var orig = try std.fs.cwd().openDir(".", .{});
-    defer orig.close();
-    try tmp.dir.setAsCwd();
-    defer orig.setAsCwd() catch {};
+    var orig = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig) catch {};
 
-    var console = DevConsole.init(allocator);
+    var console = DevConsole.init(allocator, io);
     defer console.deinit();
     try console.addSink(.{ .file = "console.log" });
 
     console.info("hello {s}", .{"world"});
     console.warn("careful", .{});
 
-    const contents = try std.fs.cwd().readFileAlloc(allocator, "console.log", 4096);
-    defer allocator.free(contents);
+    var buf: [4096]u8 = undefined;
+    const contents = try std.Io.Dir.cwd().readFile(io, "console.log", &buf);
 
     try testing.expect(std.mem.indexOf(u8, contents, "hello world") != null);
     try testing.expect(std.mem.indexOf(u8, contents, "INFO") != null);
@@ -291,15 +309,16 @@ test "file sink writes formatted log lines" {
 
 test "min level filter" {
     const allocator = testing.allocator;
+    const io = testing.io;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var orig = try std.fs.cwd().openDir(".", .{});
-    defer orig.close();
-    try tmp.dir.setAsCwd();
-    defer orig.setAsCwd() catch {};
+    var orig = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer orig.close(io);
+    try std.process.setCurrentDir(io, tmp.dir);
+    defer std.process.setCurrentDir(io, orig) catch {};
 
-    var console = DevConsole.init(allocator);
+    var console = DevConsole.init(allocator, io);
     defer console.deinit();
     try console.addSink(.{ .file = "filtered.log" });
     console.setMinLevel(.warn);
@@ -307,8 +326,8 @@ test "min level filter" {
     console.debug("hidden", .{});
     console.warn("visible", .{});
 
-    const contents = try std.fs.cwd().readFileAlloc(allocator, "filtered.log", 4096);
-    defer allocator.free(contents);
+    var buf: [4096]u8 = undefined;
+    const contents = try std.Io.Dir.cwd().readFile(io, "filtered.log", &buf);
     try testing.expect(std.mem.indexOf(u8, contents, "hidden") == null);
     try testing.expect(std.mem.indexOf(u8, contents, "visible") != null);
 }

--- a/src/core/log.zig
+++ b/src/core/log.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 /// Logger that writes timestamped messages to a file
 pub const Logger = struct {
     file: std.fs.File,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
 
     /// Initialize a logger that writes to the given file path
     pub fn init(path: []const u8) !Logger {

--- a/src/core/log.zig
+++ b/src/core/log.zig
@@ -7,6 +7,10 @@ const std = @import("std");
 pub const Logger = struct {
     io: std.Io,
     file: std.Io.File,
+    /// Append cursor. Only advanced after a successful flush — a failed write
+    /// leaves it pointing at where the truncated record started, so the next
+    /// log line will overwrite the partial one. Acceptable for a debug logger;
+    /// not safe under concurrent writers to the same file.
     end_pos: u64,
     mutex: std.Io.Mutex,
 

--- a/src/core/log.zig
+++ b/src/core/log.zig
@@ -5,45 +5,52 @@ const std = @import("std");
 
 /// Logger that writes timestamped messages to a file
 pub const Logger = struct {
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
+    end_pos: u64,
     mutex: std.Io.Mutex,
 
     /// Initialize a logger that writes to the given file path
-    pub fn init(path: []const u8) !Logger {
-        const file = try std.fs.cwd().createFile(path, .{ .truncate = false });
-        // Seek to end for append behavior
-        file.seekFromEnd(0) catch {};
+    pub fn init(io: std.Io, path: []const u8) !Logger {
+        const file = try std.Io.Dir.cwd().createFile(io, path, .{ .truncate = false });
+        // Capture current length so subsequent writes append.
+        const end_pos = std.Io.File.length(file, io) catch 0;
         return .{
+            .io = io,
             .file = file,
-            .mutex = .{},
+            .end_pos = end_pos,
+            .mutex = .init,
         };
     }
 
     /// Close the log file
     pub fn deinit(self: *Logger) void {
-        self.file.close();
+        self.file.close(self.io);
     }
 
     /// Write a log message with timestamp prefix
     pub fn log(self: *Logger, comptime fmt: []const u8, args: anytype) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
-        const writer = self.file.writer();
+        var buf: [1024]u8 = undefined;
+        var w = self.file.writer(self.io, &buf);
+        w.seekTo(self.end_pos) catch return;
 
-        // Write timestamp
-        const now = std.time.timestamp();
+        const now = std.Io.Timestamp.now(self.io, .real).toSeconds();
         const epoch_seconds = std.time.epoch.EpochSeconds{ .secs = @intCast(now) };
         const day_seconds = epoch_seconds.getDaySeconds();
 
-        writer.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
+        w.interface.print("[{d:0>2}:{d:0>2}:{d:0>2}] ", .{
             day_seconds.getHoursIntoDay(),
             day_seconds.getMinutesIntoHour(),
             day_seconds.getSecondsIntoMinute(),
         }) catch return;
 
-        // Write message
-        writer.print(fmt, args) catch return;
-        writer.writeByte('\n') catch return;
+        w.interface.print(fmt, args) catch return;
+        w.interface.writeByte('\n') catch return;
+        w.interface.flush() catch return;
+
+        self.end_pos = w.logicalPos();
     }
 };

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -155,14 +155,14 @@ pub fn Program(comptime Model: type) type {
         pub fn start(self: *Self) !void {
             // Initialize logger if configured
             if (self.options.log_file) |log_path| {
-                self.logger = Logger.init(log_path) catch null;
+                self.logger = Logger.init(self.io, log_path) catch null;
                 if (self.logger != null) {
                     self.context._logger = &self.logger.?;
                 }
             }
 
             // Initialize terminal
-            self.terminal = try Terminal.init(.{
+            self.terminal = try Terminal.init(self.io, .{
                 .alt_screen = self.options.alt_screen,
                 .hide_cursor = !self.options.cursor,
                 .mouse = self.options.mouse,

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -100,7 +100,7 @@ pub fn Program(comptime Model: type) type {
                 .terminal = null,
                 // `self` is returned by value, so don't capture an arena allocator here.
                 // It would point at this function's stack copy and dangle after return.
-                .context = Context.init(allocator, allocator, environ_map),
+                .context = Context.init(allocator, allocator, io, environ_map),
                 .options = options,
                 .running = false,
                 .clock_epoch = clock_epoch,

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -46,13 +46,17 @@ pub fn Program(comptime Model: type) type {
 
     return struct {
         allocator: std.mem.Allocator,
+        io: std.Io,
         arena: std.heap.ArenaAllocator,
         model: Model,
         terminal: ?Terminal,
         context: Context,
         options: Options,
         running: bool,
-        clock: std.time.Timer,
+        /// Boot-clock epoch from which `start_time`, `last_frame_time`, etc. are measured.
+        /// `.boot` includes time the system was suspended, giving a monotonic reading
+        /// without gaps on resume.
+        clock_epoch: std.Io.Clock.Timestamp,
         start_time: u64,
         last_frame_time: u64,
         pending_tick: ?u64,
@@ -69,17 +73,17 @@ pub fn Program(comptime Model: type) type {
         const Self = @This();
 
         /// Initialize the program
-        pub fn init(allocator: std.mem.Allocator) !Self {
-            return initWithOptions(allocator, .{});
+        pub fn init(allocator: std.mem.Allocator, io: std.Io) !Self {
+            return initWithOptions(allocator, io, .{});
         }
 
         /// Initialize with custom options
-        pub fn initWithOptions(allocator: std.mem.Allocator, options: Options) !Self {
+        pub fn initWithOptions(allocator: std.mem.Allocator, io: std.Io, options: Options) !Self {
             const arena = std.heap.ArenaAllocator.init(allocator);
-            var clock = try std.time.Timer.start();
-            const now = clock.read();
+            const clock_epoch = std.Io.Clock.Timestamp.now(io, .boot);
             const self = Self{
                 .allocator = allocator,
+                .io = io,
                 .arena = arena,
                 .model = undefined,
                 .terminal = null,
@@ -88,9 +92,9 @@ pub fn Program(comptime Model: type) type {
                 .context = Context.init(allocator, allocator),
                 .options = options,
                 .running = false,
-                .clock = clock,
-                .start_time = now,
-                .last_frame_time = now,
+                .clock_epoch = clock_epoch,
+                .start_time = 0,
+                .last_frame_time = 0,
                 .pending_tick = null,
                 .every_interval = null,
                 .last_every_tick = 0,
@@ -187,9 +191,9 @@ pub fn Program(comptime Model: type) type {
             self.context.kitty_text_sizing = width_caps.kitty_text_sizing;
             unicode.setWidthStrategy(effective_width_strategy);
 
-            self.clock.reset();
-            self.start_time = self.clock.read();
-            self.last_frame_time = self.start_time;
+            self.clock_epoch = std.Io.Clock.Timestamp.now(self.io, .boot);
+            self.start_time = 0;
+            self.last_frame_time = 0;
             self.context.elapsed = 0;
             self.context.delta = 0;
             self.context.frame = 0;
@@ -210,7 +214,7 @@ pub fn Program(comptime Model: type) type {
 
         /// Execute a single frame: poll input, process events, render.
         pub fn tick(self: *Self) !void {
-            const now = self.clock.read();
+            const now = self.elapsedNs();
             const delta = now - self.last_frame_time;
 
             // Enforce framerate limit
@@ -220,10 +224,10 @@ pub fn Program(comptime Model: type) type {
                 16_666_666; // ~60fps default
 
             if (delta < min_frame_time_ns) {
-                sleepNs(min_frame_time_ns - delta);
+                sleepNs(self.io, min_frame_time_ns - delta);
             }
 
-            const frame_time = self.clock.read();
+            const frame_time = self.elapsedNs();
             const actual_delta = frame_time - self.last_frame_time;
             self.last_frame_time = frame_time;
 
@@ -405,7 +409,7 @@ pub fn Program(comptime Model: type) type {
             }
 
             // Avoid a large post-resume frame delta.
-            self.last_frame_time = self.clock.read();
+            self.last_frame_time = self.elapsedNs();
 
             // Force re-render
             self.last_view_hash = 0;
@@ -742,56 +746,21 @@ pub fn Program(comptime Model: type) type {
             return @intCast(value);
         }
 
-        fn sleepNs(nanoseconds: u64) void {
+        /// Nanoseconds elapsed on the boot clock since `clock_epoch`.
+        fn elapsedNs(self: *const Self) u64 {
+            const dur = self.clock_epoch.untilNow(self.io);
+            const ns = dur.raw.nanoseconds;
+            if (ns <= 0) return 0;
+            return @intCast(ns);
+        }
+
+        fn sleepNs(io: std.Io, nanoseconds: u64) void {
             if (nanoseconds == 0) return;
-            const ns_per_s: u64 = if (@hasDecl(std.time, "ns_per_s")) std.time.ns_per_s else 1_000_000_000;
-            const ns_per_ms: u64 = if (@hasDecl(std.time, "ns_per_ms")) std.time.ns_per_ms else 1_000_000;
-
-            // Zig 0.15 API path.
-            if (@hasDecl(std.Thread, "sleep")) {
-                std.Thread.sleep(nanoseconds);
-                return;
-            }
-
-            // Zig 0.16+ API path.
-            if (@hasDecl(std, "Io")) {
-                const Io = std.Io;
-                if (@hasDecl(Io, "Threaded") and
-                    @hasDecl(Io, "Clock") and
-                    @hasDecl(Io.Clock, "Duration") and
-                    @hasDecl(Io.Clock.Duration, "fromNanoseconds") and
-                    @hasDecl(Io.Clock.Duration, "sleep"))
-                {
-                    var threaded_io: Io.Threaded = .init_single_threaded;
-                    const io = threaded_io.io();
-                    const duration = Io.Clock.Duration.fromNanoseconds(@intCast(nanoseconds));
-                    duration.sleep(io) catch {};
-                    return;
-                }
-            }
-
-            // Fallback for targets/environments where the above are unavailable.
-            if (@hasDecl(std, "os") and @hasDecl(std.os, "windows") and builtin.os.tag == .windows) {
-                const windows = std.os.windows;
-                const big_ms_from_ns = nanoseconds / ns_per_ms;
-                const ms = std.math.cast(windows.DWORD, big_ms_from_ns) orelse std.math.maxInt(windows.DWORD);
-                windows.kernel32.Sleep(ms);
-                return;
-            }
-
-            if (@hasDecl(std, "posix") and @hasDecl(std.posix, "nanosleep")) {
-                const seconds = nanoseconds / ns_per_s;
-                const rem_ns = nanoseconds % ns_per_s;
-                std.posix.nanosleep(seconds, rem_ns);
-                return;
-            }
-
-            // Last resort: spin for the requested duration.
-            var timer = std.time.Timer.start() catch return;
-            const start_ns = timer.read();
-            while (timer.read() - start_ns < nanoseconds) {
-                std.atomic.spinLoopHint();
-            }
+            const duration: std.Io.Clock.Duration = .{
+                .raw = std.Io.Duration.fromNanoseconds(@intCast(nanoseconds)),
+                .clock = .boot,
+            };
+            duration.sleep(io) catch {};
         }
 
         fn resetFrameAllocator(self: *Self) void {

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -54,11 +54,10 @@ pub fn Program(comptime Model: type) type {
         context: Context,
         options: Options,
         running: bool,
-        /// Boot-clock epoch from which `start_time`, `last_frame_time`, etc. are measured.
+        /// Boot-clock epoch from which `last_frame_time` and `context.elapsed` are measured.
         /// `.boot` includes time the system was suspended, giving a monotonic reading
         /// without gaps on resume.
         clock_epoch: std.Io.Clock.Timestamp,
-        start_time: u64,
         last_frame_time: u64,
         pending_tick: ?u64,
         every_interval: ?u64,
@@ -104,7 +103,6 @@ pub fn Program(comptime Model: type) type {
                 .options = options,
                 .running = false,
                 .clock_epoch = clock_epoch,
-                .start_time = 0,
                 .last_frame_time = 0,
                 .pending_tick = null,
                 .every_interval = null,
@@ -203,7 +201,6 @@ pub fn Program(comptime Model: type) type {
             unicode.setWidthStrategy(effective_width_strategy);
 
             self.clock_epoch = std.Io.Clock.Timestamp.now(self.io, .boot);
-            self.start_time = 0;
             self.last_frame_time = 0;
             self.context.elapsed = 0;
             self.context.delta = 0;
@@ -243,7 +240,7 @@ pub fn Program(comptime Model: type) type {
             self.last_frame_time = frame_time;
 
             self.context.delta = actual_delta;
-            self.context.elapsed = frame_time - self.start_time;
+            self.context.elapsed = frame_time;
             self.context.frame += 1;
 
             self.resetFrameAllocator();

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -47,6 +47,7 @@ pub fn Program(comptime Model: type) type {
     return struct {
         allocator: std.mem.Allocator,
         io: std.Io,
+        environ_map: *const std.process.Environ.Map,
         arena: std.heap.ArenaAllocator,
         model: Model,
         terminal: ?Terminal,
@@ -73,23 +74,33 @@ pub fn Program(comptime Model: type) type {
         const Self = @This();
 
         /// Initialize the program
-        pub fn init(allocator: std.mem.Allocator, io: std.Io) !Self {
-            return initWithOptions(allocator, io, .{});
+        pub fn init(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            environ_map: *const std.process.Environ.Map,
+        ) !Self {
+            return initWithOptions(allocator, io, environ_map, .{});
         }
 
         /// Initialize with custom options
-        pub fn initWithOptions(allocator: std.mem.Allocator, io: std.Io, options: Options) !Self {
+        pub fn initWithOptions(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            environ_map: *const std.process.Environ.Map,
+            options: Options,
+        ) !Self {
             const arena = std.heap.ArenaAllocator.init(allocator);
             const clock_epoch = std.Io.Clock.Timestamp.now(io, .boot);
             const self = Self{
                 .allocator = allocator,
                 .io = io,
+                .environ_map = environ_map,
                 .arena = arena,
                 .model = undefined,
                 .terminal = null,
                 // `self` is returned by value, so don't capture an arena allocator here.
                 // It would point at this function's stack copy and dangle after return.
-                .context = Context.init(allocator, allocator),
+                .context = Context.init(allocator, allocator, environ_map),
                 .options = options,
                 .running = false,
                 .clock_epoch = clock_epoch,
@@ -162,7 +173,7 @@ pub fn Program(comptime Model: type) type {
             }
 
             // Initialize terminal
-            self.terminal = try Terminal.init(self.io, .{
+            self.terminal = try Terminal.init(self.io, self.environ_map, .{
                 .alt_screen = self.options.alt_screen,
                 .hide_cursor = !self.options.cursor,
                 .mouse = self.options.mouse,
@@ -364,15 +375,14 @@ pub fn Program(comptime Model: type) type {
             if (self.options.unicode_width_strategy) |forced| {
                 return forced;
             }
-            if (envUnicodeWidthOverride()) |from_env| {
+            if (envUnicodeWidthOverride(self.environ_map)) |from_env| {
                 return from_env;
             }
             return detected;
         }
 
-        fn envUnicodeWidthOverride() ?unicode.WidthStrategy {
-            const raw = std.process.getEnvVarOwned(std.heap.page_allocator, "ZZ_UNICODE_WIDTH") catch return null;
-            defer std.heap.page_allocator.free(raw);
+        fn envUnicodeWidthOverride(environ_map: *const std.process.Environ.Map) ?unicode.WidthStrategy {
+            const raw = environ_map.get("ZZ_UNICODE_WIDTH") orelse return null;
             if (std.ascii.eqlIgnoreCase(raw, "unicode")) return .unicode;
             if (std.ascii.eqlIgnoreCase(raw, "legacy")) return .legacy_wcwidth;
             if (std.ascii.eqlIgnoreCase(raw, "auto")) return null;

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -763,11 +763,7 @@ pub fn Program(comptime Model: type) type {
 
         fn sleepNs(io: std.Io, nanoseconds: u64) void {
             if (nanoseconds == 0) return;
-            const duration: std.Io.Clock.Duration = .{
-                .raw = std.Io.Duration.fromNanoseconds(@intCast(nanoseconds)),
-                .clock = .boot,
-            };
-            duration.sleep(io) catch {};
+            std.Io.sleep(io, .fromNanoseconds(nanoseconds), .boot) catch unreachable;
         }
 
         fn resetFrameAllocator(self: *Self) void {

--- a/src/input/keys.zig
+++ b/src/input/keys.zig
@@ -173,15 +173,7 @@ pub const KeyEvent = struct {
     }
 
     /// Format the key event for display
-    pub fn format(
-        self: KeyEvent,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: *Writer,
-    ) !void {
-        _ = fmt;
-        _ = options;
-
+    pub fn format(self: KeyEvent, writer: *Writer) Writer.Error!void {
         if (self.modifiers.ctrl) try writer.writeAll("ctrl+");
         if (self.modifiers.alt) try writer.writeAll("alt+");
         if (self.modifiers.shift) try writer.writeAll("shift+");

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,7 +13,7 @@
 //!     count: i32,
 //!
 //!     pub const Msg = union(enum) {
-//!         key: zz.msg.Key,
+//!         key: zz.KeyEvent,
 //!     };
 //!
 //!     pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
@@ -38,11 +38,8 @@
 //!     }
 //! };
 //!
-//! pub fn main() !void {
-//!     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-//!     defer _ = gpa.deinit();
-//!
-//!     var program = try zz.Program(Model).init(gpa.allocator());
+//! pub fn main(init: std.process.Init) !void {
+//!     var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 //!     defer program.deinit();
 //!     try program.run();
 //! }

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -249,27 +249,24 @@ pub const ColorProfile = enum {
     ansi256,
     true_color,
 
-    /// Detect terminal color profile from environment
-    pub fn detect() ColorProfile {
+    /// Detect terminal color profile from the supplied environment.
+    pub fn detect(environ_map: *const std.process.Environ.Map) ColorProfile {
         if (comptime builtin.os.tag == .windows) {
             // Windows Terminal supports true color VT sequences
             return .true_color;
         }
 
-        // Check NO_COLOR
-        if (std.posix.getenv("NO_COLOR")) |_| {
+        if (environ_map.get("NO_COLOR")) |_| {
             return .ascii;
         }
 
-        // Check for true color support
-        if (std.posix.getenv("COLORTERM")) |ct| {
+        if (environ_map.get("COLORTERM")) |ct| {
             if (std.mem.eql(u8, ct, "truecolor") or std.mem.eql(u8, ct, "24bit")) {
                 return .true_color;
             }
         }
 
-        // Check for 256 color support
-        if (std.posix.getenv("TERM")) |term| {
+        if (environ_map.get("TERM")) |term| {
             if (std.mem.indexOf(u8, term, "256color") != null) {
                 return .ansi256;
             }
@@ -294,13 +291,13 @@ pub const ColorProfile = enum {
     }
 };
 
-/// Detect if terminal has a dark background
-pub fn hasDarkBackground() bool {
+/// Detect if terminal has a dark background using the supplied environment.
+pub fn hasDarkBackground(environ_map: *const std.process.Environ.Map) bool {
     if (comptime builtin.os.tag == .windows) {
         return true;
     }
 
-    if (std.posix.getenv("COLORFGBG")) |val| {
+    if (environ_map.get("COLORFGBG")) |val| {
         // Format: "foreground;background"
         if (std.mem.lastIndexOfScalar(u8, val, ';')) |idx| {
             const bg_str = val[idx + 1 ..];

--- a/src/style/theme.zig
+++ b/src/style/theme.zig
@@ -1,6 +1,7 @@
 //! Theming system for ZigZag.
 //! Provides centralized color palettes and component-specific themes.
 
+const std = @import("std");
 const Color = @import("color.zig").Color;
 const style_mod = @import("style.zig");
 
@@ -305,9 +306,9 @@ pub const ThemeManager = struct {
     is_dark: bool,
     palette_index: usize,
 
-    /// Initialize with auto-detected dark/light background.
-    pub fn init() ThemeManager {
-        const is_dark = @import("color.zig").hasDarkBackground();
+    /// Initialize with dark/light background detected from `environ_map`.
+    pub fn init(environ_map: *const std.process.Environ.Map) ThemeManager {
+        const is_dark = @import("color.zig").hasDarkBackground(environ_map);
         const palette = AdaptivePalette.default.resolve(is_dark);
         return .{
             .current = .fromPalette(palette),
@@ -316,9 +317,9 @@ pub const ThemeManager = struct {
         };
     }
 
-    /// Initialize with a specific palette.
-    pub fn initWithPalette(palette: Palette) ThemeManager {
-        const is_dark = @import("color.zig").hasDarkBackground();
+    /// Initialize with a specific palette and `environ_map`-detected dark/light hint.
+    pub fn initWithPalette(environ_map: *const std.process.Environ.Map, palette: Palette) ThemeManager {
+        const is_dark = @import("color.zig").hasDarkBackground(environ_map);
         return .{
             .current = .fromPalette(palette),
             .is_dark = is_dark,

--- a/src/terminal/platform/posix.zig
+++ b/src/terminal/platform/posix.zig
@@ -38,9 +38,10 @@ pub const State = struct {
     }
 };
 
-/// Check if a file descriptor is a TTY
+/// Check if a file descriptor is a TTY by probing for terminal window size.
 pub fn isTty(fd: posix.fd_t) bool {
-    return posix.isatty(fd);
+    var wsz: posix.winsize = undefined;
+    return posix.system.ioctl(fd, posix.T.IOCGWINSZ, @intFromPtr(&wsz)) == 0;
 }
 
 /// Get terminal size using ioctl (falls back to 80x24 for non-TTY)

--- a/src/terminal/platform/posix.zig
+++ b/src/terminal/platform/posix.zig
@@ -183,7 +183,7 @@ pub fn setupSignals() !void {
     const handler = posix.Sigaction{
         .handler = .{
             .handler = struct {
-                fn handle(_: c_int) callconv(std.builtin.CallingConvention.c) void {
+                fn handle(_: posix.SIG) callconv(.c) void {
                     resize_signaled.store(true, .release);
                 }
             }.handle,

--- a/src/terminal/platform/posix.zig
+++ b/src/terminal/platform/posix.zig
@@ -39,6 +39,8 @@ pub const State = struct {
 };
 
 /// Check if a file descriptor is a TTY by probing for terminal window size.
+/// Replaces `posix.isatty`, which was removed in Zig 0.16; a successful
+/// `TIOCGWINSZ` ioctl is only granted to terminal devices.
 pub fn isTty(fd: posix.fd_t) bool {
     var wsz: posix.winsize = undefined;
     return posix.system.ioctl(fd, posix.T.IOCGWINSZ, @intFromPtr(&wsz)) == 0;

--- a/src/terminal/platform/windows.zig
+++ b/src/terminal/platform/windows.zig
@@ -37,11 +37,14 @@ const KEY_EVENT: windows.WORD = 0x0001;
 const MOUSE_EVENT: windows.WORD = 0x0002;
 const INFINITE: windows.DWORD = 0xFFFFFFFF;
 const WAIT_OBJECT_0: windows.DWORD = 0x00000000;
+const CP_UTF8: windows.UINT = 65001;
 
 /// Terminal state for Windows
 pub const State = struct {
     original_input_mode: windows.DWORD = 0,
     original_output_mode: windows.DWORD = 0,
+    original_output_cp: windows.UINT = 0,
+    original_input_cp: windows.UINT = 0,
     in_raw_mode: bool = false,
     in_alt_screen: bool = false,
     mouse_enabled: bool = false,
@@ -96,6 +99,10 @@ extern "kernel32" fn ReadFile(
     lpNumberOfBytesRead: ?*windows.DWORD,
     lpOverlapped: ?*anyopaque,
 ) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) windows.UINT;
+extern "kernel32" fn SetConsoleOutputCP(wCodePageID: windows.UINT) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetConsoleCP() callconv(.winapi) windows.UINT;
+extern "kernel32" fn SetConsoleCP(wCodePageID: windows.UINT) callconv(.winapi) windows.BOOL;
 
 const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
     dwSize: COORD,
@@ -194,6 +201,13 @@ pub fn enableRawMode(state: *State) !void {
         return TerminalError.SetConsoleFailed;
     }
 
+    // Switch the console code pages to UTF-8 so multi-byte sequences (box-drawing,
+    // emoji, etc.) emitted by the renderer aren't reinterpreted as the OEM codepage.
+    state.original_output_cp = GetConsoleOutputCP();
+    state.original_input_cp = GetConsoleCP();
+    _ = SetConsoleOutputCP(CP_UTF8);
+    _ = SetConsoleCP(CP_UTF8);
+
     state.in_raw_mode = true;
 }
 
@@ -203,6 +217,8 @@ pub fn disableRawMode(state: *State) void {
 
     _ = SetConsoleMode(state.stdin_handle, state.original_input_mode);
     _ = SetConsoleMode(state.stdout_handle, state.original_output_mode);
+    if (state.original_output_cp != 0) _ = SetConsoleOutputCP(state.original_output_cp);
+    if (state.original_input_cp != 0) _ = SetConsoleCP(state.original_input_cp);
 
     state.in_raw_mode = false;
 }

--- a/src/terminal/platform/windows.zig
+++ b/src/terminal/platform/windows.zig
@@ -35,6 +35,8 @@ const FILE_TYPE_CHAR: windows.DWORD = 0x0002;
 const FILE_TYPE_PIPE: windows.DWORD = 0x0003;
 const KEY_EVENT: windows.WORD = 0x0001;
 const MOUSE_EVENT: windows.WORD = 0x0002;
+const INFINITE: windows.DWORD = 0xFFFFFFFF;
+const WAIT_OBJECT_0: windows.DWORD = 0x00000000;
 
 /// Terminal state for Windows
 pub const State = struct {
@@ -48,8 +50,8 @@ pub const State = struct {
 
     pub fn init() State {
         return .{
-            .stdin_handle = windows.GetStdHandle(windows.STD_INPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE,
-            .stdout_handle = windows.GetStdHandle(windows.STD_OUTPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE,
+            .stdin_handle = std.Io.File.stdin().handle,
+            .stdout_handle = std.Io.File.stdout().handle,
         };
     }
 };
@@ -82,6 +84,17 @@ extern "kernel32" fn ReadConsoleInputW(
     lpBuffer: [*]INPUT_RECORD,
     nLength: windows.DWORD,
     lpNumberOfEventsRead: *windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn WaitForSingleObject(
+    hHandle: windows.HANDLE,
+    dwMilliseconds: windows.DWORD,
+) callconv(.winapi) windows.DWORD;
+extern "kernel32" fn ReadFile(
+    hFile: windows.HANDLE,
+    lpBuffer: [*]u8,
+    nNumberOfBytesToRead: windows.DWORD,
+    lpNumberOfBytesRead: ?*windows.DWORD,
+    lpOverlapped: ?*anyopaque,
 ) callconv(.winapi) windows.BOOL;
 
 const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
@@ -133,13 +146,13 @@ const KEY_EVENT_RECORD = extern struct {
 pub fn isTty(handle: windows.HANDLE) bool {
     if (handle == windows.INVALID_HANDLE_VALUE) return false;
     var mode: windows.DWORD = 0;
-    return GetConsoleMode(handle, &mode) != 0;
+    return GetConsoleMode(handle, &mode).toBool();
 }
 
 /// Get terminal size
 pub fn getSize(handle: windows.HANDLE) !Size {
     var info: CONSOLE_SCREEN_BUFFER_INFO = undefined;
-    if (GetConsoleScreenBufferInfo(handle, &info) == 0) {
+    if (!GetConsoleScreenBufferInfo(handle, &info).toBool()) {
         return TerminalError.GetConsoleFailed;
     }
     return .{
@@ -159,23 +172,23 @@ pub fn enableRawMode(state: *State) !void {
     }
 
     // Save original modes
-    if (GetConsoleMode(state.stdin_handle, &state.original_input_mode) == 0) {
+    if (!GetConsoleMode(state.stdin_handle, &state.original_input_mode).toBool()) {
         return TerminalError.GetConsoleFailed;
     }
-    if (GetConsoleMode(state.stdout_handle, &state.original_output_mode) == 0) {
+    if (!GetConsoleMode(state.stdout_handle, &state.original_output_mode).toBool()) {
         return TerminalError.GetConsoleFailed;
     }
 
     // Set input mode for raw input with VT processing.
     // Avoid WINDOW_INPUT because it can signal wait handles without producing bytes for ReadFile.
     const input_mode: windows.DWORD = ENABLE_VIRTUAL_TERMINAL_INPUT;
-    if (SetConsoleMode(state.stdin_handle, input_mode) == 0) {
+    if (!SetConsoleMode(state.stdin_handle, input_mode).toBool()) {
         return TerminalError.SetConsoleFailed;
     }
 
     // Enable VT processing on output
     const output_mode: windows.DWORD = state.original_output_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    if (SetConsoleMode(state.stdout_handle, output_mode) == 0) {
+    if (!SetConsoleMode(state.stdout_handle, output_mode).toBool()) {
         // Restore input mode and fail
         _ = SetConsoleMode(state.stdin_handle, state.original_input_mode);
         return TerminalError.SetConsoleFailed;
@@ -217,7 +230,7 @@ pub fn enableMouse(state: *State, writer: *Writer) !void {
     // Enable mouse input in console mode
     if (state.stdin_handle != windows.INVALID_HANDLE_VALUE) {
         var mode: windows.DWORD = 0;
-        if (GetConsoleMode(state.stdin_handle, &mode) != 0) {
+        if (GetConsoleMode(state.stdin_handle, &mode).toBool()) {
             _ = SetConsoleMode(state.stdin_handle, mode | ENABLE_MOUSE_INPUT);
         }
     }
@@ -241,21 +254,18 @@ pub fn readInput(state: *State, buffer: []u8, timeout_ms: i32) !usize {
 
     // Match POSIX behavior: wait up to timeout_ms for input, then return 0.
     const wait_ms: windows.DWORD = if (timeout_ms < 0)
-        windows.INFINITE
+        INFINITE
     else
         @intCast(timeout_ms);
 
-    windows.WaitForSingleObject(state.stdin_handle, wait_ms) catch |err| switch (err) {
-        error.WaitTimeOut => return 0,
-        else => return 0,
-    };
+    if (WaitForSingleObject(state.stdin_handle, wait_ms) != WAIT_OBJECT_0) return 0;
 
     const file_type = GetFileType(state.stdin_handle);
 
     // ConPTY/Windows Terminal can expose stdin as a pipe. Ensure there are bytes before reading.
     if (file_type == FILE_TYPE_PIPE) {
         var available: windows.DWORD = 0;
-        if (PeekNamedPipe(state.stdin_handle, null, 0, null, &available, null) == 0 or available == 0) {
+        if (!PeekNamedPipe(state.stdin_handle, null, 0, null, &available, null).toBool() or available == 0) {
             return 0;
         }
     }
@@ -266,8 +276,9 @@ pub fn readInput(state: *State, buffer: []u8, timeout_ms: i32) !usize {
     }
 
     // Read from the configured stdin handle after it is signaled as readable.
-    const stdin: std.fs.File = .{ .handle = state.stdin_handle };
-    return stdin.read(buffer) catch 0;
+    var bytes_read: windows.DWORD = 0;
+    if (!ReadFile(state.stdin_handle, buffer.ptr, @intCast(buffer.len), &bytes_read, null).toBool()) return 0;
+    return bytes_read;
 }
 
 fn hasReadableConsoleInput(handle: windows.HANDLE) bool {
@@ -275,26 +286,26 @@ fn hasReadableConsoleInput(handle: windows.HANDLE) bool {
 
     while (true) {
         var event_count: windows.DWORD = 0;
-        if (GetNumberOfConsoleInputEvents(handle, &event_count) == 0 or event_count == 0) {
+        if (!GetNumberOfConsoleInputEvents(handle, &event_count).toBool() or event_count == 0) {
             return false;
         }
 
         var peeked: windows.DWORD = 0;
-        if (PeekConsoleInputW(handle, &record_buf, 1, &peeked) == 0 or peeked == 0) {
+        if (!PeekConsoleInputW(handle, &record_buf, 1, &peeked).toBool() or peeked == 0) {
             return false;
         }
 
         const record = record_buf[0];
         switch (record.EventType) {
             KEY_EVENT => {
-                if (record.Event.KeyEvent.bKeyDown != 0) return true;
+                if (record.Event.KeyEvent.bKeyDown.toBool()) return true;
             },
             MOUSE_EVENT => return true,
             else => {},
         }
 
         var consumed: windows.DWORD = 0;
-        if (ReadConsoleInputW(handle, &record_buf, 1, &consumed) == 0 or consumed == 0) {
+        if (!ReadConsoleInputW(handle, &record_buf, 1, &consumed).toBool() or consumed == 0) {
             return false;
         }
     }

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -261,6 +261,7 @@ pub const Config = struct {
 /// Terminal abstraction
 pub const Terminal = struct {
     io: std.Io,
+    environ_map: *const std.process.Environ.Map,
     state: platform.State,
     config: Config,
     stdin: std.Io.File,
@@ -270,11 +271,12 @@ pub const Terminal = struct {
     unicode_width_caps: UnicodeWidthCapabilities = .{},
     image_caps: ImageCapabilities = .{},
 
-    pub fn init(io: std.Io, config: Config) !Terminal {
+    pub fn init(io: std.Io, environ_map: *const std.process.Environ.Map, config: Config) !Terminal {
         var state = platform.State.init();
 
         var term: Terminal = if (is_wasm) .{
             .io = io,
+            .environ_map = environ_map,
             .state = state,
             .config = config,
             .stdin = undefined,
@@ -294,6 +296,7 @@ pub const Terminal = struct {
 
             break :blk .{
                 .io = io,
+                .environ_map = environ_map,
                 .state = state,
                 .config = config,
                 .stdin = stdin,
@@ -1029,27 +1032,25 @@ pub const Terminal = struct {
             return;
         }
 
-        const term_features_owned = std.process.getEnvVarOwned(std.heap.page_allocator, "TERM_FEATURES") catch null;
-        defer if (term_features_owned) |value| std.heap.page_allocator.free(value);
-        const term_features = if (term_features_owned) |value| value else "";
+        const term_features = self.environ_map.get("TERM_FEATURES") orelse "";
 
-        const kitty_candidate = looksLikeKittyTerminal() or
-            envVarEquals("TERM_PROGRAM", "WezTerm") or
-            envVarContains("TERM", "wezterm") or
-            envVarContains("TERM", "ghostty");
-        const iterm_candidate = looksLikeIterm2Terminal() or
-            envVarEquals("TERM_PROGRAM", "WezTerm");
-        const in_multiplexer = isInsideMultiplexer();
+        const kitty_candidate = looksLikeKittyTerminal(self.environ_map) or
+            envVarEquals(self.environ_map, "TERM_PROGRAM", "WezTerm") or
+            envVarContains(self.environ_map, "TERM", "wezterm") or
+            envVarContains(self.environ_map, "TERM", "ghostty");
+        const iterm_candidate = looksLikeIterm2Terminal(self.environ_map) or
+            envVarEquals(self.environ_map, "TERM_PROGRAM", "WezTerm");
+        const in_multiplexer = isInsideMultiplexer(self.environ_map);
 
         var kitty = false;
         var iterm = iterm_candidate or termFeaturesContain(term_features, "F");
-        var sixel = looksLikeSixelTerminal() or termFeaturesContain(term_features, "Sx");
+        var sixel = looksLikeSixelTerminal(self.environ_map) or termFeaturesContain(term_features, "Sx");
 
         if (kitty_candidate) {
             kitty = self.queryKittyGraphicsSupport() catch false;
             // Keep an env fallback only outside multiplexers where probe failures are uncommon.
             if (!kitty and !in_multiplexer) {
-                kitty = envVarExists("KITTY_WINDOW_ID");
+                kitty = envVarExists(self.environ_map, "KITTY_WINDOW_ID");
             }
         }
 
@@ -1181,14 +1182,13 @@ pub const Terminal = struct {
     }
 
     fn resolveOsc52Passthrough(self: *const Terminal, mode: Osc52Passthrough) ansi.Osc52Passthrough {
-        _ = self;
         return switch (mode) {
             .none => .none,
             .tmux => .tmux,
             .dcs => .dcs,
             .auto => blk: {
-                if (envVarExists("TMUX")) break :blk .tmux;
-                if (envVarContains("TERM", "screen")) break :blk .dcs;
+                if (envVarExists(self.environ_map, "TMUX")) break :blk .tmux;
+                if (envVarContains(self.environ_map, "TERM", "screen")) break :blk .dcs;
                 break :blk .none;
             },
         };
@@ -1595,7 +1595,7 @@ pub const Terminal = struct {
     }
 
     fn selectWidthStrategy(self: *const Terminal) unicode.WidthStrategy {
-        if (isInsideMultiplexer()) {
+        if (isInsideMultiplexer(self.environ_map)) {
             return .legacy_wcwidth;
         }
 
@@ -1607,7 +1607,7 @@ pub const Terminal = struct {
             return .unicode;
         }
 
-        if (isKnownUnicodeWidthTerminal()) {
+        if (isKnownUnicodeWidthTerminal(self.environ_map)) {
             return .unicode;
         }
 
@@ -1615,7 +1615,7 @@ pub const Terminal = struct {
     }
 
     fn queryKittyTextSizingSupport(self: *Terminal) !bool {
-        if (!looksLikeKittyTerminal()) return false;
+        if (!looksLikeKittyTerminal(self.environ_map)) return false;
 
         const cpr = "\x1b[6n";
         // CR, CPR, draw 2-cell space via kitty OSC 66 width-only, CPR.
@@ -1684,8 +1684,8 @@ pub const Terminal = struct {
         return null;
     }
 
-    fn isInsideMultiplexer() bool {
-        return envVarExists("TMUX") or envVarExists("ZELLIJ") or envVarContains("TERM", "screen");
+    fn isInsideMultiplexer(environ_map: *const std.process.Environ.Map) bool {
+        return envVarExists(environ_map, "TMUX") or envVarExists(environ_map, "ZELLIJ") or envVarContains(environ_map, "TERM", "screen");
     }
 
     fn drainInput(self: *Terminal) void {
@@ -1738,28 +1738,28 @@ pub const Terminal = struct {
         return null;
     }
 
-    fn isKnownUnicodeWidthTerminal() bool {
+    fn isKnownUnicodeWidthTerminal(environ_map: *const std.process.Environ.Map) bool {
         // Terminals known to use grapheme-aware width by default.
-        return envVarEquals("TERM_PROGRAM", "WezTerm") or
-            envVarEquals("TERM_PROGRAM", "iTerm.app") or
-            envVarContains("TERM", "wezterm") or
-            envVarContains("TERM", "ghostty");
+        return envVarEquals(environ_map, "TERM_PROGRAM", "WezTerm") or
+            envVarEquals(environ_map, "TERM_PROGRAM", "iTerm.app") or
+            envVarContains(environ_map, "TERM", "wezterm") or
+            envVarContains(environ_map, "TERM", "ghostty");
     }
 
-    fn looksLikeKittyTerminal() bool {
-        return envVarExists("KITTY_WINDOW_ID") or envVarContains("TERM", "kitty");
+    fn looksLikeKittyTerminal(environ_map: *const std.process.Environ.Map) bool {
+        return envVarExists(environ_map, "KITTY_WINDOW_ID") or envVarContains(environ_map, "TERM", "kitty");
     }
 
-    fn looksLikeIterm2Terminal() bool {
-        return envVarEquals("TERM_PROGRAM", "iTerm.app") or
-            envVarEquals("LC_TERMINAL", "iTerm2");
+    fn looksLikeIterm2Terminal(environ_map: *const std.process.Environ.Map) bool {
+        return envVarEquals(environ_map, "TERM_PROGRAM", "iTerm.app") or
+            envVarEquals(environ_map, "LC_TERMINAL", "iTerm2");
     }
 
-    fn looksLikeSixelTerminal() bool {
-        return envVarContains("TERM", "sixel") or
-            envVarContains("TERM", "mlterm") or
-            envVarContains("TERM", "yaft") or
-            envVarContains("TERM", "contour");
+    fn looksLikeSixelTerminal(environ_map: *const std.process.Environ.Map) bool {
+        return envVarContains(environ_map, "TERM", "sixel") or
+            envVarContains(environ_map, "TERM", "mlterm") or
+            envVarContains(environ_map, "TERM", "yaft") or
+            envVarContains(environ_map, "TERM", "contour");
     }
 
     fn isLikelyFullSixelSequence(bytes: []const u8) bool {
@@ -1797,21 +1797,18 @@ pub const Terminal = struct {
         return true;
     }
 
-    fn envVarExists(name: []const u8) bool {
-        const value = std.process.getEnvVarOwned(std.heap.page_allocator, name) catch return false;
-        defer std.heap.page_allocator.free(value);
+    fn envVarExists(environ_map: *const std.process.Environ.Map, name: []const u8) bool {
+        const value = environ_map.get(name) orelse return false;
         return value.len > 0;
     }
 
-    fn envVarEquals(name: []const u8, expected: []const u8) bool {
-        const value = std.process.getEnvVarOwned(std.heap.page_allocator, name) catch return false;
-        defer std.heap.page_allocator.free(value);
+    fn envVarEquals(environ_map: *const std.process.Environ.Map, name: []const u8, expected: []const u8) bool {
+        const value = environ_map.get(name) orelse return false;
         return std.ascii.eqlIgnoreCase(value, expected);
     }
 
-    fn envVarContains(name: []const u8, needle: []const u8) bool {
-        const value = std.process.getEnvVarOwned(std.heap.page_allocator, name) catch return false;
-        defer std.heap.page_allocator.free(value);
+    fn envVarContains(environ_map: *const std.process.Environ.Map, name: []const u8, needle: []const u8) bool {
+        const value = environ_map.get(name) orelse return false;
         return std.mem.indexOf(u8, value, needle) != null;
     }
 

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -249,9 +249,9 @@ pub const Config = struct {
     /// Enable bracketed paste mode
     bracketed_paste: bool = true,
     /// Custom input file (default: stdin)
-    input: ?std.fs.File = null,
+    input: ?std.Io.File = null,
     /// Custom output file (default: stdout)
-    output: ?std.fs.File = null,
+    output: ?std.Io.File = null,
     /// Enable Kitty keyboard protocol
     kitty_keyboard: bool = false,
     /// OSC 52 clipboard configuration
@@ -260,26 +260,28 @@ pub const Config = struct {
 
 /// Terminal abstraction
 pub const Terminal = struct {
+    io: std.Io,
     state: platform.State,
     config: Config,
-    stdin: std.fs.File,
+    stdin: std.Io.File,
     out: Writer,
     pending_input: [8192]u8 = undefined,
     pending_input_len: usize = 0,
     unicode_width_caps: UnicodeWidthCapabilities = .{},
     image_caps: ImageCapabilities = .{},
 
-    pub fn init(config: Config) !Terminal {
+    pub fn init(io: std.Io, config: Config) !Terminal {
         var state = platform.State.init();
 
         var term: Terminal = if (is_wasm) .{
+            .io = io,
             .state = state,
             .config = config,
             .stdin = undefined,
-            .out = .init({}),
+            .out = .init(io, {}),
         } else blk: {
-            const stdout = config.output orelse std.fs.File.stdout();
-            const stdin = config.input orelse std.fs.File.stdin();
+            const stdout = config.output orelse std.Io.File.stdout();
+            const stdin = config.input orelse std.Io.File.stdin();
 
             // Apply custom fd overrides
             if (builtin.os.tag != .windows) {
@@ -291,10 +293,11 @@ pub const Terminal = struct {
             }
 
             break :blk .{
+                .io = io,
                 .state = state,
                 .config = config,
                 .stdin = stdin,
-                .out = .init(stdout),
+                .out = .init(io, stdout),
             };
         };
 
@@ -545,8 +548,8 @@ pub const Terminal = struct {
         var collected = std.array_list.Managed(u8).init(allocator);
         defer collected.deinit();
 
-        const deadline_ms = std.time.milliTimestamp() + timeout_ms;
-        while (std.time.milliTimestamp() < deadline_ms) {
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
+        while (withinDeadline(self.io, start, timeout_ms)) {
             var chunk: [256]u8 = undefined;
             const n = self.readPlatformInput(&chunk, 30) catch 0;
             if (n == 0) continue;
@@ -681,7 +684,7 @@ pub const Terminal = struct {
     /// Transmit an image file to the Kitty cache without displaying it (`a=t,t=f`).
     pub fn transmitKittyImageFromFile(self: *Terminal, path: []const u8, options: KittyTransmitOptions) !bool {
         if (!self.image_caps.kitty_graphics or path.len == 0) return false;
-        if (!fileExists(path)) return false;
+        if (!fileExists(self.io, path)) return false;
 
         var params_buf: [256]u8 = undefined;
         var params_writer = FixedWriter(&params_buf);
@@ -736,11 +739,11 @@ pub const Terminal = struct {
     /// Returns `false` when unsupported or path is empty.
     pub fn drawIterm2ImageFromFile(self: *Terminal, path: []const u8, options: Iterm2ImageFileOptions) !bool {
         if (!self.image_caps.iterm2_inline_image or path.len == 0) return false;
-        if (!fileExists(path)) return false;
+        if (!fileExists(self.io, path)) return false;
 
-        var file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
-        const stat = try file.stat();
+        var file = try std.Io.Dir.cwd().openFile(self.io, path, .{});
+        defer file.close(self.io);
+        const stat = try file.stat(self.io);
 
         var params_buf: [256]u8 = undefined;
         var params_writer = FixedWriter(&params_buf);
@@ -792,7 +795,7 @@ pub const Terminal = struct {
     /// Draw an image file using a specific or auto-selected protocol.
     pub fn drawImageFromFileWithProtocol(self: *Terminal, path: []const u8, options: ImageFileOptions, protocol: ImageProtocol) !bool {
         if (path.len == 0) return false;
-        if (!fileExists(path)) return false;
+        if (!fileExists(self.io, path)) return false;
 
         switch (protocol) {
             .kitty => {
@@ -942,11 +945,11 @@ pub const Terminal = struct {
     /// - regular image files converted through `img2sixel` when available.
     pub fn drawSixelFromFile(self: *Terminal, path: []const u8, options: SixelImageFileOptions) !bool {
         if (!self.image_caps.sixel or path.len == 0) return false;
-        if (!fileExists(path)) return false;
+        if (!fileExists(self.io, path)) return false;
 
         if (isSixelDataPath(path)) {
-            var file = try std.fs.cwd().openFile(path, .{});
-            defer file.close();
+            var file = try std.Io.Dir.cwd().openFile(self.io, path, .{});
+            defer file.close(self.io);
             try self.sendSixelPayloadFromFile(&file);
             return true;
         }
@@ -1243,7 +1246,7 @@ pub const Terminal = struct {
         }
     }
 
-    fn sendIterm2InlineImagePayload(self: *Terminal, params: []const u8, file: *std.fs.File, file_size: u64) !void {
+    fn sendIterm2InlineImagePayload(self: *Terminal, params: []const u8, file: *std.Io.File, file_size: u64) !void {
         const encoder = std.base64.standard.Encoder;
         var raw_buf: [3072]u8 = undefined;
         var b64_buf: [4096]u8 = undefined;
@@ -1256,8 +1259,11 @@ pub const Terminal = struct {
             try self.writeBytes(":");
 
             while (true) {
-                const n = try file.read(&raw_buf);
-                if (n == 0) break;
+                const n = file.readStreaming(self.io, &.{&raw_buf}) catch |err| switch (err) {
+                    error.EndOfStream => break,
+                    else => |e| return e,
+                };
+                if (n == 0) continue;
                 const encoded_len = encoder.calcSize(n);
                 const encoded = encoder.encode(b64_buf[0..encoded_len], raw_buf[0..n]);
                 try self.writeBytes(encoded);
@@ -1272,8 +1278,11 @@ pub const Terminal = struct {
         try self.writeBytes("\x07");
 
         while (true) {
-            const n = try file.read(&raw_buf);
-            if (n == 0) break;
+            const n = file.readStreaming(self.io, &.{&raw_buf}) catch |err| switch (err) {
+                error.EndOfStream => break,
+                else => |e| return e,
+            };
+            if (n == 0) continue;
             const encoded_len = encoder.calcSize(n);
             const encoded = encoder.encode(b64_buf[0..encoded_len], raw_buf[0..n]);
             try self.writeBytes(ansi.OSC ++ "1337;FilePart=");
@@ -1331,14 +1340,17 @@ pub const Terminal = struct {
         try self.writeBytes(ansi.OSC ++ "1337;FileEnd\x07");
     }
 
-    fn sendSixelPayloadFromFile(self: *Terminal, file: *std.fs.File) !void {
+    fn sendSixelPayloadFromFile(self: *Terminal, file: *std.Io.File) !void {
         var payload_buf: [4096]u8 = undefined;
         var first_read = true;
         var wrapped = false;
 
         while (true) {
-            const n = try file.read(&payload_buf);
-            if (n == 0) break;
+            const n = file.readStreaming(self.io, &.{&payload_buf}) catch |err| switch (err) {
+                error.EndOfStream => break,
+                else => |e| return e,
+            };
+            if (n == 0) continue;
             const chunk = payload_buf[0..n];
 
             if (first_read) {
@@ -1376,9 +1388,9 @@ pub const Terminal = struct {
 
         var collected: [1024]u8 = undefined;
         var collected_len: usize = 0;
-        const deadline_ms = std.time.milliTimestamp() + 180;
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
 
-        while (std.time.milliTimestamp() < deadline_ms) {
+        while (withinDeadline(self.io, start, 180)) {
             var chunk: [128]u8 = undefined;
             const n = self.readInput(&chunk, 30) catch 0;
             if (n == 0) continue;
@@ -1430,9 +1442,9 @@ pub const Terminal = struct {
 
         var collected: [2048]u8 = undefined;
         var collected_len: usize = 0;
-        const deadline_ms = std.time.milliTimestamp() + 180;
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
 
-        while (std.time.milliTimestamp() < deadline_ms) {
+        while (withinDeadline(self.io, start, 180)) {
             var chunk: [128]u8 = undefined;
             const n = self.readInput(&chunk, 30) catch 0;
             if (n == 0) continue;
@@ -1470,9 +1482,9 @@ pub const Terminal = struct {
 
         var collected: [1024]u8 = undefined;
         var collected_len: usize = 0;
-        const deadline_ms = std.time.milliTimestamp() + 120;
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
 
-        while (std.time.milliTimestamp() < deadline_ms) {
+        while (withinDeadline(self.io, start, 120)) {
             var chunk: [128]u8 = undefined;
             const n = self.readInput(&chunk, 25) catch 0;
             if (n == 0) continue;
@@ -1531,9 +1543,9 @@ pub const Terminal = struct {
 
         var collected: [512]u8 = undefined;
         var collected_len: usize = 0;
-        const deadline_ms = std.time.milliTimestamp() + 250;
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
 
-        while (std.time.milliTimestamp() < deadline_ms) {
+        while (withinDeadline(self.io, start, 250)) {
             var chunk: [128]u8 = undefined;
             const n = self.readInput(&chunk, 40) catch 0;
             if (n == 0) continue;
@@ -1613,9 +1625,9 @@ pub const Terminal = struct {
 
         var buf: [512]u8 = undefined;
         var len: usize = 0;
-        const deadline_ms = std.time.milliTimestamp() + 250;
+        const start = std.Io.Clock.Timestamp.now(self.io, .boot);
 
-        while (std.time.milliTimestamp() < deadline_ms) {
+        while (withinDeadline(self.io, start, 250)) {
             var chunk: [128]u8 = undefined;
             const n = self.readInput(&chunk, 40) catch 0;
             if (n == 0) continue;
@@ -1762,9 +1774,15 @@ pub const Terminal = struct {
             std.mem.endsWith(u8, path, ".SIX");
     }
 
-    fn fileExists(path: []const u8) bool {
-        std.fs.cwd().access(path, .{}) catch return false;
+    fn fileExists(io: std.Io, path: []const u8) bool {
+        std.Io.Dir.cwd().access(io, path, .{}) catch return false;
         return true;
+    }
+
+    fn withinDeadline(io: std.Io, start: std.Io.Clock.Timestamp, timeout_ms: u64) bool {
+        const elapsed_ns = start.untilNow(io).raw.nanoseconds;
+        const deadline_ns: i96 = @as(i96, @intCast(timeout_ms)) * std.time.ns_per_ms;
+        return elapsed_ns < deadline_ns;
     }
 
     fn commandExists(name: []const u8) bool {
@@ -1800,14 +1818,16 @@ pub const Terminal = struct {
     /// Buffered writer that exposes a `std.Io.Writer` interface and drains to
     /// the terminal's output sink (stdout file, or the wasm host on wasm).
     pub const Writer = struct {
-        file: if (is_wasm) void else std.fs.File,
+        io: std.Io,
+        file: if (is_wasm) void else std.Io.File,
         buffer: [4096]u8 = undefined,
         writer: std.Io.Writer,
 
         const vtable: std.Io.Writer.VTable = .{ .drain = drain };
 
-        pub fn init(file: if (is_wasm) void else std.fs.File) Writer {
+        pub fn init(io: std.Io, file: if (is_wasm) void else std.Io.File) Writer {
             return .{
+                .io = io,
                 .file = file,
                 .writer = .{ .vtable = &vtable, .buffer = &.{} },
             };
@@ -1858,7 +1878,7 @@ pub const Terminal = struct {
             if (is_wasm) {
                 try platform.wasm_writer_instance.writer.writeAll(bytes);
             } else {
-                self.file.writeAll(bytes) catch return error.WriteFailed;
+                self.file.writeStreamingAll(self.io, bytes) catch return error.WriteFailed;
             }
         }
     };

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -552,7 +552,7 @@ pub const Terminal = struct {
         defer collected.deinit();
 
         const start = std.Io.Clock.Timestamp.now(self.io, .boot);
-        while (withinDeadline(self.io, start, timeout_ms)) {
+        while (withinDeadline(self.io, start, @intCast(@max(timeout_ms, 0)))) {
             var chunk: [256]u8 = undefined;
             const n = self.readPlatformInput(&chunk, 30) catch 0;
             if (n == 0) continue;
@@ -957,7 +957,7 @@ pub const Terminal = struct {
             return true;
         }
 
-        if (!commandExists("img2sixel")) return false;
+        if (!commandExists(self.io, "img2sixel")) return false;
 
         var argv_buf: [6][]const u8 = undefined;
         var argc: usize = 0;
@@ -980,16 +980,16 @@ pub const Terminal = struct {
         argv_buf[argc] = path;
         argc += 1;
 
-        const result = try std.process.Child.run(.{
-            .allocator = std.heap.page_allocator,
+        const result = try std.process.run(std.heap.page_allocator, self.io, .{
             .argv = argv_buf[0..argc],
-            .max_output_bytes = options.max_output_bytes,
+            .stdout_limit = .limited(options.max_output_bytes),
+            .stderr_limit = .limited(options.max_output_bytes),
         });
         defer std.heap.page_allocator.free(result.stdout);
         defer std.heap.page_allocator.free(result.stderr);
 
         switch (result.term) {
-            .Exited => |code| if (code != 0) return error.BrokenPipe,
+            .exited => |code| if (code != 0) return error.BrokenPipe,
             else => return error.BrokenPipe,
         }
 
@@ -1785,12 +1785,12 @@ pub const Terminal = struct {
         return elapsed_ns < deadline_ns;
     }
 
-    fn commandExists(name: []const u8) bool {
+    fn commandExists(io: std.Io, name: []const u8) bool {
         const argv = [_][]const u8{ name, "--version" };
-        const result = std.process.Child.run(.{
-            .allocator = std.heap.page_allocator,
+        const result = std.process.run(std.heap.page_allocator, io, .{
             .argv = &argv,
-            .max_output_bytes = 1024,
+            .stdout_limit = .limited(1024),
+            .stderr_limit = .limited(1024),
         }) catch return false;
         defer std.heap.page_allocator.free(result.stdout);
         defer std.heap.page_allocator.free(result.stderr);

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -1282,7 +1282,7 @@ pub const Terminal = struct {
                 error.EndOfStream => break,
                 else => |e| return e,
             };
-            if (n == 0) continue;
+            if (n == 0) break;
             const encoded_len = encoder.calcSize(n);
             const encoded = encoder.encode(b64_buf[0..encoded_len], raw_buf[0..n]);
             try self.writeBytes(ansi.OSC ++ "1337;FilePart=");
@@ -1350,7 +1350,7 @@ pub const Terminal = struct {
                 error.EndOfStream => break,
                 else => |e| return e,
             };
-            if (n == 0) continue;
+            if (n == 0) break;
             const chunk = payload_buf[0..n];
 
             if (first_read) {

--- a/src/unicode/display_width.zig
+++ b/src/unicode/display_width.zig
@@ -645,8 +645,8 @@ test "emoji are wide" {
     try std.testing.expectEqual(@as(usize, 2), charWidth(0x1F600)); // Grinning face
     try std.testing.expectEqual(@as(usize, 2), charWidth(0x1F4A9)); // Pile of poo
     try std.testing.expectEqual(@as(usize, 2), charWidth(0x1F680)); // Rocket
-    try std.testing.expectEqual(@as(usize, 2), charWidth(0x2615));  // Hot beverage
-    try std.testing.expectEqual(@as(usize, 2), charWidth(0x231A));  // Watch
+    try std.testing.expectEqual(@as(usize, 2), charWidth(0x2615)); // Hot beverage
+    try std.testing.expectEqual(@as(usize, 2), charWidth(0x231A)); // Watch
 }
 
 test "variation selectors are zero-width" {

--- a/tests/input_tests.zig
+++ b/tests/input_tests.zig
@@ -142,7 +142,7 @@ test "KeyEvent format" {
     var buf: Writer.Allocating = .init(allocator);
     defer buf.deinit();
 
-    try event.format("", .{}, &buf.writer);
+    try event.format(&buf.writer);
     try testing.expectEqualStrings("ctrl+a", buf.written());
 }
 

--- a/tests/program_tests.zig
+++ b/tests/program_tests.zig
@@ -21,7 +21,9 @@ const DummyModel = struct {
 };
 
 test "Program.init context allocator is stable before start and can be rebound to arena" {
-    var program = try zz.Program(DummyModel).init(testing.allocator);
+    var env_map: std.process.Environ.Map = .init(testing.allocator);
+    defer env_map.deinit();
+    var program = try zz.Program(DummyModel).init(testing.allocator, testing.io, &env_map);
     defer program.deinit();
 
     const backing_ptr = @intFromPtr(testing.allocator.ptr);

--- a/tests/theme_tests.zig
+++ b/tests/theme_tests.zig
@@ -83,7 +83,9 @@ test "Theme boldStyleWith creates bold inline style" {
 }
 
 test "ThemeManager init and cycle" {
-    var tm = zz.ThemeManager.init();
+    var env_map: std.process.Environ.Map = .init(testing.allocator);
+    defer env_map.deinit();
+    var tm = zz.ThemeManager.init(&env_map);
 
     // Should start at index 0
     try testing.expectEqualStrings("Default Dark", tm.currentName());
@@ -100,7 +102,9 @@ test "ThemeManager init and cycle" {
 }
 
 test "ThemeManager setBuiltinByIndex" {
-    var tm = zz.ThemeManager.init();
+    var env_map: std.process.Environ.Map = .init(testing.allocator);
+    defer env_map.deinit();
+    var tm = zz.ThemeManager.init(&env_map);
 
     tm.setBuiltinByIndex(4); // Dracula
     try testing.expectEqualStrings("Dracula", tm.currentName());
@@ -108,7 +112,9 @@ test "ThemeManager setBuiltinByIndex" {
 }
 
 test "ThemeManager setPalette with custom palette" {
-    var tm = zz.ThemeManager.init();
+    var env_map: std.process.Environ.Map = .init(testing.allocator);
+    defer env_map.deinit();
+    var tm = zz.ThemeManager.init(&env_map);
 
     const custom = zz.Palette{
         .primary = .red,

--- a/tests/toast_tests.zig
+++ b/tests/toast_tests.zig
@@ -208,7 +208,7 @@ test "Toast constrains long messages to configured width" {
 }
 
 fn rightEdgeDisplay(line: []const u8) usize {
-    const trimmed = std.mem.trimRight(u8, line, " ");
+    const trimmed = std.mem.trimEnd(u8, line, " ");
     return zz.measure.width(trimmed);
 }
 


### PR DESCRIPTION
Updates the API to use `std.Io` VTable and chunky main `init: std.process.Init`, which was mostly a mechanical refactor. Updates CI / Documentation to use Zig 0.16.0

Did not touch `asyncTask` code beyond just passing a `std.Io` object in some callsites, though possible future work would be using `std.Io` for async.

**Incidental bug-fixes:**
* Discovered and fixed a memory leak in markdown noticed during testing
* Discovered and fixed wrong codepage causing buggy rendering on Windows

**Tested:** Working on Windows, Mac, Linux (`zig build`, `zig build test`, `zig build run-*`)