### PR TITLE
chore: check formatting in CI, and stop pacing failures being UB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ env:
   ZIG_VERSION: "0.16.0"
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+      - run: zig fmt --check src tests examples build.zig
+
   build:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ coverage/
 # OS files
 Thumbs.db
 desktop.ini
+# macOS writes an AppleDouble sidecar next to every file on a filesystem that
+# cannot hold extended attributes (exFAT, NTFS, most network shares). They are
+# metadata for a file that is already tracked, and they turn up in their
+# thousands.
+._*
 
 # Temporary files
 *.tmp

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -66,7 +66,8 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
                 title_s.render(alloc, "Calendar Demo") catch "Calendar",

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -23,16 +23,16 @@ const Model = struct {
     };
 
     const rows = [_][]const []const u8{
-        &.{ "01", "Alice",   "Platform", "Berlin",     "Engineer",       "5y",  "4.8", "$120k" },
-        &.{ "02", "Bob",     "Growth",   "Lisbon",     "PM",             "3y",  "4.1", "$110k" },
-        &.{ "03", "Carol",   "Platform", "Tokyo",      "Staff Eng",      "9y",  "4.9", "$180k" },
-        &.{ "04", "Dan",     "Infra",    "Berlin",     "SRE",            "2y",  "4.3", "$130k" },
-        &.{ "05", "Eve",     "Growth",   "Lisbon",     "Designer",       "1y",  "4.5", "$95k"  },
-        &.{ "06", "Frank",   "Infra",    "Singapore",  "Eng Manager",    "7y",  "4.6", "$160k" },
-        &.{ "07", "Grace",   "Platform", "Berlin",     "Engineer",       "4y",  "4.7", "$125k" },
-        &.{ "08", "Heidi",   "Sec",      "Tel Aviv",   "Security Eng",   "6y",  "4.4", "$140k" },
-        &.{ "09", "Ivan",    "Growth",   "Lisbon",     "Engineer",       "2y",  "4.0", "$105k" },
-        &.{ "10", "Judy",    "Platform", "Tokyo",      "Engineer",       "3y",  "4.2", "$118k" },
+        &.{ "01", "Alice", "Platform", "Berlin", "Engineer", "5y", "4.8", "$120k" },
+        &.{ "02", "Bob", "Growth", "Lisbon", "PM", "3y", "4.1", "$110k" },
+        &.{ "03", "Carol", "Platform", "Tokyo", "Staff Eng", "9y", "4.9", "$180k" },
+        &.{ "04", "Dan", "Infra", "Berlin", "SRE", "2y", "4.3", "$130k" },
+        &.{ "05", "Eve", "Growth", "Lisbon", "Designer", "1y", "4.5", "$95k" },
+        &.{ "06", "Frank", "Infra", "Singapore", "Eng Manager", "7y", "4.6", "$160k" },
+        &.{ "07", "Grace", "Platform", "Berlin", "Engineer", "4y", "4.7", "$125k" },
+        &.{ "08", "Heidi", "Sec", "Tel Aviv", "Security Eng", "6y", "4.4", "$140k" },
+        &.{ "09", "Ivan", "Growth", "Lisbon", "Engineer", "2y", "4.0", "$105k" },
+        &.{ "10", "Judy", "Platform", "Tokyo", "Engineer", "3y", "4.2", "$118k" },
     };
 
     pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -90,7 +90,8 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
                 title,

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -59,7 +59,8 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}",
             .{
                 title_s.render(alloc, "Sortable Table Demo") catch "",

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -117,7 +117,8 @@ const Model = struct {
 
         const active_label = if (self.active == 0) "A" else "B";
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\nActive: {s}\n\n{s}\n\n{s}",
             .{
                 title_s.render(alloc, "Sub-Program Demo") catch "Sub-Program",

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -82,7 +82,8 @@ const Model = struct {
         label_style = label_style.fg(zz.Color.gray(12));
         label_style = label_style.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s} visible (default):\n{s}\n\n{s} hidden (clip):\n{s}\n\n{s} ellipsis:\n{s}\n\n{s} word_wrap:\n{s}\n\n{s} char_wrap:\n{s}\n\nPress q to quit",
             .{
                 title,

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -54,7 +54,8 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc,
+        const content = std.fmt.allocPrint(
+            alloc,
             "{s}\n\n{s}\n\n{s}",
             .{
                 title_s.render(alloc, std.fmt.allocPrint(alloc, "Virtual List - {d} items", .{TOTAL_ITEMS}) catch "Virtual List") catch "Virtual List",

--- a/src/core/program.zig
+++ b/src/core/program.zig
@@ -344,7 +344,10 @@ pub fn Program(comptime Model: type) type {
                         .raw = .{ .nanoseconds = @intCast(deadline_offset_ns) },
                         .clock = .boot,
                     });
-                    deadline.wait(self.io) catch unreachable;
+                    // A wait that fails (a cancelled or interrupted sleep)
+                    // just means this frame is not paced; `unreachable` here
+                    // would be undefined behaviour in a release build.
+                    deadline.wait(self.io) catch {};
                 }
             }
         }
@@ -812,11 +815,6 @@ pub fn Program(comptime Model: type) type {
             const ns = dur.raw.nanoseconds;
             if (ns <= 0) return 0;
             return @intCast(ns);
-        }
-
-        fn sleepNs(io: std.Io, nanoseconds: u64) void {
-            if (nanoseconds == 0) return;
-            std.Io.sleep(io, .fromNanoseconds(nanoseconds), .boot) catch unreachable;
         }
 
         fn resetFrameAllocator(self: *Self) void {

--- a/tests/unicode_tests.zig
+++ b/tests/unicode_tests.zig
@@ -20,7 +20,7 @@ test "charWidth: emoji are wide" {
     defer zz.unicode.setWidthStrategy(.legacy_wcwidth);
     try testing.expectEqual(@as(usize, 2), zz.unicode.charWidth(0x1F600)); // grinning face
     try testing.expectEqual(@as(usize, 2), zz.unicode.charWidth(0x1F680)); // rocket
-    try testing.expectEqual(@as(usize, 2), zz.unicode.charWidth(0x2615));  // hot beverage
+    try testing.expectEqual(@as(usize, 2), zz.unicode.charWidth(0x2615)); // hot beverage
 }
 
 test "charWidth: combining marks are zero-width" {


### PR DESCRIPTION
Small cleanups from the codebase review.

## `zig fmt` in CI

Formatting was never enforced, and eight files had drifted (`tests/unicode_tests.zig` and seven examples). CI now runs `zig fmt --check src tests examples build.zig`, and those files are formatted — the whole diff outside the workflow is 52 lines of whitespace.

## `catch unreachable` on the frame-pacing wait

```zig
deadline.wait(self.io) catch unreachable;
```

A wait can fail — a cancelled or interrupted sleep. `unreachable` on that path is undefined behaviour in a release build, and the only consequence of the failure is that one frame goes unpaced. It now continues instead.

## Dead code

`sleepNs` had no callers.

`zig build test` and `zig build` clean on 0.16.0.