### PR TITLE
fixed the cursor index when filtering list

### DIFF
--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -391,7 +391,7 @@ pub fn List(comptime T: type) type {
             }
 
             if (self.cursor >= self.filtered_indices.items.len and self.filtered_indices.items.len > 0) {
-                self.cursor = self.filtered_indices.items.len - 1;
+                self.cursor = 0;
             }
             self.ensureVisible();
         }


### PR DESCRIPTION
In src/components/list.zig, the function _updateFilter()_ sets the List's cursor field to "_self.filtered_indices.items.len - 1_" — i.e., to the last filtered item — when the _cursor field_ is greater than or equal to _filtered_indices.items.len_ and that length is greater than zero.

This behavior is confusing because it makes it appear as if there is only one filtered item, while there are other items above. You can see the behavior in this video:

[video before the change](https://github.com/user-attachments/assets/590ceef1-0756-4b37-b6e8-2d3c056e68fe)

In my view, the correct behavior is to reset the cursor to the first item when the list is filtered. Accordingly, the code has been changed to the following:

```zig
--- a/src/components/list.zig
+++ b/src/components/list.zig
@@ -391,7 +391,7 @@ pub fn List(comptime T: type) type {
             }
 
             if (self.cursor >= self.filtered_indices.items.len and self.filtered_indices.items.len > 0) {
-                self.cursor = self.filtered_indices.items.len - 1;
+                self.cursor = 0;
             }
             self.ensureVisible();
         }
```

This is the behavior after the change:

[video after the change](https://github.com/user-attachments/assets/f35be1c0-a965-47a6-9859-190a8760a66d)

**Nice library, btw. Thanks a lot!**