### PR TITLE
fix: keep escape sequences intact across read boundaries (#123)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -838,12 +838,19 @@ var program = zz.Program(Model).initWithOptions(init.gpa, init.io, init.environ_
     },
     .unicode_width_strategy = null, // null=auto, .legacy_wcwidth, .unicode
     .suspend_enabled = true,    // Enable Ctrl+Z suspend/resume
+    .escape_timeout_ms = 50,    // How long a lone ESC waits for a sequence
     .title = "My App",         // Window title
     .log_file = "debug.log",   // Debug log file path
     .input = custom_stdin,      // Custom input (for testing/piping)
     .output = custom_stdout,    // Custom output (for testing/piping)
 });
 ```
+
+`escape_timeout_ms` exists because a bare `ESC` is byte-for-byte the beginning of
+every arrow key, function key and mouse report. The runtime holds a lone `ESC`
+for this long, and delivers it as the Escape key only if nothing follows.
+Lower it for a snappier Escape; raise it when sequences arrive in pieces over a
+slow link.
 
 Unicode width strategy can also be overridden per-process with `ZZ_UNICODE_WIDTH=auto|legacy|unicode`.
 By default (`null`/`auto`), ZigZag:
@@ -911,6 +918,41 @@ pub const Msg = union(enum) {
     paste: []const u8,  // Receives full pasted text
 };
 ```
+
+A paste arrives as one event. Very large pastes (beyond the parser's internal
+buffer) stream in as several consecutive `paste` events instead, split only on
+codepoint boundaries — append them rather than replacing.
+
+### Parsing terminal input yourself
+
+`zz.InputParser` is the decoder the runtime uses, exposed for custom input
+loops. It matters because terminals do not deliver whole sequences: a read
+lands wherever the kernel had bytes ready, so an SGR mouse report is routinely
+cut in half during fast scrolling. Parsing each read on its own turns the
+leading `ESC` into an Escape key press and spills the remaining bytes into the
+application as text.
+
+```zig
+var parser: zz.InputParser = .{};
+
+// Every loop iteration, including the ones that read nothing — a lone ESC is
+// only released once `escape_timeout_ns` has passed without more input.
+const n = try terminal.readInput(&buf, 0);
+const events = try parser.feed(allocator, buf[0..n], now_ns);
+for (events) |event| switch (event) {
+    .key => |k| ...,
+    .mouse => |m| ...,
+    .none => {},
+};
+```
+
+Terminal replies that are not key presses (device attributes, cursor position
+reports, OSC clipboard answers, Kitty graphics acknowledgements) are consumed
+and discarded rather than surfacing as text.
+
+For a buffer that is known to be complete — a test fixture, a recorded
+session — `zz.input.keyboard.parseAll` decodes it in one call without any
+retained state.
 
 ### OSC 52 clipboard
 

--- a/build.zig
+++ b/build.zig
@@ -92,6 +92,7 @@ pub fn build(b: *std.Build) void {
     const test_files = [_][]const u8{
         "tests/style_tests.zig",
         "tests/input_tests.zig",
+        "tests/input_stream_tests.zig",
         "tests/layout_tests.zig",
         "tests/unicode_tests.zig",
         "tests/program_tests.zig",

--- a/src/core/context.zig
+++ b/src/core/context.zig
@@ -380,4 +380,13 @@ pub const Options = struct {
 
     /// Enable suspend/resume with Ctrl+Z
     suspend_enabled: bool = true,
+
+    /// How long a lone ESC waits for the rest of an escape sequence before it
+    /// is delivered as the Escape key (milliseconds).
+    ///
+    /// A bare ESC is byte-for-byte the start of every arrow key, function key
+    /// and mouse report, so the two can only be told apart by whether more
+    /// input follows. Lower values make Escape feel snappier; raise it if
+    /// sequences arrive in pieces over a slow link (ssh, serial).
+    escape_timeout_ms: u32 = 50,
 };

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -24,6 +24,13 @@ const PendingImage = union(enum) {
     place_cached: command.PlaceCachedImage,
 };
 
+/// Bytes pulled from the terminal per read.
+const read_chunk_size = 1024;
+
+/// Upper bound on reads per tick, so a firehose on stdin cannot starve
+/// rendering.
+const max_reads_per_tick = 8;
+
 /// Program runtime that manages the application lifecycle
 pub fn Program(comptime Model: type) type {
     // Ensure Model has required declarations
@@ -77,6 +84,8 @@ pub fn Program(comptime Model: type) type {
         last_line_count: usize,
         pending_image: ?PendingImage,
         logger: ?Logger,
+        /// Retains escape sequences that a read cut in half.
+        input_parser: keyboard.InputParser,
 
         /// Message filter function
         filter: ?*const fn (UserMsg) ?UserMsg,
@@ -123,6 +132,7 @@ pub fn Program(comptime Model: type) type {
                 .last_line_count = 0,
                 .pending_image = null,
                 .logger = null,
+                .input_parser = .{},
                 .filter = null,
             };
 
@@ -198,6 +208,9 @@ pub fn Program(comptime Model: type) type {
                 .osc52 = self.options.osc52,
             });
 
+            self.input_parser.escape_timeout_ns =
+                @as(u64, self.options.escape_timeout_ms) * std.time.ns_per_ms;
+
             // Set title if provided
             if (self.options.title) |title| {
                 try self.terminal.?.setTitle(title);
@@ -266,23 +279,7 @@ pub fn Program(comptime Model: type) type {
                 }
             }
 
-            // Non-blocking drain; input typed during pacing sits in the TTY buffer.
-            var input_buf: [256]u8 = undefined;
-            const bytes_read = try self.terminal.?.readInput(&input_buf, 0);
-
-            if (bytes_read > 0) {
-                const events = try keyboard.parseAll(self.context.allocator, input_buf[0..bytes_read]);
-                for (events) |event| {
-                    const user_cmd = switch (event) {
-                        .key => |k| self.processKeyEvent(k),
-                        .mouse => |m| self.processMouseEvent(m),
-                        .none => null,
-                    };
-                    if (user_cmd) |cmd| {
-                        try self.processCommand(cmd);
-                    }
-                }
-            }
+            try self.drainInput();
 
             // Handle pending tick
             if (self.pending_tick) |tick_ns| {
@@ -346,6 +343,42 @@ pub fn Program(comptime Model: type) type {
                     });
                     deadline.wait(self.io) catch unreachable;
                 }
+            }
+        }
+
+        /// Read whatever the terminal has ready and dispatch the events it
+        /// decodes into.
+        ///
+        /// Reads are non-blocking, so a burst that outgrows one buffer (paste,
+        /// or a trackpad producing mouse reports faster than a frame) is
+        /// picked up within the same tick instead of trickling in over the
+        /// following ones. `InputParser` stitches sequences back together when
+        /// a read lands in the middle of one.
+        fn drainInput(self: *Self) !void {
+            var input_buf: [read_chunk_size]u8 = undefined;
+
+            var reads: usize = 0;
+            while (reads < max_reads_per_tick) : (reads += 1) {
+                const bytes_read = try self.terminal.?.readInput(&input_buf, 0);
+
+                const events = try self.input_parser.feed(
+                    self.context.allocator,
+                    input_buf[0..bytes_read],
+                    self.context.elapsed,
+                );
+                for (events) |event| {
+                    const user_cmd = switch (event) {
+                        .key => |k| self.processKeyEvent(k),
+                        .mouse => |m| self.processMouseEvent(m),
+                        .none => null,
+                    };
+                    if (user_cmd) |cmd| {
+                        try self.processCommand(cmd);
+                    }
+                }
+
+                // A short read means the terminal has nothing left for now.
+                if (bytes_read < input_buf.len) break;
             }
         }
 
