### PR TITLE
fix: detect terminal resize on Windows via console buffer polling

### DIFF
--- a/src/terminal/platform/windows.zig
+++ b/src/terminal/platform/windows.zig
@@ -333,14 +333,49 @@ pub fn flush(handle: windows.HANDLE) void {
     // Windows typically auto-flushes
 }
 
+/// Last observed console window dimensions, used to detect resizes by polling.
+/// Windows has no SIGWINCH equivalent, so `checkResize` compares the current
+/// size against these cached values. `resize_initialized` guards the first read
+/// so startup establishes a baseline without reporting a spurious resize.
+var resize_initialized: bool = false;
+var cached_cols: windows.SHORT = 0;
+var cached_rows: windows.SHORT = 0;
+
 /// Setup signal handlers (Windows uses console events differently)
 pub fn setupSignals() !void {
-    // Windows handles resize through WINDOW_BUFFER_SIZE_EVENT
-    // This is handled in the input loop
+    // Windows has no SIGWINCH. Resize is detected by polling the console screen
+    // buffer in `checkResize`, so there is nothing to register here.
 }
 
-/// Check if resize was signaled
-pub fn checkResize() bool {
-    // On Windows, resize is handled through console events
+/// Check whether the terminal was resized since the last call.
+///
+/// Polls the console window dimensions (via the same handle `getSize` reads) and
+/// compares them against the last observed size. `GetConsoleScreenBufferInfo` is
+/// a cheap kernel read, so polling each frame is negligible. Polling is used
+/// instead of `WINDOW_BUFFER_SIZE_EVENT` because those records are only queued
+/// when `ENABLE_WINDOW_INPUT` is set on the input mode, which `enableRawMode`
+/// deliberately avoids. Because the size is re-polled every frame, a transiently
+/// stale reading under ConPTY self-corrects on a later frame.
+pub fn checkResize(handle: windows.HANDLE) bool {
+    var info: CONSOLE_SCREEN_BUFFER_INFO = undefined;
+    if (!GetConsoleScreenBufferInfo(handle, &info).toBool()) return false;
+
+    const cols = info.srWindow.Right - info.srWindow.Left + 1;
+    const rows = info.srWindow.Bottom - info.srWindow.Top + 1;
+
+    // The first successful read establishes the baseline without signaling a
+    // resize; the initial size is already reported via `getSize` at startup.
+    if (!resize_initialized) {
+        resize_initialized = true;
+        cached_cols = cols;
+        cached_rows = rows;
+        return false;
+    }
+
+    if (cols != cached_cols or rows != cached_rows) {
+        cached_cols = cols;
+        cached_rows = rows;
+        return true;
+    }
     return false;
 }

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -431,8 +431,13 @@ pub const Terminal = struct {
 
     /// Check if terminal was resized
     pub fn checkResize(self: *Terminal) bool {
-        _ = self;
-        return platform.checkResize();
+        if (is_wasm) {
+            return platform.checkResize();
+        } else if (builtin.os.tag == .windows) {
+            return platform.checkResize(self.state.stdout_handle);
+        } else {
+            return platform.checkResize();
+        }
     }
 
     /// Get a Writer interface.


### PR DESCRIPTION
## Problem

Fixes #114. On Windows, `checkResize()` was a stub that always returned `false`, so `Program.tick()` never entered the resize branch — `context.width`/`context.height` stayed frozen at startup values and the `window_size` message was never dispatched. zigzag TUIs on Windows never adapted to a resized terminal window.

## Fix

Detect resize by polling `GetConsoleScreenBufferInfo` and comparing the `srWindow` dimensions against the last observed size.

`WINDOW_BUFFER_SIZE_EVENT` is intentionally **not** used: per the Windows Console docs, those records are only queued when `ENABLE_WINDOW_INPUT` is set on the input mode, which `enableRawMode` deliberately avoids (it wakes the stdin wait-handle without producing `ReadFile` bytes). Polling is the only viable mechanism under the current input mode, and it works under the classic console host. Under ConPTY/Windows Terminal a transiently stale reading self-corrects because the size is re-polled every frame; it degrades gracefully (returns `false`) when stdout isn't a console.

Notes:
- A first-read guard establishes the baseline so startup doesn't report a spurious resize.
- `checkResize` now takes the same stdout handle `getSize` uses (`state.stdout_handle`), so detection and measurement agree when a custom `Config.output` handle is set.

## Verification

- Compiles clean for Windows (`x86_64-windows-gnu`), POSIX (native), and WASM.
- `zig build test` passes.