### PR TITLE
Fix: Remove error union from `Program.init*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
     try program.run();
 }
@@ -883,7 +883,7 @@ const fs = zz.FocusStyle{
 Configure the program with custom options:
 
 ```zig
-var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
+var program = zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
     .fps = 60,                  // Target frame rate
     .alt_screen = true,         // Use alternate screen buffer
     .mouse = false,             // Enable mouse tracking
@@ -928,7 +928,7 @@ For model state that must live across frames, allocate with `ctx.persistent_allo
 For applications that need to do other work between frames (network polling, background processing, etc.), use `start()` + `tick()` instead of `run()`:
 
 ```zig
-var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 defer program.deinit();
 
 try program.start();
@@ -955,7 +955,7 @@ pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
 Intercept and transform messages before they reach your model:
 
 ```zig
-var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 program.setFilter(&myFilter);
 
 fn myFilter(msg: Model.Msg) ?Model.Msg {

--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -162,7 +162,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -204,7 +204,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -158,7 +158,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -147,7 +147,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -134,7 +134,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -81,7 +81,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -310,7 +310,7 @@ fn inlineStat(ctx: *const zz.Context, label: []const u8, value: []const u8) ![]c
 }
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
     try program.run();
 }

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -130,7 +130,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
+    var program = zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .title = "ZigZag OSC 52 Clipboard",
         .osc52 = .{
             .enabled = true,

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -113,7 +113,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -110,7 +110,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -262,7 +262,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -92,7 +92,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -105,7 +105,7 @@ pub fn main(init: std.process.Init) !void {
     try console.addSink(.{ .file = "dev_console.log" });
     try console.addSink(.{ .tcp = .{ .host = "127.0.0.1", .port = 7878 } });
 
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -97,7 +97,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -120,7 +120,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -166,7 +166,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var prog = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -79,7 +79,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -106,7 +106,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -80,7 +80,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -325,7 +325,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -108,7 +108,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -32,7 +32,7 @@ const sample_md =
     \\const zz = @import("zigzag");
     \\
     \\pub fn main() !void {
-    \\    var program = try zz.Program(Model).init(allocator);
+    \\    var program = zz.Program(Model).init(allocator);
     \\    try program.run();
     \\}
     \\```
@@ -95,7 +95,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -156,7 +156,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -145,7 +145,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var prog = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -140,7 +140,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
+    var program = zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .mouse = true,
     });
     defer program.deinit();

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -161,7 +161,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -185,7 +185,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -1036,7 +1036,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
+    var program = zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_map, .{
         .mouse = true,
         .title = "ZigZag Showcase",
     });

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -105,7 +105,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -73,7 +73,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -132,7 +132,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -133,7 +133,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -148,7 +148,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -104,7 +104,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -153,7 +153,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -216,7 +216,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -290,7 +290,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -246,7 +246,7 @@ fn clearShortcut(label: []const u8, key: []const u8) zz.Tooltip {
 }
 
 pub fn main(init: std.process.Init) !void {
-    var prog = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var prog = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer prog.deinit();
 
     try prog.run();

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -80,7 +80,7 @@ const items_array = blk: {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -90,7 +90,7 @@ const Model = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+    var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
     defer program.deinit();
 
     try program.run();

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -77,7 +77,7 @@ pub fn Program(comptime Model: type) type {
             allocator: std.mem.Allocator,
             io: std.Io,
             environ_map: *const std.process.Environ.Map,
-        ) !Self {
+        ) Self {
             return initWithOptions(allocator, io, environ_map, .{});
         }
 
@@ -87,7 +87,7 @@ pub fn Program(comptime Model: type) type {
             io: std.Io,
             environ_map: *const std.process.Environ.Map,
             options: Options,
-        ) !Self {
+        ) Self {
             const arena = std.heap.ArenaAllocator.init(allocator);
             const clock_epoch = std.Io.Clock.Timestamp.now(io, .boot);
             const self = Self{

--- a/src/root.zig
+++ b/src/root.zig
@@ -39,7 +39,7 @@
 //! };
 //!
 //! pub fn main(init: std.process.Init) !void {
-//!     var program = try zz.Program(Model).init(init.gpa, init.io, init.environ_map);
+//!     var program = zz.Program(Model).init(init.gpa, init.io, init.environ_map);
 //!     defer program.deinit();
 //!     try program.run();
 //! }

--- a/tests/program_tests.zig
+++ b/tests/program_tests.zig
@@ -23,7 +23,7 @@ const DummyModel = struct {
 test "Program.init context allocator is stable before start and can be rebound to arena" {
     var env_map: std.process.Environ.Map = .init(testing.allocator);
     defer env_map.deinit();
-    var program = try zz.Program(DummyModel).init(testing.allocator, testing.io, &env_map);
+    var program = zz.Program(DummyModel).init(testing.allocator, testing.io, &env_map);
     defer program.deinit();
 
     const backing_ptr = @intFromPtr(testing.allocator.ptr);


### PR DESCRIPTION
While writing my TUI application I noticed my refactored main had some code that looked like it shouldn't compile:

```zig
pub fn main(init: std.process.Init) u8 {
    // ...
    var program = try zz.Program(tui.Model).initWithOptions(
        arena.allocator(),
        init.io,
        init.environ_map,
        .{
            .kitty_keyboard = true,
            .bracketed_paste = true,
            .title = "Hanabi",
            .alt_screen = true,
        },
    );
    // ...
    return 0;
}
```

`try` without `!u8` as the return type *should* fail in most contexts; The reason it doesn't here is because the error set is `{}` -- there are no possible errors from the code path. 

Checking `init`, nothing currently throws an error, it's all infallible struct initialization. Reflecting this appropriately in the type signature keeps the API honest to the real behavior, as it currently is impossible to throw an error. If at some point this changes, error-unions can be reintroduced then.