### PR TITLE
fix: don't store frame-arena string in mouse example

### DIFF
--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -36,7 +36,7 @@ const Model = struct {
         return .enable_mouse;
     }
 
-    pub fn update(self: *Model, msg: Msg, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn update(self: *Model, msg: Msg, _: *zz.Context) zz.Cmd(Msg) {
         switch (msg) {
             .key => |k| switch (k.key) {
                 .char => |c| if (c == 'q') return .quit,
@@ -58,11 +58,10 @@ const Model = struct {
                                 },
                                 1 => {
                                     self.click_count += 1;
-                                    self.last_event = std.fmt.allocPrint(
-                                        ctx.allocator,
-                                        "Count: {d}",
-                                        .{self.click_count},
-                                    ) catch "Count++";
+                                    // ctx.allocator is a per-frame arena, so
+                                    // strings stored in the model must not be
+                                    // allocated from it.
+                                    self.last_event = "Count incremented!";
                                 },
                                 2 => {
                                     self.click_count = 0;

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -231,8 +231,7 @@ const Model = struct {
             \\const std = @import("std");
             \\
             \\pub fn main() !void {
-            \\    const stdout = std.Io.getStdOut().writer();
-            \\    try stdout.print("Hello, {s}!\n", .{"world"});
+            \\    std.debug.print("Hello, {s}!\n", .{"world"});
             \\}
             \\
             \\// Edit this code with the text area component.

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -37,15 +37,7 @@ pub const MouseEvent = struct {
     event_type: EventType,
     modifiers: keys.Modifiers = .{},
 
-    pub fn format(
-        self: MouseEvent,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: *Writer,
-    ) !void {
-        _ = fmt;
-        _ = options;
-
+    pub fn format(self: MouseEvent, writer: *Writer) Writer.Error!void {
         try writer.print("{s} {s} at ({d}, {d})", .{
             @tagName(self.event_type),
             @tagName(self.button),


### PR DESCRIPTION
Fixes #122

The Count++ handler stored a string allocated from ctx.allocator in the model. That allocator is a per-frame arena that gets reset every tick, so last_event ended up pointing at freed memory. Whatever got rendered from it could wrap or contain newlines, which left a stale row on screen and showed up as the duplicated help line. Use a static message instead, the count is already shown on its own line.