### PR TITLE
chore: update zig 0.16 api compatibility

### DIFF
--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -231,8 +231,7 @@ const Model = struct {
             \\const std = @import("std");
             \\
             \\pub fn main() !void {
-            \\    const stdout = std.Io.getStdOut().writer();
-            \\    try stdout.print("Hello, {s}!\n", .{"world"});
+            \\    std.debug.print("Hello, {s}!\n", .{"world"});
             \\}
             \\
             \\// Edit this code with the text area component.

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -37,15 +37,7 @@ pub const MouseEvent = struct {
     event_type: EventType,
     modifiers: keys.Modifiers = .{},
 
-    pub fn format(
-        self: MouseEvent,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: *Writer,
-    ) !void {
-        _ = fmt;
-        _ = options;
-
+    pub fn format(self: MouseEvent, writer: *Writer) Writer.Error!void {
         try writer.print("{s} {s} at ({d}, {d})", .{
             @tagName(self.event_type),
             @tagName(self.button),


### PR DESCRIPTION
- Simplify `MouseEvent.format` to the new zig 0.16 `std.fmt` signature, dropping the unused `fmt`/`options` parameters and using `Writer.Error`.
- Replace removed `std.Io.getStdOut().writer()` usage in the showcase example with `std.debug.print` so it builds against the current stdlib.