### PR TITLE
fix: invert y-axis label row index to match plot orientation

### DIFF
--- a/src/components/chart.zig
+++ b/src/components/chart.zig
@@ -392,12 +392,12 @@ pub const Chart = struct {
     }
 
     fn renderPlotRow(self: *const Chart, allocator: std.mem.Allocator, row_index: usize, plot_line: []const u8, plot_height: usize, y_label_width: usize, y_ticks: *const TickSet) ![]const u8 {
-        _ = plot_height;
         var result: Writer.Allocating = .init(allocator);
         const writer = &result.writer;
 
         if (self.y_axis.show_labels) {
-            const label = y_ticks.labelForRow(row_index) orelse "";
+            const tick_row = if (plot_height > 0) plot_height - 1 - row_index else row_index;
+            const label = y_ticks.labelForRow(tick_row) orelse "";
             const padded = try renderPaddedLabel(allocator, label, y_label_width, self.y_axis.label_style);
             defer allocator.free(padded);
             try writer.writeAll(padded);


### PR DESCRIPTION
Fixes #110.

## Summary
- The plot is rendered top→bottom, but `TickSet.updatePositions` stored tick positions using `mapToResolution` directly, which puts the smallest value at position 0. `mapY` (used for drawing the data) flips the coordinate so the largest value lands at screen row 0, leaving the y-axis labels mirrored relative to the plot.
- `renderPlotRow` now looks up the tick label by `plot_height - 1 - row_index`, matching the rendered plot orientation (largest value at top, smallest at bottom).
- Drops the `_ = plot_height` discard now that the parameter is used.

## Test plan
- [x] `zig build run-charts` (or equivalent) and confirm y-axis labels are ordered largest at top, smallest at bottom.
- [x] Charts with `show_labels = false` still render unchanged.