### PR TITLE
feat: let init, update and view return error unions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -22,6 +22,32 @@ ZigZag uses the Elm Architecture (Model-Update-View):
 4. **update** - Handle messages and update state
 5. **view** - Render your model to a string
 
+### Fallible callbacks
+
+`init`, `update` and `view` may each return an error union. Rendering allocates
+on nearly every line, and without this each allocation needs its own fallback:
+
+```zig
+// Plain signature — every allocation needs a `catch`, and a failed one is
+// silently rendered as text.
+pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    const title = title_style.render(ctx.allocator, "Report") catch "Report";
+    const body = std.fmt.allocPrint(ctx.allocator, "{d} rows", .{self.rows}) catch "?";
+    return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ title, body }) catch "Error";
+}
+
+// Error union — the runtime propagates the failure out of `tick()`.
+pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+    const title = try title_style.render(ctx.allocator, "Report");
+    const body = try std.fmt.allocPrint(ctx.allocator, "{d} rows", .{self.rows});
+    return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ title, body });
+}
+```
+
+Both forms are supported; the runtime picks the right one at compile time, per
+function. `SubProgram` mirrors its child, so a fallible child model gives a
+`SubProgram` whose `view` is fallible too.
+
 ### Commands
 
 Commands let you perform side effects:

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -37,7 +37,9 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    // Returning an error union lets every allocation below use `try`, instead
+    // of each one needing its own `catch "..."` fallback.
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Title style
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
@@ -62,25 +64,25 @@ const Model = struct {
         box_style = box_style.paddingAll(1);
         box_style = box_style.alignH(.center);
 
-        const title = title_style.render(ctx.allocator, "Counter Demo") catch "Counter Demo";
-        const counter = std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count}) catch "?";
-        const styled_counter = counter_style.render(ctx.allocator, counter) catch counter;
+        const title = try title_style.render(ctx.allocator, "Counter Demo");
+        const counter = try std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count});
+        const styled_counter = try counter_style.render(ctx.allocator, counter);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\nCount: {s}",
             .{ title, styled_counter },
-        ) catch "Error";
+        );
 
-        const boxed = box_style.render(ctx.allocator, content) catch content;
+        const boxed = try box_style.render(ctx.allocator, content);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Up/+ Increment  Down/- Decrement  r Reset  q Quit",
-        ) catch "";
+        );
 
         // Get max width for centering
         const box_width = zz.measure.maxLineWidth(boxed);
@@ -88,14 +90,14 @@ const Model = struct {
         const max_width = @max(box_width, help_width);
 
         // Center elements
-        const centered_box = zz.place.place(ctx.allocator, max_width, zz.measure.height(boxed), .center, .top, boxed) catch boxed;
-        const centered_help = zz.place.place(ctx.allocator, max_width, 1, .center, .top, help) catch help;
+        const centered_box = try zz.place.place(ctx.allocator, max_width, zz.measure.height(boxed), .center, .top, boxed);
+        const centered_help = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, help);
 
-        const final_content = std.fmt.allocPrint(
+        const final_content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}",
             .{ centered_box, centered_help },
-        ) catch "Error";
+        );
 
         // Center in terminal
         return zz.place.place(
@@ -105,7 +107,7 @@ const Model = struct {
             .center,
             .middle,
             final_content,
-        ) catch final_content;
+        );
     }
 };
 

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -199,16 +199,19 @@ const Model = struct {
         };
     }
 
-    fn capsString(self: *const Model, allocator: std.mem.Allocator) []const u8 {
+    fn capsString(self: *const Model, allocator: std.mem.Allocator) ![]const u8 {
         return std.fmt.allocPrint(allocator, "kitty={s} iterm2={s} sixel={s}", .{
             if (self.caps.kitty_graphics) "yes" else "no",
             if (self.caps.iterm2_inline_image) "yes" else "no",
             if (self.caps.sixel) "yes" else "no",
-        }) catch "?";
+        });
     }
 