@@ -440,6 +473,10 @@ pub fn Program(comptime Model: type) type {
             if (self.terminal) |*term| {
                 term.setup() catch {};
             }
+
+            // Whatever was mid-sequence when we stopped will never be
+            // completed; drop it instead of merging it with post-resume input.
+            self.input_parser.reset();
 
             // Avoid a large post-resume delta, and rebase the pacing anchor so we
             // don't burst-render to "catch up" the suspended interval. Advance the

--- a/src/input/keyboard.zig
+++ b/src/input/keyboard.zig
@@ -20,29 +20,86 @@ pub const ParseResult = union(enum) {
 /// Return type for parse functions
 pub const ParseReturn = struct { result: ParseResult, consumed: usize };
 
-/// Parse a single input event from raw terminal data
+/// Outcome of a single streaming parse step.
+pub const StreamStep = union(enum) {
+    /// A whole sequence was decoded; `consumed` is always greater than zero.
+    /// `result` is `.none` for sequences that are well formed but carry no
+    /// key or mouse event (device reports, OSC replies, ...) — those bytes
+    /// are dropped instead of leaking to the application as text.
+    event: ParseReturn,
+    /// `data` ends in the middle of a sequence. Keep the bytes and retry once
+    /// more input has arrived.
+    incomplete,
+};
+
+const paste_start = "\x1b[200~";
+const paste_end = "\x1b[201~";
+
+/// Parse one event, treating `data` as everything that will ever arrive.
+///
+/// A sequence truncated by the end of the buffer is decoded as best it can be:
+/// a cut-off CSI yields the bare Escape key and its remaining bytes are read
+/// as text. When bytes come from a stream — where a sequence is routinely
+/// split across two reads — use `InputParser` instead, which holds the tail
+/// back until the rest arrives.
 pub fn parse(data: []const u8) ParseReturn {
+    return switch (parseStream(data)) {
+        .event => |e| e,
+        .incomplete => parseFlush(data),
+    };
+}
+
+/// Parse one event, reporting `.incomplete` when `data` stops mid-sequence
+/// rather than guessing at the truncated bytes.
+pub fn parseStream(data: []const u8) StreamStep {
+    if (data.len == 0) return .incomplete;
+
+    if (data[0] == 0x1b) {
+        const frame_len = switch (frameEscape(data)) {
+            .complete => |n| n,
+            .incomplete => return .incomplete,
+        };
+        return parseFramed(data, frame_len);
+    }
+
+    // Control characters
+    if (data[0] < 32) {
+        return .{ .event = .{ .result = .{ .key = parseControl(data[0]) }, .consumed = 1 } };
+    }
+
+    // DEL character
+    if (data[0] == 127) {
+        return .{ .event = .{ .result = .{ .key = .{ .key = .backspace } }, .consumed = 1 } };
+    }
+
+    // UTF-8 character. A multi-byte codepoint split across reads has to wait
+    // for its continuation bytes, otherwise it decodes as mojibake.
+    const len = std.unicode.utf8ByteSequenceLength(data[0]) catch {
+        return .{ .event = .{ .result = .{ .key = .{ .key = .{ .char = data[0] } } }, .consumed = 1 } };
+    };
+    if (len > data.len) return .incomplete;
+    const codepoint = std.unicode.utf8Decode(data[0..len]) catch data[0];
+    return .{ .event = .{ .result = .{ .key = .{ .key = .{ .char = codepoint } } }, .consumed = len } };
+}
+
+/// Decode `data` as if no further input will arrive. Used to release a partial
+/// sequence that has waited long enough to be a real Escape key press.
+pub fn parseFlush(data: []const u8) ParseReturn {
     if (data.len == 0) return .{ .result = .none, .consumed = 0 };
 
-    // Check for escape sequence
     if (data[0] == 0x1b) {
-        if (data.len == 1) {
-            // Just escape key
-            return .{ .result = .{ .key = .{ .key = .escape } }, .consumed = 1 };
+        if (std.mem.startsWith(u8, data, paste_start)) {
+            if (parseBracketedPaste(data)) |result| return result;
         }
 
         // CSI sequence
         if (data.len >= 2 and data[1] == '[') {
-            if (parseCsi(data)) |result| {
-                return result;
-            }
+            if (parseCsi(data)) |result| return result;
         }
 
         // SS3 sequence (F1-F4 on some terminals)
         if (data.len >= 2 and data[1] == 'O') {
-            if (parseSs3(data)) |result| {
-                return result;
-            }
+            if (parseSs3(data)) |result| return result;
         }
 
         // Alt + key
@@ -79,6 +136,129 @@ pub fn parse(data: []const u8) ParseReturn {
     return .{ .result = .{ .key = .{ .key = .{ .char = data[0] } } }, .consumed = 1 };
 }
 
+/// Extent of a leading escape sequence, before interpreting it.
+const Frame = union(enum) {
+    complete: usize,
+    incomplete,
+};
+
+/// Measure the escape sequence starting at `data[0]`, which must be ESC.
+/// Framing is purely structural (ECMA-48), so an unrecognised sequence still
+/// gets a length and can be skipped as a unit.
+fn frameEscape(data: []const u8) Frame {
+    if (data.len < 2) return .incomplete;
+
+    return switch (data[1]) {
+        '[' => frameCsi(data),
+        'O' => if (data.len >= 3) Frame{ .complete = 3 } else .incomplete,
+        ']' => frameString(data, .bel_or_st),
+        'P', '_', '^', 'X' => frameString(data, .st_only),
+        // ESC ESC ... — Alt applied to another sequence.
+        0x1b => switch (frameEscape(data[1..])) {
+            .complete => |n| Frame{ .complete = 1 + n },
+            .incomplete => .incomplete,
+        },
+        else => frameAltKey(data),
+    };
+}
+
+/// ESC [ <params 0x30-0x3F> <intermediates 0x20-0x2F> <final 0x40-0x7E>
+fn frameCsi(data: []const u8) Frame {
+    var i: usize = 2;
+    while (i < data.len and data[i] >= 0x30 and data[i] <= 0x3f) : (i += 1) {}
+    while (i < data.len and data[i] >= 0x20 and data[i] <= 0x2f) : (i += 1) {}
+    if (i >= data.len) return .incomplete;
+    // Anything else in place of the final byte means the terminal cut the
+    // sequence short. Consume what is there so the stream resynchronises on
+    // the next byte instead of stalling forever.
+    if (data[i] < 0x40 or data[i] > 0x7e) return .{ .complete = i };
+    return .{ .complete = i + 1 };
+}
+
+const StringTerm = enum { bel_or_st, st_only };
+
+/// OSC/DCS/APC/PM/SOS strings run until ST (ESC \), and OSC also until BEL.
+fn frameString(data: []const u8, term: StringTerm) Frame {
+    var i: usize = 2;
+    while (i < data.len) : (i += 1) {
+        if (term == .bel_or_st and data[i] == 0x07) return .{ .complete = i + 1 };
+        if (data[i] == 0x1b) {
+            if (i + 1 >= data.len) return .incomplete;
+            if (data[i + 1] == '\\') return .{ .complete = i + 2 };
+            // A bare ESC that is not ST aborts the string.
+            return .{ .complete = i };
+        }
+    }
+    return .incomplete;
+}
+
+/// ESC followed by one key.
+fn frameAltKey(data: []const u8) Frame {
+    const b = data[1];
+    if (b < 0x80) return .{ .complete = 2 };
+    const len = std.unicode.utf8ByteSequenceLength(b) catch return .{ .complete = 2 };
+    if (1 + len > data.len) return .incomplete;
+    return .{ .complete = 1 + len };
+}
+
+/// Interpret an escape sequence whose length is already known.
+fn parseFramed(data: []const u8, frame_len: usize) StreamStep {
+    const dropped = StreamStep{ .event = .{ .result = .none, .consumed = frame_len } };
+    if (frame_len < 2) return .{ .event = .{ .result = .{ .key = .{ .key = .escape } }, .consumed = 1 } };
+
+    const seq = data[0..frame_len];
+
+    switch (data[1]) {
+        '[' => {
+            // An X10 mouse report carries three raw payload bytes past the
+            // final byte, which the CSI framing rules know nothing about.
+            if (std.mem.eql(u8, seq, "\x1b[M")) {
+                if (data.len < mouse.x10_report_len) return .incomplete;
+                if (mouse.parseX10(data)) |m| {
+                    return .{ .event = .{ .result = .{ .mouse = m }, .consumed = mouse.x10_report_len } };
+                }
+                return .{ .event = .{ .result = .none, .consumed = mouse.x10_report_len } };
+            }
+
+            // The closing marker of a bracketed paste lives past this frame.
+            if (std.mem.eql(u8, seq, paste_start)) {
+                const content = data[paste_start.len..];
+                const end = std.mem.indexOf(u8, content, paste_end) orelse return .incomplete;
+                return .{ .event = .{
+                    .result = .{ .key = .{ .key = .{ .paste = content[0..end] } } },
+                    .consumed = paste_start.len + end + paste_end.len,
+                } };
+            }
+            if (parseCsi(seq)) |result| return .{ .event = result };
+            return dropped;
+        },
+        'O' => {
+            if (parseSs3(seq)) |result| return .{ .event = result };
+            return dropped;
+        },
+        // Terminal replies (clipboard, graphics, status). Nothing here is a key
+        // press, so the whole string is swallowed rather than echoed as text.
+        ']', 'P', '_', '^', 'X' => return dropped,
+        else => {},
+    }
+
+    // Alt + key. Parsed against the rest of the buffer rather than just this
+    // frame, because the inner sequence may reach past it (an X10 report or a
+    // paste carries payload the framing rules cannot see).
+    switch (parseStream(data[1..])) {
+        .event => |inner| switch (inner.result) {
+            .key => |k| {
+                var key_event = k;
+                key_event.modifiers.alt = true;
+                return .{ .event = .{ .result = .{ .key = key_event }, .consumed = 1 + inner.consumed } };
+            },
+            .mouse => |m| return .{ .event = .{ .result = .{ .mouse = m }, .consumed = 1 + inner.consumed } },
+            .none => return .{ .event = .{ .result = .none, .consumed = 1 + inner.consumed } },
+        },
+        .incomplete => return .incomplete,
+    }
+}
+
 fn parseControl(c: u8) KeyEvent {
     return switch (c) {
         0 => .{ .key = .null_key, .modifiers = .{ .ctrl = true } },
@@ -100,19 +280,29 @@ fn parseControl(c: u8) KeyEvent {
     };
 }
 
+/// Append a decimal digit to a CSI parameter, saturating rather than
+/// overflowing: nothing stops a terminal (or a corrupted stream) from sending
+/// a parameter with more digits than a u16 can hold.
+fn accumulateParam(value: u16, digit: u8) u16 {
+    const scaled = std.math.mul(u16, value, 10) catch return std.math.maxInt(u16);
+    return std.math.add(u16, scaled, digit - '0') catch std.math.maxInt(u16);
+}
+
 fn parseCsi(data: []const u8) ?ParseReturn {
     if (data.len < 3) return null;
     if (data[0] != 0x1b or data[1] != '[') return null;
-
-    // Check for bracketed paste start: ESC[200~
-    if (data.len >= 6 and std.mem.startsWith(u8, data[2..], "200~")) {
-        return parseBracketedPaste(data);
-    }
 
     // Check for mouse SGR sequence
     if (data.len >= 3 and data[2] == '<') {
         if (mouse.parseSgr(data)) |m| {
             return .{ .result = .{ .mouse = m.event }, .consumed = m.consumed };
+        }
+    }
+
+    // Check for a legacy X10 mouse report
+    if (data[2] == 'M') {
+        if (mouse.parseX10(data)) |m| {
+            return .{ .result = .{ .mouse = m }, .consumed = mouse.x10_report_len };
         }
     }
 
@@ -126,7 +316,7 @@ fn parseCsi(data: []const u8) ?ParseReturn {
     while (idx < data.len and param_count < params.len) {
         const c = data[idx];
         if (c >= '0' and c <= '9') {
-            params[param_count] = params[param_count] * 10 + @as(u16, @intCast(c - '0'));
+            params[param_count] = accumulateParam(params[param_count], c);
             idx += 1;
         } else if (c == ';') {
             param_count += 1;
@@ -138,7 +328,7 @@ fn parseCsi(data: []const u8) ?ParseReturn {
             idx += 1;
             // Parse the sub-parameter value
             while (idx < data.len and data[idx] >= '0' and data[idx] <= '9') {
-                sub_params[param_count] = sub_params[param_count] * 10 + @as(u16, @intCast(data[idx] - '0'));
+                sub_params[param_count] = accumulateParam(sub_params[param_count], data[idx]);
                 idx += 1;
             }
         } else {
@@ -262,19 +452,16 @@ fn parseKittyCsi(params: []const u16, sub_params: []const u16, has_colon: bool, 
 }
 
 /// Parse bracketed paste: ESC[200~ ... ESC[201~
+/// `data` must start with the opening marker.
 fn parseBracketedPaste(data: []const u8) ?ParseReturn {
-    // data starts with ESC[200~
-    const paste_start = 6; // length of ESC[200~
-    const end_marker = "\x1b[201~";
+    const content = data[paste_start.len..];
 
-    if (std.mem.indexOf(u8, data[paste_start..], end_marker)) |end_offset| {
-        const paste_content = data[paste_start .. paste_start + end_offset];
-        const total_consumed = paste_start + end_offset + end_marker.len;
+    if (std.mem.indexOf(u8, content, paste_end)) |end_offset| {
         return .{
             .result = .{ .key = .{
-                .key = .{ .paste = paste_content },
+                .key = .{ .paste = content[0..end_offset] },
             } },
-            .consumed = total_consumed,
+            .consumed = paste_start.len + end_offset + paste_end.len,
         };
     }
 
@@ -282,7 +469,7 @@ fn parseBracketedPaste(data: []const u8) ?ParseReturn {
     // (paste may span multiple reads)
     return .{
         .result = .{ .key = .{
-            .key = .{ .paste = data[paste_start..] },
+            .key = .{ .paste = content },
         } },
         .consumed = data.len,
     };
@@ -309,7 +496,11 @@ fn parseSs3(data: []const u8) ?ParseReturn {
     return .{ .result = .{ .key = .{ .key = key } }, .consumed = 3 };
 }
 
-/// Parse all available input events from a buffer
+/// Parse all available input events from a buffer.
+///
+/// The buffer is treated as self-contained; see `parse`. Reading from a live
+/// terminal should go through `InputParser` so that sequences split across
+/// reads survive.
 pub fn parseAll(allocator: std.mem.Allocator, data: []const u8) ![]ParseResult {
     var results = std.array_list.Managed(ParseResult).init(allocator);
     errdefer results.deinit();
@@ -326,4 +517,223 @@ pub fn parseAll(allocator: std.mem.Allocator, data: []const u8) ![]ParseResult {
     }
 
     return results.toOwnedSlice();
+}
+
+/// Incremental parser for terminal input that arrives in arbitrary chunks.
+///
+/// The OS hands over whatever bytes happen to be ready, so a single sequence
+/// is regularly split in two: an SGR mouse report like `ESC [ < 64;65;42 M`
+/// straddles the read boundary constantly while scrolling. Parsing each chunk
+/// on its own turns the leading `ESC` into an Escape key press and spills the
+/// rest into the application as literal characters. `InputParser` keeps the
+/// tail of an unfinished sequence until the remaining bytes show up.
+///
+/// A lone `ESC` cannot be told apart from the start of a sequence, so it is
+/// held as well and released as the Escape key once `escape_timeout_ns` has
+/// passed without further input — the same disambiguation vim and tmux use.
+/// That requires `feed` to be called on every event-loop iteration, including
+/// the ones where no bytes were read.
+pub const InputParser = struct {
+    /// Bytes retained between reads. Large enough for any single sequence plus
+    /// a healthy burst of mouse reports.
+    pub const capacity = 4096;
+
+    /// A paste is normally emitted as one event once its closing marker
+    /// arrives. Past this many buffered bytes it is streamed out in chunks so
+    /// the buffer cannot fill up.
+    pub const paste_chunk_threshold = capacity / 2;
+
+    pub const default_escape_timeout_ns: u64 = 50 * std.time.ns_per_ms;
+
+    buf: [capacity]u8 = undefined,
+    len: usize = 0,
+    /// Inside a bracketed paste, waiting for the closing marker.
+    in_paste: bool = false,
+    /// Set while an unfinished non-paste sequence is buffered.
+    holding: bool = false,
+    /// Timestamp passed to `feed` when the current partial sequence appeared.
+    holding_since_ns: u64 = 0,
+    /// How long a partial sequence waits before being read as a bare Escape.
+    escape_timeout_ns: u64 = default_escape_timeout_ns,
+
+    /// Feed one read's worth of bytes and collect the events they complete.
+    ///
+    /// `now_ns` is any monotonically increasing clock reading; it only drives
+    /// the escape timeout. Pass an empty `data` when a read returned nothing
+    /// so a pending Escape can still be released.
+    ///
+    /// The returned slice and any paste payloads it references are owned by
+    /// `allocator`.
+    pub fn feed(
+        self: *InputParser,
+        allocator: std.mem.Allocator,
+        data: []const u8,
+        now_ns: u64,
+    ) ![]ParseResult {
+        var results = std.array_list.Managed(ParseResult).init(allocator);
+        errdefer results.deinit();
+
+        var rest = data;
+        while (true) {
+            const take = @min(self.buf.len - self.len, rest.len);
+            @memcpy(self.buf[self.len..][0..take], rest[0..take]);
+            self.len += take;
+            rest = rest[take..];
+
+            // Bytes still waiting means the buffer is full: whatever is held
+            // cannot be completed by waiting, so release it now.
+            try self.drain(allocator, &results, now_ns, rest.len > 0);
+            if (rest.len == 0) break;
+
+            // A forced drain always empties the buffer; this only guards
+            // against a future parse step that refuses to make progress.
+            if (self.len == self.buf.len) self.clearBuffer();
+        }
+
+        return results.toOwnedSlice();
+    }
+
+    /// Bytes held back from previous feeds, waiting to be completed.
+    pub fn pending(self: *const InputParser) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    /// Drop any partial sequence. Use when the input stream is interrupted,
+    /// such as across a suspend/resume.
+    pub fn reset(self: *InputParser) void {
+        self.clearBuffer();
+        self.in_paste = false;
+    }
+
+    fn clearBuffer(self: *InputParser) void {
+        self.len = 0;
+        self.holding = false;
+    }
+
+    fn drain(
+        self: *InputParser,
+        allocator: std.mem.Allocator,
+        results: *std.array_list.Managed(ParseResult),
+        now_ns: u64,
+        force: bool,
+    ) !void {
+        var offset: usize = 0;
+
+        while (offset < self.len) {
+            const chunk = self.buf[offset..self.len];
+
+            if (self.in_paste) {
+                const consumed = try self.drainPaste(allocator, results, chunk, force);
+                if (consumed == 0) break;
+                offset += consumed;
+                continue;
+            }
+
+            if (std.mem.startsWith(u8, chunk, paste_start)) {
+                self.in_paste = true;
+                offset += paste_start.len;
+                continue;
+            }
+
+            switch (parseStream(chunk)) {
+                .event => |parsed| {
+                    if (parsed.consumed == 0) break;
+                    try appendResult(allocator, results, parsed.result);
+                    offset += parsed.consumed;
+                },
+                .incomplete => {
+                    const waited = now_ns -| self.holding_since_ns;
+                    const timed_out = self.holding and waited >= self.escape_timeout_ns;
+                    if (!force and !timed_out) break;
+
+                    const parsed = parseFlush(chunk);
+                    if (parsed.consumed == 0) break;
+                    try appendResult(allocator, results, parsed.result);
+                    offset += parsed.consumed;
+                },
+            }
+        }
+
+        if (offset > 0) {
+            if (offset < self.len) {
+                std.mem.copyForwards(u8, self.buf[0 .. self.len - offset], self.buf[offset..self.len]);
+            }
+            self.len -= offset;
+        }
+
+        if (self.len == 0 or self.in_paste) {
+            self.holding = false;
+        } else if (!self.holding or offset > 0) {
+            // A newly buffered partial starts its own timeout.
+            self.holding = true;
+            self.holding_since_ns = now_ns;
+        }
+    }
+
+    /// Consume paste content from the front of `chunk`, returning how many
+    /// bytes were taken (zero means "wait for more").
+    fn drainPaste(
+        self: *InputParser,
+        allocator: std.mem.Allocator,
+        results: *std.array_list.Managed(ParseResult),
+        chunk: []const u8,
+        force: bool,
+    ) !usize {
+        if (std.mem.indexOf(u8, chunk, paste_end)) |end| {
+            try appendPaste(allocator, results, chunk[0..end]);
+            self.in_paste = false;
+            return end + paste_end.len;
+        }
+
+        // The closing marker may be split across reads, so never touch the
+        // bytes that could still be its beginning.
+        const holdback = @min(paste_end.len - 1, chunk.len);
+        const ready = chunk.len - holdback;
+        if (!force and ready < paste_chunk_threshold) return 0;
+
+        const cut = utf8BoundaryFloor(chunk[0..ready]);
+        if (cut == 0) return 0;
+        try appendPaste(allocator, results, chunk[0..cut]);
+        return cut;
+    }
+
+    fn appendResult(
+        allocator: std.mem.Allocator,
+        results: *std.array_list.Managed(ParseResult),
+        result: ParseResult,
+    ) !void {
+        switch (result) {
+            .none => return,
+            // Paste payloads point into the buffer, which is compacted as
+            // events are consumed, so they have to be copied out.
+            .key => |k| switch (k.key) {
+                .paste => |content| return appendPaste(allocator, results, content),
+                else => {},
+            },
+            else => {},
+        }
+        try results.append(result);
+    }
+
+    fn appendPaste(
+        allocator: std.mem.Allocator,
+        results: *std.array_list.Managed(ParseResult),
+        content: []const u8,
+    ) !void {
+        const owned = try allocator.dupe(u8, content);
+        try results.append(.{ .key = .{ .key = .{ .paste = owned } } });
+    }
+};
+
+/// Length of the longest prefix of `bytes` that ends on a UTF-8 boundary.
+fn utf8BoundaryFloor(bytes: []const u8) usize {
+    var i = bytes.len;
+    var back: usize = 0;
+    while (i > 0 and back < 4) : (back += 1) {
+        i -= 1;
+        if (bytes[i] & 0xc0 == 0x80) continue; // continuation byte
+        const need = std.unicode.utf8ByteSequenceLength(bytes[i]) catch return bytes.len;
+        return if (i + need <= bytes.len) bytes.len else i;
+    }
+    return bytes.len;
 }

--- a/src/input/mouse.zig
+++ b/src/input/mouse.zig
@@ -86,6 +86,13 @@ pub fn disableSequence(mode: TrackingMode) []const u8 {
     };
 }
 
+/// Append a decimal digit to a parameter, saturating rather than overflowing
+/// on coordinates larger than a u16 can hold.
+fn accumulateParam(value: u16, digit: u8) u16 {
+    const scaled = std.math.mul(u16, value, 10) catch return std.math.maxInt(u16);
+    return std.math.add(u16, scaled, digit - '0') catch std.math.maxInt(u16);
+}
+
 /// Parse SGR mouse event (\x1b[<...M or \x1b[<...m)
 pub fn parseSgr(data: []const u8) ?struct { event: MouseEvent, consumed: usize } {
     // Format: \x1b[<Cb;Cx;CyM or \x1b[<Cb;Cx;Cym
@@ -99,7 +106,7 @@ pub fn parseSgr(data: []const u8) ?struct { event: MouseEvent, consumed: usize }
     while (idx < data.len and param_idx < 3) {
         const c = data[idx];
         if (c >= '0' and c <= '9') {
-            params[param_idx] = params[param_idx] * 10 + @as(u16, @intCast(c - '0'));
+            params[param_idx] = accumulateParam(params[param_idx], c);
             idx += 1;
         } else if (c == ';') {
             param_idx += 1;
@@ -160,5 +167,64 @@ pub fn parseSgr(data: []const u8) ?struct { event: MouseEvent, consumed: usize }
             .modifiers = modifiers,
         },
         .consumed = idx,
+    };
+}
+
+/// Length of an X10 mouse report: `ESC [ M` plus three payload bytes.
+pub const x10_report_len = 6;
+
+/// Parse an X10 mouse report (\x1b[M Cb Cx Cy).
+///
+/// Terminals that ignore the SGR request (mode 1006) answer in this older
+/// encoding, where the three bytes after `CSI M` are values biased by 32.
+/// Decoding them matters even when SGR is expected: unparsed, the payload
+/// reaches the application as three arbitrary characters.
+pub fn parseX10(data: []const u8) ?MouseEvent {
+    if (data.len < x10_report_len) return null;
+    if (!std.mem.startsWith(u8, data, "\x1b[M")) return null;
+
+    const cb: u16 = data[3] -% 32;
+    const raw_x: u16 = data[4] -% 32;
+    const raw_y: u16 = data[5] -% 32;
+
+    var modifiers = keys.Modifiers{};
+    if (cb & 4 != 0) modifiers.shift = true;
+    if (cb & 8 != 0) modifiers.alt = true;
+    if (cb & 16 != 0) modifiers.ctrl = true;
+
+    const is_motion = cb & 32 != 0;
+    const is_wheel = cb & 64 != 0;
+    const low = cb & 0b11;
+
+    const button: Button = if (is_wheel) switch (low) {
+        0 => .wheel_up,
+        1 => .wheel_down,
+        2 => .wheel_left,
+        else => .wheel_right,
+    } else switch (low) {
+        0 => .left,
+        1 => .middle,
+        2 => .right,
+        // X10 does not report which button was let go of.
+        else => .none,
+    };
+
+    const event_type: EventType = if (is_wheel)
+        .press
+    else if (is_motion and button == .none)
+        .move
+    else if (is_motion)
+        .drag
+    else if (low == 3)
+        .release
+    else
+        .press;
+
+    return .{
+        .x = if (raw_x > 0) raw_x - 1 else 0,
+        .y = if (raw_y > 0) raw_y - 1 else 0,
+        .button = button,
+        .event_type = event_type,
+        .modifiers = modifiers,
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -93,6 +93,7 @@ pub const input = struct {
     pub const mouse = @import("input/mouse.zig");
     pub const keys = @import("input/keys.zig");
 };
+pub const InputParser = input.keyboard.InputParser;
 pub const Key = input.keys.Key;
 pub const KeyEvent = input.keys.KeyEvent;
 pub const Modifiers = input.keys.Modifiers;

--- a/tests/input_stream_tests.zig
+++ b/tests/input_stream_tests.zig
@@ -1,0 +1,473 @@
+//! Streaming input parser tests.
+//!
+//! Terminal reads are chunked wherever the OS decides, so every sequence has
+//! to survive being cut at an arbitrary byte. These tests split known-good
+//! sequences at every possible boundary and check the events come out whole.
+
+const std = @import("std");
+const testing = std.testing;
+const zz = @import("zigzag");
+
+const keyboard = zz.input.keyboard;
+const InputParser = zz.InputParser;
+
+const ms = std.time.ns_per_ms;
+
+/// Collects everything a parser emits, so a sequence can be fed in pieces.
+const Harness = struct {
+    arena: std.heap.ArenaAllocator,
+    parser: InputParser = .{},
+    events: std.array_list.Managed(keyboard.ParseResult),
+    now_ns: u64 = 0,
+
+    fn init() Harness {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(testing.allocator),
+            .events = std.array_list.Managed(keyboard.ParseResult).init(testing.allocator),
+        };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.events.deinit();
+        self.arena.deinit();
+    }
+
+    fn feed(self: *Harness, data: []const u8) !void {
+        const produced = try self.parser.feed(self.arena.allocator(), data, self.now_ns);
+        try self.events.appendSlice(produced);
+    }
+
+    /// Advance the clock and feed nothing, as the event loop does on an idle
+    /// frame.
+    fn idle(self: *Harness, ns: u64) !void {
+        self.now_ns += ns;
+        try self.feed("");
+    }
+
+    fn keys(self: *const Harness) usize {
+        var n: usize = 0;
+        for (self.events.items) |e| {
+            if (e == .key) n += 1;
+        }
+        return n;
+    }
+};
+
+fn expectSingleMouse(events: []const keyboard.ParseResult, expected: zz.MouseEvent) !void {
+    try testing.expectEqual(@as(usize, 1), events.len);
+    try testing.expect(events[0] == .mouse);
+    const m = events[0].mouse;
+    try testing.expectEqual(expected.x, m.x);
+    try testing.expectEqual(expected.y, m.y);
+    try testing.expectEqual(expected.button, m.button);
+    try testing.expectEqual(expected.event_type, m.event_type);
+}
+
+test "SGR mouse report split at every byte boundary yields one event" {
+    const seq = "\x1b[<64;65;42M";
+    const expected = zz.MouseEvent{
+        .x = 64,
+        .y = 41,
+        .button = .wheel_up,
+        .event_type = .press,
+    };
+
+    for (1..seq.len) |split| {
+        var h = Harness.init();
+        defer h.deinit();
+
+        try h.feed(seq[0..split]);
+        try h.feed(seq[split..]);
+
+        expectSingleMouse(h.events.items, expected) catch |err| {
+            std.debug.print("split at {d} produced {d} events\n", .{ split, h.events.items.len });
+            return err;
+        };
+    }
+}
+
+test "SGR mouse report split across three reads yields one event" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b[<");
+    try h.feed("0;12;");
+    try h.feed("34M");
+
+    try expectSingleMouse(h.events.items, .{
+        .x = 11,
+        .y = 33,
+        .button = .left,
+        .event_type = .press,
+    });
+}
+
+test "rapid scroll burst split mid-sequence produces only mouse events" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    // Twenty wheel reports, chopped into 7-byte reads the way a small read
+    // buffer would cut them.
+    var stream = std.array_list.Managed(u8).init(testing.allocator);
+    defer stream.deinit();
+    for (0..20) |i| {
+        var buf: [32]u8 = undefined;
+        try stream.appendSlice(try std.fmt.bufPrint(&buf, "\x1b[<64;{d};{d}M", .{ i + 1, i + 1 }));
+    }
+
+    var offset: usize = 0;
+    while (offset < stream.items.len) {
+        const end = @min(offset + 7, stream.items.len);
+        try h.feed(stream.items[offset..end]);
+        offset = end;
+    }
+
+    try testing.expectEqual(@as(usize, 20), h.events.items.len);
+    for (h.events.items, 0..) |event, i| {
+        try testing.expect(event == .mouse);
+        try testing.expectEqual(@as(u16, @intCast(i)), event.mouse.x);
+        try testing.expectEqual(zz.MouseButton.wheel_up, event.mouse.button);
+    }
+}
+
+test "arrow key split across reads is not decoded as escape plus text" {
+    for (1..3) |split| {
+        var h = Harness.init();
+        defer h.deinit();
+
+        try h.feed("\x1b[A"[0..split]);
+        try h.feed("\x1b[A"[split..]);
+
+        try testing.expectEqual(@as(usize, 1), h.events.items.len);
+        try testing.expect(h.events.items[0].key.key == .up);
+    }
+}
+
+test "multi-byte codepoint split across reads decodes once" {
+    const utf8 = "€"; // three bytes
+    for (1..utf8.len) |split| {
+        var h = Harness.init();
+        defer h.deinit();
+
+        try h.feed(utf8[0..split]);
+        try h.feed(utf8[split..]);
+
+        try testing.expectEqual(@as(usize, 1), h.events.items.len);
+        try testing.expectEqual(@as(u21, '€'), h.events.items[0].key.key.char);
+    }
+}
+
+test "lone escape is held then released after the timeout" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    try h.idle(49 * ms);
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    try h.idle(1 * ms);
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expect(h.events.items[0].key.key == .escape);
+    try testing.expectEqual(@as(usize, 0), h.parser.pending().len);
+}
+
+test "escape followed by typing still resolves to escape then the key" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b");
+    try h.idle(60 * ms);
+    try h.feed("q");
+
+    try testing.expectEqual(@as(usize, 2), h.events.items.len);
+    try testing.expect(h.events.items[0].key.key == .escape);
+    try testing.expectEqual(@as(u21, 'q'), h.events.items[1].key.key.char);
+}
+
+test "escape immediately followed by a key is alt-modified" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1bq");
+
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expect(h.events.items[0].key.modifiers.alt);
+    try testing.expectEqual(@as(u21, 'q'), h.events.items[0].key.key.char);
+}
+
+test "escape prefixed sequences keep their payload" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    // ESC ESC [ A — Alt applied to a whole sequence.
+    try h.feed("\x1b\x1b[A");
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expect(h.events.items[0].key.key == .up);
+    try testing.expect(h.events.items[0].key.modifiers.alt);
+
+    // The payload bytes of a nested mouse report must not spill out as text.
+    try h.feed("\x1b\x1b[M\x20\x21\x21");
+    try testing.expectEqual(@as(usize, 2), h.events.items.len);
+    try testing.expect(h.events.items[1] == .mouse);
+}
+
+test "device attribute reply is swallowed instead of leaking as text" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b[?62;1;2;6;9c");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    // Split the same reply and confirm nothing leaks either way.
+    var split_h = Harness.init();
+    defer split_h.deinit();
+    try split_h.feed("\x1b[?62;1");
+    try split_h.feed(";2;6;9c");
+    try testing.expectEqual(@as(usize, 0), split_h.events.items.len);
+}
+
+test "cursor position report is swallowed" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b[24;80R");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+}
+
+test "OSC reply is swallowed including its payload" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    // An OSC 52 clipboard reply carries base64 that would otherwise arrive as
+    // a stream of key presses.
+    try h.feed("\x1b]52;c;aGVsbG8=\x07");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    try h.feed("\x1b]11;rgb:1e1e/1e1e/2e2e\x1b\\");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    // ... and still recognises the key typed right after it.
+    try h.feed("x");
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expectEqual(@as(u21, 'x'), h.events.items[0].key.key.char);
+}
+
+test "kitty graphics reply is swallowed" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b_Gi=31;OK\x1b\\");
+    try h.feed("a");
+
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expectEqual(@as(u21, 'a'), h.events.items[0].key.key.char);
+}
+
+test "bracketed paste split across reads arrives as one event" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b[200~hello ");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    try h.feed("world\x1b[20");
+    try testing.expectEqual(@as(usize, 0), h.events.items.len);
+
+    try h.feed("1~");
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expectEqualStrings("hello world", h.events.items[0].key.key.paste);
+}
+
+test "paste larger than the buffer streams out in chunks" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    var content = std.array_list.Managed(u8).init(testing.allocator);
+    defer content.deinit();
+    for (0..(InputParser.capacity * 3)) |i| {
+        try content.append(@intCast('a' + (i % 26)));
+    }
+
+    try h.feed("\x1b[200~");
+    var offset: usize = 0;
+    while (offset < content.items.len) {
+        const end = @min(offset + 512, content.items.len);
+        try h.feed(content.items[offset..end]);
+        offset = end;
+    }
+    try h.feed("\x1b[201~");
+
+    var joined = std.array_list.Managed(u8).init(testing.allocator);
+    defer joined.deinit();
+    for (h.events.items) |event| {
+        try testing.expect(event.key.key == .paste);
+        try joined.appendSlice(event.key.key.paste);
+    }
+
+    try testing.expect(h.events.items.len > 1);
+    try testing.expectEqualStrings(content.items, joined.items);
+
+    // The stream is usable again straight after the paste.
+    try h.feed("z");
+    try testing.expectEqual(@as(u21, 'z'), h.events.items[h.events.items.len - 1].key.key.char);
+}
+
+test "paste chunking never splits a codepoint" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    var content = std.array_list.Managed(u8).init(testing.allocator);
+    defer content.deinit();
+    while (content.items.len < InputParser.capacity * 2) {
+        try content.appendSlice("日本語テキスト");
+    }
+
+    try h.feed("\x1b[200~");
+    var offset: usize = 0;
+    while (offset < content.items.len) {
+        const end = @min(offset + 300, content.items.len);
+        try h.feed(content.items[offset..end]);
+        offset = end;
+    }
+    try h.feed("\x1b[201~");
+
+    var joined = std.array_list.Managed(u8).init(testing.allocator);
+    defer joined.deinit();
+    for (h.events.items) |event| {
+        try testing.expect(std.unicode.utf8ValidateSlice(event.key.key.paste));
+        try joined.appendSlice(event.key.key.paste);
+    }
+    try testing.expectEqualStrings(content.items, joined.items);
+}
+
+test "a sequence that never terminates cannot stall the stream" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    // A CSI whose parameter run is longer than the whole buffer: the parser
+    // must give up on it rather than block every later key press.
+    var garbage = std.array_list.Managed(u8).init(testing.allocator);
+    defer garbage.deinit();
+    try garbage.appendSlice("\x1b[");
+    try garbage.appendNTimes('1', InputParser.capacity * 2);
+
+    try h.feed(garbage.items);
+    try h.feed("k");
+
+    const last = h.events.items[h.events.items.len - 1];
+    try testing.expectEqual(@as(u21, 'k'), last.key.key.char);
+    try testing.expect(h.parser.pending().len < InputParser.capacity);
+}
+
+test "legacy X10 mouse report is decoded instead of leaking three characters" {
+    // ESC [ M, button 0, column 33, row 25 (each biased by 32).
+    const seq = "\x1b[M\x20\x41\x39";
+
+    for (1..seq.len) |split| {
+        var h = Harness.init();
+        defer h.deinit();
+
+        try h.feed(seq[0..split]);
+        try h.feed(seq[split..]);
+
+        try expectSingleMouse(h.events.items, .{
+            .x = 32,
+            .y = 24,
+            .button = .left,
+            .event_type = .press,
+        });
+    }
+}
+
+test "oversized parameters saturate instead of overflowing" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    // Parameter runs wider than a u16 used to abort the process on a debug
+    // build, so any terminal reply with a huge parameter took the app down.
+    try h.feed("\x1b[99999999999;99999999999R");
+    try h.feed("\x1b[<0;99999999;99999999M");
+    try h.feed("\x1b[99999999999u");
+    try h.feed("q");
+
+    const last = h.events.items[h.events.items.len - 1];
+    try testing.expectEqual(@as(u21, 'q'), last.key.key.char);
+}
+
+test "reset drops a partial sequence" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("\x1b[<64;1");
+    try testing.expect(h.parser.pending().len > 0);
+
+    h.parser.reset();
+    try testing.expectEqual(@as(usize, 0), h.parser.pending().len);
+
+    try h.feed("a");
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expectEqual(@as(u21, 'a'), h.events.items[0].key.key.char);
+}
+
+test "mixed keys and mouse reports keep their order" {
+    var h = Harness.init();
+    defer h.deinit();
+
+    try h.feed("a\x1b[<0;5;5M");
+    try h.feed("\x1b[Bb");
+
+    try testing.expectEqual(@as(usize, 4), h.events.items.len);
+    try testing.expectEqual(@as(u21, 'a'), h.events.items[0].key.key.char);
+    try testing.expect(h.events.items[1] == .mouse);
+    try testing.expect(h.events.items[2].key.key == .down);
+    try testing.expectEqual(@as(u21, 'b'), h.events.items[3].key.key.char);
+}
+
+test "escape timeout is configurable" {
+    var h = Harness.init();
+    defer h.deinit();
+    h.parser.escape_timeout_ns = 5 * ms;
+
+    try h.feed("\x1b");
+    try h.idle(6 * ms);
+
+    try testing.expectEqual(@as(usize, 1), h.events.items.len);
+    try testing.expect(h.events.items[0].key.key == .escape);
+}
+
+test "parseStream reports incomplete instead of guessing" {
+    try testing.expect(keyboard.parseStream("\x1b") == .incomplete);
+    try testing.expect(keyboard.parseStream("\x1b[") == .incomplete);
+    try testing.expect(keyboard.parseStream("\x1b[<64;65;4") == .incomplete);
+    try testing.expect(keyboard.parseStream("\x1bO") == .incomplete);
+    try testing.expect(keyboard.parseStream("\x1b]52;c;aGk=") == .incomplete);
+    try testing.expect(keyboard.parseStream("\xe2\x82") == .incomplete);
+
+    try testing.expect(keyboard.parseStream("\x1b[A") == .event);
+    try testing.expect(keyboard.parseStream("a") == .event);
+}
+
+test "parse still resolves truncated input for single-shot callers" {
+    // Unchanged behaviour: a caller handing over a complete buffer gets the
+    // bare Escape key for a sequence that was cut off.
+    const escape = keyboard.parse("\x1b");
+    try testing.expect(escape.result.key.key == .escape);
+    try testing.expectEqual(@as(usize, 1), escape.consumed);
+
+    const truncated = keyboard.parse("\x1b[");
+    try testing.expect(truncated.result.key.key == .escape);
+    try testing.expectEqual(@as(usize, 1), truncated.consumed);
+}
+
+test "parseAll drops complete sequences it has no event for" {
+    const allocator = testing.allocator;
+
+    const events = try keyboard.parseAll(allocator, "a\x1b[?62;1cb");
+    defer allocator.free(events);
+
+    try testing.expectEqual(@as(usize, 2), events.len);
+    try testing.expectEqual(@as(u21, 'a'), events[0].key.key.char);
+    try testing.expectEqual(@as(u21, 'b'), events[1].key.key.char);
+}


### PR DESCRIPTION
Fixes #123.

## The bug

A terminal read hands over whatever bytes were ready, so a single sequence is regularly split in two. `parse` had no way to express *"this is cut off, wait for more"*: when `parseCsi` returned null it fell through to consuming the `ESC` as an Escape key press, and the remaining bytes were re-read as individual characters.

During fast trackpad scrolling that turns SGR mouse reports into visible garbage (`[<64;65;42M`), and takes the app down when the leaked bytes land on a quit binding — exactly what @sessions-matthew reported.

## The fix

Sequences are now **framed structurally** (ECMA-48 param/intermediate/final bytes, OSC & DCS string terminators) *before* being interpreted. That separates two failure modes which were previously indistinguishable:

| | before | after |
|---|---|---|
| cut off by the read buffer | `ESC` consumed as Escape, rest leaks as text | `parseStream` → `.incomplete`, bytes retained until the rest arrives |
| complete but not a key press (DA reply, cursor position report, OSC 52 answer, Kitty graphics ack) | leaks its payload as text | consumed as a unit and dropped |

`InputParser` is the new stateful front end. It holds the tail of an unfinished sequence between reads, and because a lone `ESC` is byte-for-byte the start of every arrow key, it is held too and released as the Escape key after `escape_timeout_ms` (default 50 ms) of silence — the disambiguation vim and tmux use.

The issue's proposed patch used file-scope `var pending_buf` / `pending_len`. This avoids that: the buffer lives on the parser, which lives on the `Program`, so two programs (or two tests) cannot corrupt each other. It also can't deadlock — the original patch returned `consumed = 0` for *any* `parseCsi` failure, so a complete-but-unrecognised sequence (e.g. a `\x1b[?62;1;2c` device attribute reply) would sit in the pending buffer forever and stall all further input.

## Also fixed on the same path

- **`u16` overflow in CSI parameter accumulation** — `params[n] * 10 + digit` aborts the process on a debug build for any parameter with more than 5 digits. Found by the new fuzz-ish test; parameters now saturate. Same fix in `mouse.parseSgr`.
- **Multi-byte codepoints split across reads** decoded as mojibake; they now wait for their continuation bytes.
- **Pastes larger than one read** lost their opening marker and arrived as individual key presses. They now stream as `paste` events, split only on codepoint boundaries.
- **Legacy X10 mouse reports** (`CSI M` + three raw bytes — what a terminal sends when it ignores the SGR request) are decoded instead of spilling three characters.
- **Input is drained until the terminal runs dry** rather than one 256-byte read per frame, so a scroll burst no longer backs up across frames.

## API

Additive only; `parse` / `parseAll` keep their signatures and their behaviour for callers handing over a complete buffer.

- `zz.InputParser` — streaming parser (`feed`, `pending`, `reset`)
- `keyboard.parseStream` / `keyboard.parseFlush` — the two halves `parse` is now built from
- `mouse.parseX10`
- `Options.escape_timeout_ms` (default 50)

## Tests

New `tests/input_stream_tests.zig` (22 cases). The mouse and arrow-key tests re-run the same sequence split at **every** byte boundary, since the bug only shows up at specific offsets:

- SGR mouse report split at every boundary → exactly one event
- 20-report scroll burst chopped into 7-byte reads → 20 mouse events, zero key events
- lone ESC held, then released on timeout; ESC + later keystroke → Escape *then* the key
- DA reply / cursor position report / OSC 52 answer / Kitty graphics ack → swallowed, following keystroke still recognised
- paste split across three reads (marker straddling the boundary) → one event
- paste 3× the buffer size → chunks that reassemble byte-identically, no split codepoints
- a never-terminating sequence longer than the buffer → cannot stall the stream
- oversized parameters → no abort

`zig build test` and `zig build` both clean on 0.16.0.