### PR TITLE
ci: run the test suite in release modes too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,23 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
       - run: zig build test
 
+  # Debug catches overflow and bounds violations by panicking; the release
+  # modes are where a wrong assumption turns into wrong output instead. Run
+  # both, on Linux only, since these catch codegen and safety differences
+  # rather than platform ones.
+  test-release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        optimize: [ReleaseSafe, ReleaseFast]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+      - run: zig build test -Doptimize=${{ matrix.optimize }}
+
   cross-compile:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
> **Stacked on #135** — base branch is `chore/ci-fmt-and-pacing-safety`, since both edit `ci.yml`. Merge #135 first and GitHub retargets this to `main`.

Item 5 from the review.

CI only ever ran Debug. That matters: the `u16` overflow in `parseCsi` that #130 fixes behaves differently on either side of the line — Debug aborts the process, ReleaseFast wraps silently and hands the parser a garbage coordinate. Whichever way a bug lands, only one of the two builds shows it.

Adds ReleaseSafe and ReleaseFast test jobs. Linux only: these catch codegen and safety differences, not platform ones, so there is no reason to multiply them across the OS matrix.

Verified locally — ReleaseSafe, ReleaseFast and ReleaseSmall all pass on 0.16.0.