-    /// Render the view
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    /// Render the view.
+    ///
+    /// The error union means every allocation here can just be `try`ed; a view
+    /// returning plain `[]const u8` has to end each one in `catch "..."`.
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
@@ -227,25 +230,25 @@ const Model = struct {
         image_hint_style = image_hint_style.fg(zz.Color.gray(16));
         image_hint_style = image_hint_style.inline_style(true);
 
-        const title = title_style.render(ctx.allocator, "Hello, ZigZag!") catch "Hello, ZigZag!";
-        const subtitle = subtitle_style.render(ctx.allocator, "A TUI library for Zig") catch "";
-        const hint = hint_style.render(ctx.allocator, "Press 'q' to quit") catch "";
+        const title = try title_style.render(ctx.allocator, "Hello, ZigZag!");
+        const subtitle = try subtitle_style.render(ctx.allocator, "A TUI library for Zig");
+        const hint = try hint_style.render(ctx.allocator, "Press 'q' to quit");
 
         const image_hint_text = if (self.image_supported)
             "'i' draw  'c' cache  'z' z-index  'd' delete  'p' protocol"
         else
             "Inline image protocol not detected in this terminal";
-        const image_hint = image_hint_style.render(ctx.allocator, image_hint_text) catch image_hint_text;
+        const image_hint = try image_hint_style.render(ctx.allocator, image_hint_text);
 
-        const caps_text = self.capsString(ctx.allocator);
-        const caps_line = image_hint_style.render(ctx.allocator, caps_text) catch caps_text;
+        const caps_text = try self.capsString(ctx.allocator);
+        const caps_line = try image_hint_style.render(ctx.allocator, caps_text);
 
-        const protocol_text = std.fmt.allocPrint(ctx.allocator, "protocol: {s}  z-index: {s}  cached: {s}", .{
+        const protocol_text = try std.fmt.allocPrint(ctx.allocator, "protocol: {s}  z-index: {s}  cached: {s}", .{
             self.protocolName(),
             if (self.image_behind_text) "behind" else "normal",
             if (self.image_cached) "yes" else "no",
-        }) catch "";
-        const protocol_line = image_hint_style.render(ctx.allocator, protocol_text) catch protocol_text;
+        });
+        const protocol_line = try image_hint_style.render(ctx.allocator, protocol_text);
 
         const status_text = if (self.image_attempted and self.image_supported)
             "Image command sent (check assets/cat.png path)"
@@ -253,7 +256,7 @@ const Model = struct {
             "Image skipped: unsupported terminal protocol"
         else
             "";
-        const status = hint_style.render(ctx.allocator, status_text) catch status_text;
+        const status = try hint_style.render(ctx.allocator, status_text);
 
         // Get max width for centering
         const max_width = @max(
@@ -268,19 +271,19 @@ const Model = struct {
         );
 
         // Center each element
-        const centered_title = zz.place.place(ctx.allocator, max_width, 1, .center, .top, title) catch title;
-        const centered_subtitle = zz.place.place(ctx.allocator, max_width, 1, .center, .top, subtitle) catch subtitle;
-        const centered_hint = zz.place.place(ctx.allocator, max_width, 1, .center, .top, hint) catch hint;
-        const centered_image_hint = zz.place.place(ctx.allocator, max_width, 1, .center, .top, image_hint) catch image_hint;
-        const centered_caps = zz.place.place(ctx.allocator, max_width, 1, .center, .top, caps_line) catch caps_line;
-        const centered_protocol = zz.place.place(ctx.allocator, max_width, 1, .center, .top, protocol_line) catch protocol_line;
-        const centered_status = zz.place.place(ctx.allocator, max_width, 1, .center, .top, status) catch status;
+        const centered_title = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, title);
+        const centered_subtitle = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, subtitle);
+        const centered_hint = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, hint);
+        const centered_image_hint = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, image_hint);
+        const centered_caps = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, caps_line);
+        const centered_protocol = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, protocol_line);
+        const centered_status = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, status);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}\n{s}\n{s}\n{s}\n{s}",
             .{ centered_title, centered_subtitle, centered_hint, centered_image_hint, centered_caps, centered_protocol, centered_status },
