### PR TITLE
fix: frame escape sequences correctly when truncating and wrapping

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -356,7 +356,9 @@ pub const CompleteColor = color.CompleteColor;
 pub const CompleteAdaptiveColor = color.CompleteAdaptiveColor;
 
 // Overflow
+pub const overflow = @import("style/overflow.zig");
 pub const Overflow = style.Overflow;
+pub const applyOverflow = overflow.applyOverflow;
 
 // Style utilities
 pub const StyleRange = style.StyleRange;

--- a/src/style/compress.zig
+++ b/src/style/compress.zig
@@ -117,39 +117,31 @@ pub fn compressAnsi(allocator: std.mem.Allocator, input: []const u8) ![]const u8
     var last_was_reset = false;
 
     while (i < input.len) {
-        // Check for ESC[
-        if (i + 1 < input.len and input[i] == 0x1b and input[i + 1] == '[') {
-            // Find the end of the CSI sequence
-            var seq_end = i + 2;
-            while (seq_end < input.len) {
-                const c = input[seq_end];
-                if ((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z')) {
-                    seq_end += 1;
-                    break;
-                }
-                seq_end += 1;
-            }
-
-            const seq = input[i..seq_end];
-
-            // Check for reset sequence
-            if (std.mem.eql(u8, seq, ansi.reset)) {
-                if (!last_was_reset) {
-                    try writer.writeAll(seq);
-                    last_was_reset = true;
-                }
-                // Skip duplicate resets
-            } else {
-                try writer.writeAll(seq);
-                last_was_reset = false;
-            }
-
-            i = seq_end;
-        } else {
+        const seq_len = ansi.escapeSequenceLen(input, i);
+        if (seq_len == 0) {
             try writer.writeByte(input[i]);
             last_was_reset = false;
             i += 1;
+            continue;
         }
+
+        const seq = input[i..][0..seq_len];
+        i += seq_len;
+
+        // Only a bare reset is a candidate for removal. A string sequence
+        // (OSC, DCS, APC) is copied whole: its payload can contain bytes that
+        // look like CSI sequences — a tmux passthrough wraps them by design —
+        // and rewriting those would corrupt it.
+        if (std.mem.eql(u8, seq, ansi.reset)) {
+            if (!last_was_reset) {
+                try writer.writeAll(seq);
+                last_was_reset = true;
+            }
+            continue;
+        }
+
+        try writer.writeAll(seq);
+        last_was_reset = false;
     }
 
     return result.toOwnedSlice();

--- a/src/style/overflow.zig
+++ b/src/style/overflow.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 const Writer = std.Io.Writer;
 const measure = @import("../layout/measure.zig");
+const ansi = @import("../terminal/ansi.zig");
+const unicode = @import("../unicode.zig");
 
 /// Overflow policy for text that exceeds width constraints.
 pub const Overflow = enum {
@@ -53,13 +55,11 @@ fn applyClip(result: *std.array_list.Managed(u8), line: []const u8, max_width: u
     var visible_width: usize = 0;
     var i: usize = 0;
     while (i < line.len) {
-        // Skip ANSI escape sequences
-        if (line[i] == 0x1b and i + 1 < line.len and line[i + 1] == '[') {
-            const seq_start = i;
-            i += 2;
-            while (i < line.len and line[i] != 'm' and line[i] != 'H' and line[i] != 'J' and line[i] != 'K' and line[i] != 'A' and line[i] != 'B' and line[i] != 'C' and line[i] != 'D') : (i += 1) {}
-            if (i < line.len) i += 1;
-            try result.appendSlice(line[seq_start..i]);
+        // Escape sequences are copied through untouched and cost no width.
+        const esc_len = ansi.escapeSequenceLen(line, i);
+        if (esc_len > 0) {
+            try result.appendSlice(line[i..][0..esc_len]);
+            i += esc_len;
             continue;
         }
 
@@ -90,12 +90,11 @@ fn applyEllipsis(result: *std.array_list.Managed(u8), line: []const u8, max_widt
     var i: usize = 0;
     const target_width = max_width - 1;
     while (i < line.len) {
-        if (line[i] == 0x1b and i + 1 < line.len and line[i + 1] == '[') {
-            const seq_start = i;
-            i += 2;
-            while (i < line.len and line[i] != 'm' and line[i] != 'H' and line[i] != 'J' and line[i] != 'K' and line[i] != 'A' and line[i] != 'B' and line[i] != 'C' and line[i] != 'D') : (i += 1) {}
-            if (i < line.len) i += 1;
-            try result.appendSlice(line[seq_start..i]);
+        // Escape sequences are copied through untouched and cost no width.
+        const esc_len = ansi.escapeSequenceLen(line, i);
+        if (esc_len > 0) {
+            try result.appendSlice(line[i..][0..esc_len]);
+            i += esc_len;
             continue;
         }
 
@@ -124,12 +123,11 @@ fn applyWordWrap(result: *std.array_list.Managed(u8), line: []const u8, max_widt
 
     while (i < line.len) {
         // Skip ANSI sequences
-        if (line[i] == 0x1b and i + 1 < line.len and line[i + 1] == '[') {
-            const seq_start = i;
-            i += 2;
-            while (i < line.len and line[i] != 'm' and line[i] != 'H' and line[i] != 'J' and line[i] != 'K' and line[i] != 'A' and line[i] != 'B' and line[i] != 'C' and line[i] != 'D') : (i += 1) {}
-            if (i < line.len) i += 1;
-            try result.appendSlice(line[seq_start..i]);
+        // Escape sequences are copied through untouched and cost no width.
+        const esc_len = ansi.escapeSequenceLen(line, i);
+        if (esc_len > 0) {
+            try result.appendSlice(line[i..][0..esc_len]);
+            i += esc_len;
             continue;
         }
 
@@ -157,11 +155,11 @@ fn applyWordWrap(result: *std.array_list.Managed(u8), line: []const u8, max_widt
         const word_start = i;
         var word_width: usize = 0;
         while (i < line.len and line[i] != ' ') {
-            // Skip ANSI inside word
-            if (line[i] == 0x1b and i + 1 < line.len and line[i + 1] == '[') {
-                i += 2;
-                while (i < line.len and line[i] != 'm' and line[i] != 'H' and line[i] != 'J' and line[i] != 'K' and line[i] != 'A' and line[i] != 'B' and line[i] != 'C' and line[i] != 'D') : (i += 1) {}
-                if (i < line.len) i += 1;
+            // The whole word is copied verbatim below, so an escape inside it
+            // only needs stepping over.
+            const inner_esc = ansi.escapeSequenceLen(line, i);
+            if (inner_esc > 0) {
+                i += inner_esc;
                 continue;
             }
             word_width += charDisplayWidth(line, i);
@@ -195,12 +193,11 @@ fn applyCharWrap(result: *std.array_list.Managed(u8), line: []const u8, max_widt
 
     while (i < line.len) {
         // Skip ANSI sequences
-        if (line[i] == 0x1b and i + 1 < line.len and line[i + 1] == '[') {
-            const seq_start = i;
-            i += 2;
-            while (i < line.len and line[i] != 'm' and line[i] != 'H' and line[i] != 'J' and line[i] != 'K' and line[i] != 'A' and line[i] != 'B' and line[i] != 'C' and line[i] != 'D') : (i += 1) {}
-            if (i < line.len) i += 1;
-            try result.appendSlice(line[seq_start..i]);
+        // Escape sequences are copied through untouched and cost no width.
+        const esc_len = ansi.escapeSequenceLen(line, i);
+        if (esc_len > 0) {
+            try result.appendSlice(line[i..][0..esc_len]);
+            i += esc_len;
             continue;
         }
 
@@ -219,32 +216,19 @@ fn applyCharWrap(result: *std.array_list.Managed(u8), line: []const u8, max_widt
     }
 }
 
+/// Display width of the character at `pos`.
+///
+/// Defers to the shared Unicode tables rather than an approximation of its
+/// own, so wrapping agrees with what `measure.width` reported — and so a
+/// combining mark counts as zero rather than one.
 fn charDisplayWidth(text: []const u8, pos: usize) usize {
     const byte = text[pos];
     if (byte < 0x80) return 1;
-    // Simple heuristic: CJK characters are 2-wide, others 1-wide
-    // Full-width ranges: U+1100-U+115F, U+2E80-U+A4CF, U+AC00-U+D7A3, etc.
-    const byte_len = charByteLen(byte);
-    if (byte_len >= 3 and pos + byte_len <= text.len) {
-        const cp = std.unicode.utf8Decode(text[pos..][0..byte_len]) catch return 1;
-        if (isWideCodepoint(cp)) return 2;
-    }
-    return 1;
-}
 
-fn isWideCodepoint(cp: u21) bool {
-    return (cp >= 0x1100 and cp <= 0x115F) or
-        (cp >= 0x2E80 and cp <= 0x303E) or
-        (cp >= 0x3041 and cp <= 0x33BF) or
-        (cp >= 0x3400 and cp <= 0x4DBF) or
-        (cp >= 0x4E00 and cp <= 0xA4CF) or
-        (cp >= 0xAC00 and cp <= 0xD7A3) or
-        (cp >= 0xF900 and cp <= 0xFAFF) or
-        (cp >= 0xFE30 and cp <= 0xFE6F) or
-        (cp >= 0xFF01 and cp <= 0xFF60) or
-        (cp >= 0xFFE0 and cp <= 0xFFE6) or
-        (cp >= 0x20000 and cp <= 0x2FFFD) or
-        (cp >= 0x30000 and cp <= 0x3FFFD);
+    const byte_len = charByteLen(byte);
+    if (pos + byte_len > text.len) return 1;
+    const cp = std.unicode.utf8Decode(text[pos..][0..byte_len]) catch return 1;
+    return unicode.charWidth(cp);
 }
 
 fn charByteLen(first_byte: u8) usize {

--- a/src/terminal/ansi.zig
+++ b/src/terminal/ansi.zig
@@ -62,6 +62,59 @@ pub const unicode_width_mode_disable = CSI ++ "?2027l";
 pub const kitty_keyboard_enable = CSI ++ ">1u";
 pub const kitty_keyboard_disable = CSI ++ "<u";
 
+/// Length in bytes of the escape sequence starting at `text[pos]`, or 0 when
+/// there is no sequence there.
+///
+/// This is framing only — the sequence is not interpreted. Anything that walks
+/// styled text (measuring, truncating, wrapping) needs to step over sequences
+/// as units, and getting that wrong is subtle: a CSI can end in any byte from
+/// 0x40 to 0x7E, not just a letter, and OSC/DCS/APC payloads carry arbitrary
+/// text that must not be read as content.
+///
+/// A sequence left unfinished by the end of `text` reports the remaining
+/// length, so callers always make progress.
+pub fn escapeSequenceLen(text: []const u8, pos: usize) usize {
+    if (pos >= text.len or text[pos] != ESC[0]) return 0;
+    if (pos + 1 >= text.len) return 1;
+
+    return switch (text[pos + 1]) {
+        '[' => csiLen(text, pos),
+        // SS3: ESC O plus one final byte.
+        'O' => @min(3, text.len - pos),
+        // OSC also accepts BEL as a terminator.
+        ']' => stringLen(text, pos, true),
+        // DCS, APC, PM, SOS.
+        'P', '_', '^', 'X' => stringLen(text, pos, false),
+        else => 2,
+    };
+}
+
+/// ESC [ <params 0x30-0x3F> <intermediates 0x20-0x2F> <final 0x40-0x7E>
+fn csiLen(text: []const u8, pos: usize) usize {
+    var i = pos + 2;
+    while (i < text.len and text[i] >= 0x30 and text[i] <= 0x3f) : (i += 1) {}
+    while (i < text.len and text[i] >= 0x20 and text[i] <= 0x2f) : (i += 1) {}
+    if (i >= text.len) return i - pos;
+    // A byte outside the final range cannot belong to the sequence; stop
+    // before it rather than swallowing text.
+    if (text[i] < 0x40 or text[i] > 0x7e) return i - pos;
+    return i + 1 - pos;
+}
+
+/// A string sequence runs until ST (ESC \), and until BEL when it is an OSC.
+fn stringLen(text: []const u8, pos: usize, bel_terminates: bool) usize {
+    var i = pos + 2;
+    while (i < text.len) : (i += 1) {
+        if (bel_terminates and text[i] == 0x07) return i + 1 - pos;
+        if (text[i] == ESC[0]) {
+            if (i + 1 < text.len and text[i + 1] == '\\') return i + 2 - pos;
+            // A bare ESC aborts the string.
+            return i - pos;
+        }
+    }
+    return i - pos;
+}
+
 /// Move cursor to position (1-indexed)
 pub fn cursorTo(writer: *Writer, row: u16, col: u16) !void {
     try writer.print(CSI ++ "{d};{d}H", .{ row, col });
@@ -341,6 +394,49 @@ pub fn iterm2InlineImage(writer: *Writer, params: []const u8, payload: []const u
     try writer.writeAll(":");
     try writer.writeAll(payload);
     try writer.writeAll("\x07");
+}
+
+test "escapeSequenceLen: not a sequence" {
+    try std.testing.expectEqual(@as(usize, 0), escapeSequenceLen("abc", 0));
+    try std.testing.expectEqual(@as(usize, 0), escapeSequenceLen("", 0));
+    try std.testing.expectEqual(@as(usize, 0), escapeSequenceLen("a\x1b[0m", 0));
+}
+
+test "escapeSequenceLen: CSI" {
+    try std.testing.expectEqual(@as(usize, 4), escapeSequenceLen("\x1b[0mtail", 0));
+    try std.testing.expectEqual(@as(usize, 13), escapeSequenceLen("\x1b[38;2;1;2;3mtail", 0));
+    // Final bytes that are not letters, which a scan for A-Za-z would run past.
+    try std.testing.expectEqual(@as(usize, 4), escapeSequenceLen("\x1b[3~tail", 0));
+    try std.testing.expectEqual(@as(usize, 6), escapeSequenceLen("\x1b[?25htail", 0));
+    // Private and intermediate bytes.
+    try std.testing.expectEqual(@as(usize, 9), escapeSequenceLen("\x1b[?2027$ptail", 0));
+}
+
+test "escapeSequenceLen: string sequences" {
+    try std.testing.expectEqual(@as(usize, 10), escapeSequenceLen("\x1b]0;title\x07tail", 0));
+    try std.testing.expectEqual(@as(usize, 11), escapeSequenceLen("\x1b]0;title\x1b\\tail", 0));
+    try std.testing.expectEqual(@as(usize, 10), escapeSequenceLen("\x1bPtmux;q\x1b\\tail", 0));
+    try std.testing.expectEqual(@as(usize, 13), escapeSequenceLen("\x1b_Gf=100;ab\x1b\\tail", 0));
+    // BEL is content inside a DCS, not a terminator.
+    try std.testing.expectEqual(@as(usize, 7), escapeSequenceLen("\x1bPa\x07b\x1b\\tail", 0));
+}
+
+test "escapeSequenceLen: SS3 and two-byte escapes" {
+    try std.testing.expectEqual(@as(usize, 3), escapeSequenceLen("\x1bOPtail", 0));
+    try std.testing.expectEqual(@as(usize, 2), escapeSequenceLen("\x1bMtail", 0));
+}
+
+test "escapeSequenceLen: truncated input still advances" {
+    for ([_][]const u8{ "\x1b", "\x1b[", "\x1b[38;2", "\x1b]0;partial", "\x1bP", "\x1bO" }) |input| {
+        const len = escapeSequenceLen(input, 0);
+        try std.testing.expect(len > 0);
+        try std.testing.expect(len <= input.len);
+    }
+}
+
+test "escapeSequenceLen: offset within a string" {
+    const text = "ab\x1b[31mcd";
+    try std.testing.expectEqual(@as(usize, 5), escapeSequenceLen(text, 2));
 }
 
 test "osc52Encoded direct BEL" {

--- a/tests/style_tests.zig
+++ b/tests/style_tests.zig
@@ -98,3 +98,118 @@ test "Style with border" {
     try testing.expect(style.border_sides.left);
     try testing.expect(style.border_sides.right);
 }
+
+// ---------------------------------------------------------------------------
+// Overflow and compression around escape sequences
+// ---------------------------------------------------------------------------
+
+const hyperlink = "\x1b]8;;https://example.com\x07";
+const link_end = "\x1b]8;;\x07";
+const kitty_image = "\x1b_Gf=100,a=T;iVBORw0KGgoAAAANSUhEUg\x1b\\";
+
+test "overflow.hidden measures a hyperlink as zero width" {
+    const allocator = testing.allocator;
+    const input = hyperlink ++ "Hello, World!" ++ link_end;
+
+    const result = try zz.applyOverflow(allocator, input, 5, .hidden);
+    defer allocator.free(result);
+
+    // The link opener is carried through; only five columns of text survive.
+    try testing.expectEqualStrings(hyperlink ++ "Hello", result);
+}
+
+test "overflow.hidden steps over an image sequence" {
+    const allocator = testing.allocator;
+    const input = kitty_image ++ "Hello, World!";
+
+    const result = try zz.applyOverflow(allocator, input, 5, .hidden);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings(kitty_image ++ "Hello", result);
+}
+
+test "overflow.hidden handles CSI sequences ending in a non-letter" {
+    const allocator = testing.allocator;
+    // `CSI ? 2 5 h` ends in 'h'; a scan for the first A-Za-z used to run past
+    // it and eat the 'H' of the text.
+    const input = "\x1b[?25hHello, World!";
+
+    const result = try zz.applyOverflow(allocator, input, 5, .hidden);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings("\x1b[?25hHello", result);
+}
+
+test "overflow.ellipsis measures a hyperlink as zero width" {
+    const allocator = testing.allocator;
+    const input = hyperlink ++ "Hello, World!" ++ link_end;
+
+    const result = try zz.applyOverflow(allocator, input, 6, .ellipsis);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings(hyperlink ++ "Hello\xe2\x80\xa6", result);
+}
+
+test "overflow.char_wrap measures a hyperlink as zero width" {
+    const allocator = testing.allocator;
+    const input = hyperlink ++ "abcdef";
+
+    const result = try zz.applyOverflow(allocator, input, 3, .char_wrap);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings(hyperlink ++ "abc\ndef", result);
+}
+
+test "overflow.word_wrap measures a hyperlink as zero width" {
+    const allocator = testing.allocator;
+    const input = hyperlink ++ "alpha beta";
+
+    const result = try zz.applyOverflow(allocator, input, 5, .word_wrap);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings(hyperlink ++ "alpha\nbeta", result);
+}
+
+test "overflow uses shared width tables for wide characters" {
+    const allocator = testing.allocator;
+
+    // Two double-width characters fill four columns exactly.
+    const fits = try zz.applyOverflow(allocator, "日本語", 4, .hidden);
+    defer allocator.free(fits);
+    try testing.expectEqualStrings("日本", fits);
+
+    // A combining mark adds no width, so all four base characters survive.
+    const combining = try zz.applyOverflow(allocator, "a\u{0301}bcd", 4, .hidden);
+    defer allocator.free(combining);
+    try testing.expectEqualStrings("a\u{0301}bcd", combining);
+}
+
+test "compressAnsi leaves string sequence payloads alone" {
+    const allocator = testing.allocator;
+
+    // A tmux passthrough carries SGR bytes inside its payload by design.
+    const input = "\x1bPtmux;\x1b\x1b[0m\x1b\\text";
+    const result = try zz.compressAnsi(allocator, input);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings(input, result);
+}
+
+test "compressAnsi still collapses repeated resets" {
+    const allocator = testing.allocator;
+
+    const result = try zz.compressAnsi(allocator, "a\x1b[0m\x1b[0m\x1b[0mb");
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings("a\x1b[0mb", result);
+}
+
+test "compressAnsi keeps CSI sequences ending in a non-letter intact" {
+    const allocator = testing.allocator;
+
+    const input = "\x1b[3~\x1b[0m\x1b[0mtail";
+    const result = try zz.compressAnsi(allocator, input);
+    defer allocator.free(result);
+
+    try testing.expectEqualStrings("\x1b[3~\x1b[0mtail", result);
+}


### PR DESCRIPTION
Item 2 from the review — the CSI-only assumption in `style/overflow.zig` and `style/compress.zig` that #136 fixed in `measure.zig`. It turned out to be worse than "OSC isn't handled".

## The bug

`overflow.zig` carried **five copies** of the same escape scanner, `compress.zig` a sixth. All of them assume a sequence is `ESC [` … followed by a letter. That is wrong twice over:

**A CSI can end in any byte from 0x40 to 0x7E, not just a letter.** `\x1b[?25hHello` ends at `h`, but a scan for the first `A-Za-z` runs past it to the `H` of "Hello" and swallows it:

```
applyOverflow("\x1b[?25hHello, World!", 5, .hidden)
  before -> "\x1b[?25hHello, W"      (14 columns, and the H is inside the "sequence")
  after  -> "\x1b[?25hHello"
```

**OSC, DCS and APC are not recognised at all**, so their payloads are measured as visible text. A hyperlink's URL or a Kitty image's base64 eats the entire width budget:

```
applyOverflow("\x1b]8;;https://example.com\x07Hello, World!" ++ end, 5, .hidden)
  before -> "\x1b]8;;" + garbage    (the URL counted as 24 columns)
  after  -> "\x1b]8;;https://example.com\x07Hello"
```

In `compressAnsi` the same gap means a tmux passthrough — which wraps SGR bytes inside its payload *by design* — can have those inner bytes treated as top-level sequences and rewritten by the reset dedup.

## The fix

`ansi.escapeSequenceLen(text, pos)` frames a sequence without interpreting it: CSI by parameter/intermediate/final byte ranges, SS3, and the string sequences (OSC/DCS/APC/PM/SOS) by their terminators. An unfinished sequence reports the remaining length so callers always advance.

All six sites route through it. **Six copies of subtly wrong scanning become one function with tests.**

`overflow.zig` also carried its own hand-rolled table of wide codepoint ranges. It now defers to `unicode.charWidth`, so wrapping agrees with what `measure.width` reported, and combining marks stop counting as a column.

## Also

`applyOverflow` is now exported. `zz.Overflow` was public but the function that applies it was not reachable from outside the library.

## Tests

9 new cases in `tests/style_tests.zig` plus 6 for `escapeSequenceLen` in `ansi.zig`. **7 of the 9 fail against the current code** — I checked by stashing the fix and re-running:

```
FAIL overflow.hidden measures a hyperlink as zero width
FAIL overflow.hidden steps over an image sequence
FAIL overflow.hidden handles CSI sequences ending in a non-letter
FAIL overflow.ellipsis measures a hyperlink as zero width
FAIL overflow.char_wrap measures a hyperlink as zero width
FAIL overflow.word_wrap measures a hyperlink as zero width
FAIL overflow uses shared width tables for wide characters
FAIL compressAnsi keeps CSI sequences ending in a non-letter intact
```

`zig build test` and `zig build` clean on 0.16.0.