### PR TITLE
fix: don't count string sequence payloads as visible width

### DIFF
--- a/src/layout/measure.zig
+++ b/src/layout/measure.zig
@@ -32,10 +32,15 @@ pub fn width(str: []const u8) usize {
                     in_escape = false;
                     escape_bracket = false;
                 }
-            } else if (c == ']') {
-                // OSC sequence - skip until BEL or ST
+            } else if (c == ']' or c == 'P' or c == '_' or c == '^' or c == 'X') {
+                // A string sequence: OSC, DCS, APC, PM or SOS. The payload is
+                // not text on screen — a Kitty graphics command (APC) or a tmux
+                // passthrough (DCS) would otherwise be counted character by
+                // character. Runs until ST, or BEL for OSC.
+                const bel_terminates = c == ']';
                 i += 1;
-                while (i < str.len and str[i] != 0x07) {
+                while (i < str.len) {
+                    if (bel_terminates and str[i] == 0x07) break;
                     if (str[i] == 0x1b and i + 1 < str.len and str[i + 1] == '\\') {
                         i += 1;
                         break;

--- a/tests/layout_tests.zig
+++ b/tests/layout_tests.zig
@@ -21,6 +21,34 @@ test "measure.width - ANSI sequences excluded" {
     try testing.expectEqual(@as(usize, 5), zz.width("\x1b[1;32mhello\x1b[0m"));
 }
 
+test "measure.width - string sequences carry no width" {
+    // OSC, terminated by BEL and by ST.
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1b]8;;https://example.com\x07hello"));
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1b]8;;https://example.com\x1b\\hello"));
+
+    // A whole hyperlink, opened and closed.
+    try testing.expectEqual(
+        @as(usize, 5),
+        zz.width("\x1b]8;;https://example.com\x07hello\x1b]8;;\x07"),
+    );
+
+    // DCS — how tmux passthrough and terminal replies are wrapped.
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1bPtmux;\x1b\\hello"));
+
+    // APC — the Kitty graphics protocol. Its payload is base64, which used to
+    // be measured character by character and blow the line width apart.
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1b_Gf=100,a=T;iVBORw0K\x1b\\hello"));
+
+    // PM and SOS.
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1b^private\x1b\\hello"));
+    try testing.expectEqual(@as(usize, 5), zz.width("\x1bXstring\x1b\\hello"));
+}
+
+test "measure.maxLineWidth - string sequences carry no width" {
+    const framed = "\x1b_Gf=100,a=T;iVBORw0KGgoAAAANSUhEUg\x1b\\short\nlonger line";
+    try testing.expectEqual(@as(usize, 11), zz.measure.maxLineWidth(framed));
+}
+
 test "measure.height - simple" {
     try testing.expectEqual(@as(usize, 1), zz.height("hello"));
     try testing.expectEqual(@as(usize, 0), zz.height(""));


### PR DESCRIPTION
From the codebase review.

## The bug

`measure.width` skips CSI and OSC, but treats every other escape as a single-character sequence — so the payload after it gets measured as text:

```
"\x1b[31mabc\x1b[0m"                 ->  3  ✓
"\x1b]8;;http://x\x07abc"            ->  3  ✓
"\x1bPtmux;q\x1b\\abc"                ->  9  ✗ (should be 3)
"\x1b_Gf=100,a=T;payload\x1b\\abc"    -> 21  ✗ (should be 3)
```

`width` and `maxLineWidth` drive centring, padding, truncation and placement, so a view that embeds an inline image (**APC** is the Kitty graphics protocol) or a tmux passthrough (**DCS**) has its entire layout thrown off — and the longer the base64 payload, the worse it gets.

## The fix

DCS, APC, PM and SOS now run to ST, the way OSC already ran to BEL. Six lines in `measure.zig`.

## Tests

`measure.width` and `maxLineWidth` against OSC (both terminators), a complete hyperlink pair, DCS, APC, PM and SOS.

## Not fixed here

`style/overflow.zig` and `style/compress.zig` carry the same CSI-only assumption. Truncating and recolouring text around a string sequence is a different enough problem that it deserves its own change rather than being folded into this one.

`zig build test` and `zig build` clean on 0.16.0.