-        ) catch "Error rendering view";
+        );
 
         if (self.image_supported and self.image_visible) {
             const image_size = if (self.image_size_cells > 0) self.image_size_cells else self.pickImageSize(ctx);
@@ -288,28 +291,28 @@ const Model = struct {
             const container_width = @max(max_width, @as(usize, image_size));
             const text_height = zz.measure.height(content);
 
-            const centered_text = zz.place.place(
+            const centered_text = try zz.place.place(
                 ctx.allocator,
                 container_width,
                 text_height,
                 .center,
                 .top,
                 content,
-            ) catch content;
+            );
 
-            const image_slot = zz.place.place(
+            const image_slot = try zz.place.place(
                 ctx.allocator,
                 container_width,
                 slot_height,
                 .left,
                 .top,
                 "",
-            ) catch "";
+            );
 
-            const container = zz.joinVertical(
+            const container = try zz.joinVertical(
                 ctx.allocator,
                 &.{ centered_text, image_slot },
-            ) catch centered_text;
+            );
 
             return zz.place.place(
                 ctx.allocator,
@@ -318,7 +321,7 @@ const Model = struct {
                 .center,
                 .middle,
                 container,
-            ) catch container;
+            );
         }
 
         return zz.place.place(
@@ -328,7 +331,7 @@ const Model = struct {
             .center,
             .middle,
             content,
-        ) catch content;
+        );
     }
 };
 

--- a/src/core/model.zig
+++ b/src/core/model.zig
@@ -1,0 +1,84 @@
+//! The Model contract, and the comptime helpers that let it be flexible.
+//!
+//! A model supplies three functions:
+//!
+//!     pub fn init(self: *Model, ctx: *Context) Cmd(Msg)
+//!     pub fn update(self: *Model, msg: Msg, ctx: *Context) Cmd(Msg)
+//!     pub fn view(self: *const Model, ctx: *const Context) []const u8
+//!
+//! Each of them may return an error union instead (`!Cmd(Msg)`, `![]const u8`).
+//! Views allocate on nearly every line, so without that every one of them ends
+//! up littered with `catch "Error"`, which turns an allocation failure into a
+//! rendering artefact.
+
+const std = @import("std");
+
+/// Whether a function returns an error union. Accepts a function type or a
+/// pointer to one.
+pub fn returnsError(comptime Func: type) bool {
+    const return_type = returnType(Func) orelse return false;
+    return @typeInfo(return_type) == .error_union;
+}
+
+/// The result type a wrapper should use to mirror `Func`'s fallibility:
+/// `Payload` when `Func` cannot fail, `E!Payload` when it can.
+pub fn Result(comptime Func: type, comptime Payload: type) type {
+    const return_type = returnType(Func) orelse return Payload;
+    return switch (@typeInfo(return_type)) {
+        .error_union => |eu| eu.error_set!Payload,
+        else => Payload,
+    };
+}
+
+fn returnType(comptime Func: type) ?type {
+    return switch (@typeInfo(Func)) {
+        .@"fn" => |f| f.return_type,
+        .pointer => |p| @typeInfo(p.child).@"fn".return_type,
+        else => null,
+    };
+}
+
+/// Fail at compile time with a readable message when a type is missing part of
+/// the Model contract.
+pub fn validate(comptime Model: type, comptime role: []const u8) void {
+    comptime {
+        for ([_][]const u8{ "Msg", "init", "update", "view" }) |name| {
+            if (!@hasDecl(Model, name)) {
+                @compileError(role ++ " '" ++ @typeName(Model) ++ "' is missing '" ++
+                    name ++ "'. A model needs a 'Msg' type plus 'init', 'update' and 'view'.");
+            }
+        }
+    }
+}
+
+test "returnsError distinguishes fallible signatures" {
+    const S = struct {
+        fn plain() u8 {
+            return 0;
+        }
+        fn fallible() !u8 {
+            return 0;
+        }
+    };
+
+    try std.testing.expect(!returnsError(@TypeOf(S.plain)));
+    try std.testing.expect(returnsError(@TypeOf(S.fallible)));
+    try std.testing.expect(returnsError(@TypeOf(&S.fallible)));
+}
+
+test "Result mirrors fallibility" {
+    const S = struct {
+        fn plain() u8 {
+            return 0;
+        }
+        fn fallible() error{Boom}!u8 {
+            return 0;
+        }
+    };
+
+    try std.testing.expectEqual([]const u8, Result(@TypeOf(S.plain), []const u8));
+    try std.testing.expectEqual(
+        error{Boom}![]const u8,
+        Result(@TypeOf(S.fallible), []const u8),
+    );
+}

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -14,6 +14,7 @@ const Logger = @import("log.zig").Logger;
 const unicode = @import("../unicode.zig");
 const Environment = @import("environment.zig").Environment;
 const frame = @import("../terminal/frame.zig");
