### PR TITLE
Fix detection of Shift + Enter in integrated terminal

### DIFF
--- a/src/input/keyboard.zig
+++ b/src/input/keyboard.zig
@@ -83,7 +83,14 @@ fn parseControl(c: u8) KeyEvent {
     return switch (c) {
         0 => .{ .key = .null_key, .modifiers = .{ .ctrl = true } },
         9 => .{ .key = .tab },
-        10, 13 => .{ .key = .enter },
+        // In raw mode 0x0a is sent by the terminal itself
+        // Some editor-integrated terminals (Zed, possibly VSCode) use this
+        // historical CR/LF split to encode Shift+Enter without a richer
+        // keyboard protocol -- plain Enter sends 0x0d, Shift+Enter sends
+        // 0x0a. Mapping LF onto Enter+Shift recovers the modifier, ensuring
+        // consistent behavior to other TUI applications / libraries.
+        10 => .{ .key = .enter, .modifiers = .{ .shift = true } },
+        13 => .{ .key = .enter },
         27 => .{ .key = .escape },
         1...8, 11, 12, 14...26 => .{
             .key = .{ .char = 'a' + c - 1 },


### PR DESCRIPTION
In terminals like Zed (possibly VS Code), typing Shift + Enter into the terminal creates `0x0A` whereas Enter creates `0x0D`. Since we're in raw mode and untranslated, we can use this to recover the modifier key, meaning applications which use Shift + Enter (like in text forms) can consistently use the ergonomic Enter = Submit, Shift + Enter = Newline.

Other TUI applications appear to make this distinction correctly in this environment, so this should help with parity.