+const model_contract = @import("model.zig");
 
 pub const Cmd = command.Cmd;
 pub const Msg = message;
@@ -34,21 +35,13 @@ const max_reads_per_tick = 8;
 
 /// Program runtime that manages the application lifecycle
 pub fn Program(comptime Model: type) type {
-    // Ensure Model has required declarations
-    comptime {
-        if (!@hasDecl(Model, "Msg")) {
-            @compileError("Model must have a 'Msg' type declaration");
-        }
-        if (!@hasDecl(Model, "init")) {
-            @compileError("Model must have an 'init' function");
-        }
-        if (!@hasDecl(Model, "update")) {
-            @compileError("Model must have an 'update' function");
-        }
-        if (!@hasDecl(Model, "view")) {
-            @compileError("Model must have a 'view' function");
-        }
-    }
+    model_contract.validate(Model, "Model");
+
+    // `init`, `update` and `view` may each return an error union; the runtime
+    // propagates it instead of the model having to swallow it.
+    const init_fallible = model_contract.returnsError(@TypeOf(Model.init));
+    const update_fallible = model_contract.returnsError(@TypeOf(Model.update));
+    const view_fallible = model_contract.returnsError(@TypeOf(Model.view));
 
     const UserMsg = Model.Msg;
     const UserCmd = Cmd(UserMsg);
@@ -240,7 +233,10 @@ pub fn Program(comptime Model: type) type {
             self.resetFrameAllocator();
 
             // Initialize the model
-            const init_cmd = self.model.init(&self.context);
+            const init_cmd = if (comptime init_fallible)
+                try self.model.init(&self.context)
+            else
+                self.model.init(&self.context);
             try self.processCommand(init_cmd);
 
             self.running = true;
@@ -275,7 +271,7 @@ pub fn Program(comptime Model: type) type {
 
                 // Only send window_size message if the user model supports it
                 if (@hasField(UserMsg, "window_size")) {
-                    const cmd = self.dispatchToModel(.{ .window_size = .{
+                    const cmd = try self.dispatchToModel(.{ .window_size = .{
                         .width = size.cols,
                         .height = size.rows,
                     } });
@@ -297,7 +293,7 @@ pub fn Program(comptime Model: type) type {
                             .timestamp = @intCast(tick_start),
                             .delta = tick_delta,
                         } };
-                        const cmd = self.dispatchToModel(user_msg);
+                        const cmd = try self.dispatchToModel(user_msg);
                         try self.processCommand(cmd);
                     }
                 }
@@ -314,7 +310,7 @@ pub fn Program(comptime Model: type) type {
                             .timestamp = @intCast(tick_start),
                             .delta = tick_delta,
                         } };
-                        const cmd = self.dispatchToModel(user_msg);
+                        const cmd = try self.dispatchToModel(user_msg);
                         try self.processCommand(cmd);
                     }
                 }
@@ -375,8 +371,8 @@ pub fn Program(comptime Model: type) type {
                 );
                 for (events) |event| {
                     const user_cmd = switch (event) {
-                        .key => |k| self.processKeyEvent(k),
-                        .mouse => |m| self.processMouseEvent(m),
+                        .key => |k| try self.processKeyEvent(k),
+                        .mouse => |m| try self.processMouseEvent(m),
                         .none => null,
                     };
                     if (user_cmd) |cmd| {
@@ -390,17 +386,19 @@ pub fn Program(comptime Model: type) type {
         }
 
         /// Dispatch a message to the model, applying the filter if set
-        fn dispatchToModel(self: *Self, user_msg: UserMsg) UserCmd {
-            if (self.filter) |f| {
-                if (f(user_msg)) |filtered_msg| {
-                    return self.model.update(filtered_msg, &self.context);
-                }
-                return .none;
-            }
-            return self.model.update(user_msg, &self.context);
+        fn dispatchToModel(self: *Self, user_msg: UserMsg) !UserCmd {
+            const delivered = if (self.filter) |f|
+                f(user_msg) orelse return .none
+            else
+                user_msg;
+
+            return if (comptime update_fallible)
+                try self.model.update(delivered, &self.context)
+            else
+                self.model.update(delivered, &self.context);
         }
 
-        fn processKeyEvent(self: *Self, key: keyboard.KeyEvent) ?UserCmd {
+        fn processKeyEvent(self: *Self, key: keyboard.KeyEvent) !?UserCmd {
             // Check for Ctrl+C to quit
             if (key.modifiers.ctrl) {
                 switch (key.key) {
@@ -423,12 +421,12 @@ pub fn Program(comptime Model: type) type {
             if (key.key == .paste) {
                 if (@hasField(UserMsg, "paste")) {
                     const user_msg = UserMsg{ .paste = key.key.paste };
-                    return self.dispatchToModel(user_msg);
+                    return try self.dispatchToModel(user_msg);
                 }
                 // If model doesn't handle paste, send as individual key events
                 if (@hasField(UserMsg, "key")) {
                     const user_msg = UserMsg{ .key = key };
-                    return self.dispatchToModel(user_msg);
+                    return try self.dispatchToModel(user_msg);
                 }
                 return null;
             }
@@ -436,7 +434,7 @@ pub fn Program(comptime Model: type) type {
             // Convert to user message if Model.Msg has a key variant
             if (@hasField(UserMsg, "key")) {
                 const user_msg = UserMsg{ .key = key };
-                return self.dispatchToModel(user_msg);
+                return try self.dispatchToModel(user_msg);
             }
 
             return null;
@@ -452,10 +450,10 @@ pub fn Program(comptime Model: type) type {
             return detected;
         }
 
-        fn processMouseEvent(self: *Self, mouse_event: keyboard.MouseEvent) ?UserCmd {
+        fn processMouseEvent(self: *Self, mouse_event: keyboard.MouseEvent) !?UserCmd {
             if (@hasField(UserMsg, "mouse")) {
                 const user_msg = UserMsg{ .mouse = mouse_event };
-                return self.dispatchToModel(user_msg);
+                return try self.dispatchToModel(user_msg);
             }
 
             return null;
@@ -512,8 +510,9 @@ pub fn Program(comptime Model: type) type {
 
             // Dispatch resumed message if model supports it
             if (@hasField(UserMsg, "resumed")) {
-                const cmd = self.dispatchToModel(.{ .resumed = {} });
-                self.processCommand(cmd) catch {};
+                if (self.dispatchToModel(.{ .resumed = {} })) |cmd| {
+                    self.processCommand(cmd) catch {};
+                } else |_| {}
             }
         }
 
@@ -542,12 +541,12 @@ pub fn Program(comptime Model: type) type {
                     }
                 },
                 .msg => |m| {
-                    const new_cmd = self.dispatchToModel(m);
+                    const new_cmd = try self.dispatchToModel(m);
                     try self.processCommand(new_cmd);
                 },
                 .perform => |func| {
                     if (func()) |m| {
-                        const new_cmd = self.dispatchToModel(m);
+                        const new_cmd = try self.dispatchToModel(m);
                         try self.processCommand(new_cmd);
                     }
                 },
@@ -876,7 +875,10 @@ pub fn Program(comptime Model: type) type {
         }
 
         fn render(self: *Self) !void {
-            const view_output = self.model.view(&self.context);
+            const view_output = if (comptime view_fallible)
+                try self.model.view(&self.context)
+            else
+                self.model.view(&self.context);
 
             const wrote = try self.renderer.render(
                 self.terminal.?.writer(),
@@ -895,7 +897,7 @@ pub fn Program(comptime Model: type) type {
 
         /// Send a message to the model
         pub fn send(self: *Self, m: UserMsg) !void {
-            const cmd = self.dispatchToModel(m);
+            const cmd = try self.dispatchToModel(m);
             try self.processCommand(cmd);
         }
 

--- a/src/core/sub_program.zig
+++ b/src/core/sub_program.zig
@@ -4,23 +4,26 @@
 const std = @import("std");
 const Context = @import("context.zig").Context;
 const command = @import("command.zig");
+const model_contract = @import("model.zig");
 
 /// A wrapper that embeds a child Model inside a parent, with message mapping.
 ///
 /// - `ChildModel` must have `Msg`, `init`, `update`, `view` like a top-level model.
 /// - `ParentMsg` is the parent's message type.
 /// - The child's `.quit` command is converted to an optional parent message via `quit_msg`.
+///
+/// Fallibility is mirrored: a child whose `view` returns `![]const u8` gives a
+/// `SubProgram` whose `view` does too, so the parent can `try` it.
 pub fn SubProgram(comptime ChildModel: type, comptime ParentMsg: type) type {
-    comptime {
-        if (!@hasDecl(ChildModel, "Msg")) @compileError("ChildModel must have a 'Msg' type");
-        if (!@hasDecl(ChildModel, "init")) @compileError("ChildModel must have an 'init' function");
-        if (!@hasDecl(ChildModel, "update")) @compileError("ChildModel must have an 'update' function");
-        if (!@hasDecl(ChildModel, "view")) @compileError("ChildModel must have a 'view' function");
-    }
+    model_contract.validate(ChildModel, "ChildModel");
 
     const ChildMsg = ChildModel.Msg;
     const ChildCmd = command.Cmd(ChildMsg);
     const ParentCmd = command.Cmd(ParentMsg);
+
+    const InitResult = model_contract.Result(@TypeOf(ChildModel.init), ParentCmd);
+    const UpdateResult = model_contract.Result(@TypeOf(ChildModel.update), ParentCmd);
+    const ViewResult = model_contract.Result(@TypeOf(ChildModel.view), []const u8);
 
     return struct {
         model: ChildModel = undefined,
@@ -31,21 +34,27 @@ pub fn SubProgram(comptime ChildModel: type, comptime ParentMsg: type) type {
         const Self = @This();
 
         /// Initialize the child model.
-        pub fn init(self: *Self, ctx: *Context) ParentCmd {
-            const child_cmd = self.model.init(ctx);
+        pub fn init(self: *Self, ctx: *Context) InitResult {
+            const child_cmd = if (comptime model_contract.returnsError(@TypeOf(ChildModel.init)))
+                try self.model.init(ctx)
+            else
+                self.model.init(ctx);
             self.initialized = true;
             return self.translateCmd(child_cmd);
         }
 
         /// Forward a child message to the child's update, returning a parent command.
-        pub fn update(self: *Self, child_msg: ChildMsg, ctx: *Context) ParentCmd {
+        pub fn update(self: *Self, child_msg: ChildMsg, ctx: *Context) UpdateResult {
             if (!self.initialized) return .none;
-            const child_cmd = self.model.update(child_msg, ctx);
+            const child_cmd = if (comptime model_contract.returnsError(@TypeOf(ChildModel.update)))
+                try self.model.update(child_msg, ctx)
+            else
+                self.model.update(child_msg, ctx);
             return self.translateCmd(child_cmd);
         }
 
         /// Render the child model.
-        pub fn view(self: *const Self, ctx: *const Context) []const u8 {
+        pub fn view(self: *const Self, ctx: *const Context) ViewResult {
             if (!self.initialized) return "";
             return self.model.view(ctx);
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -33,8 +33,10 @@
 //!         return .none;
 //!     }
 //!
-//!     pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-//!         return std.fmt.allocPrint(ctx.allocator, "Count: {d}\n\nPress q to quit", .{self.count}) catch "Error";
+//!     // `init`, `update` and `view` may return an error union, which spares
+//!     // every allocation in a view its own `catch "Error"` fallback.
+//!     pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+//!         return std.fmt.allocPrint(ctx.allocator, "Count: {d}\n\nPress q to quit", .{self.count});
 //!     }
 //! };
 //!
@@ -52,6 +54,7 @@ pub const program = @import("core/program.zig");
 pub const Program = program.Program;
 pub const Cmd = program.Cmd;
 pub const command = @import("core/command.zig");
+pub const model = @import("core/model.zig");
 pub const Environment = @import("core/environment.zig").Environment;
 pub const async_task = @import("core/async_task.zig");
 pub const AsyncRunner = async_task.AsyncRunner;

--- a/tests/program_tests.zig
+++ b/tests/program_tests.zig
@@ -20,6 +20,49 @@ const DummyModel = struct {
     }
 };
 
+/// The same model written with fallible callbacks: no `catch "Error"` needed.
+const FallibleModel = struct {
+    count: i32 = 0,
+
+    pub const Msg = union(enum) {
+        key: zz.KeyEvent,
+    };
+
+    pub fn init(self: *FallibleModel, _: *zz.Context) !zz.Cmd(Msg) {
+        self.* = .{};
+        return .none;
+    }
+
+    pub fn update(self: *FallibleModel, _: Msg, _: *zz.Context) !zz.Cmd(Msg) {
+        self.count += 1;
+        return .none;
+    }
+
+    pub fn view(self: *const FallibleModel, ctx: *const zz.Context) ![]const u8 {
+        return std.fmt.allocPrint(ctx.allocator, "Count: {d}", .{self.count});
+    }
+};
+
+test "Program accepts models whose callbacks return error unions" {
+    // Forces the runtime's tick/render/dispatch paths to be analysed against a
+    // fallible model, which is where the `try` has to line up.
+    testing.refAllDecls(zz.Program(FallibleModel));
+    testing.refAllDecls(zz.Program(DummyModel));
+
+    try testing.expect(zz.model.returnsError(@TypeOf(FallibleModel.view)));
+    try testing.expect(!zz.model.returnsError(@TypeOf(DummyModel.view)));
+}
+
+test "SubProgram mirrors the fallibility of its child" {
+    const Fallible = zz.SubProgram(FallibleModel, FallibleModel.Msg);
+    const Plain = zz.SubProgram(DummyModel, DummyModel.Msg);
+    testing.refAllDecls(Fallible);
+    testing.refAllDecls(Plain);
+
+    try testing.expect(zz.model.returnsError(@TypeOf(Fallible.view)));
+    try testing.expect(!zz.model.returnsError(@TypeOf(Plain.view)));
+}
+
 test "Program.init context allocator is stable before start and can be rebound to arena" {
     var env_map: std.process.Environ.Map = .init(testing.allocator);
     defer env_map.deinit();


### PR DESCRIPTION
Not tied to an issue — this came out of reviewing the codebase for things that would simplify the library.

## The problem

`view` returns `[]const u8`, so it cannot fail. Rendering allocates on nearly every line, which means every allocation needs its own fallback. The examples currently carry **245** of them:

```
101  catch "";
 38  catch "Error";
 14  catch "error";
 13  catch "?";
 ...
```

The quick-start snippet in `src/root.zig` taught the pattern too. Each one silently turns an allocation failure into a rendering artefact that is indistinguishable from real output — `"?"` where a number should be, a title that quietly loses its styling.

## The change

`init`, `update` and `view` may now each return `!T` instead of `T`. The runtime detects that per function at compile time and propagates the error out of `tick()`, where the caller already handles failure.

```zig
// before
pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
    const title = title_style.render(ctx.allocator, "Report") catch "Report";
    const body = std.fmt.allocPrint(ctx.allocator, "{d} rows", .{self.rows}) catch "?";
    return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ title, body }) catch "Error";
}

// after
pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
    const title = try title_style.render(ctx.allocator, "Report");
    const body = try std.fmt.allocPrint(ctx.allocator, "{d} rows", .{self.rows});
    return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ title, body });
}
```

**Fully backwards compatible** — both forms compile, mixed freely (a fallible `view` alongside a plain `update` is fine). Nothing existing has to change.

## Also

`src/core/model.zig` collects the Model contract in one place: the `@hasDecl` checks that were duplicated between `Program` and `SubProgram` (now with a message naming the type and the missing declaration), plus the two comptime helpers.

`SubProgram` mirrors its child's fallibility, so a fallible child model gives a `SubProgram` whose `view` is fallible too — otherwise composing one would be a compile error with no way out.

## Tests

`refAllDecls` on `Program(FallibleModel)` and `Program(DummyModel)` forces both instantiations to be fully analysed, so a `try` that does not line up is a build failure rather than something that only shows up in a user's app. Verified the test actually bites by removing a `try` and watching it fail. Same for `SubProgram` in both shapes, plus unit tests for the comptime helpers.

`counter` and `hello_world` are converted as worked examples. The remaining 42 still compile unchanged and can move over gradually.

`zig build test` and `zig build` clean on 0.16.0.