### PR TITLE
refactor: migrate the examples to fallible view and init

### DIFF
--- a/examples/accessibility.zig
+++ b/examples/accessibility.zig
@@ -48,21 +48,21 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var result: Writer.Allocating = .init(ctx.allocator);
         const w = &result.writer;
 
         // Title
-        const title = (zz.Style{})
+        const title = try (zz.Style{})
             .bold(true)
             .fg(.white)
             .inline_style(true)
-            .render(ctx.allocator, "Accessibility: WCAG Contrast Checker") catch "A11y Demo";
-        w.print("{s}\n\n", .{title}) catch {};
+            .render(ctx.allocator, "Accessibility: WCAG Contrast Checker");
+        try w.print("{s}\n\n", .{title});
 
         // Table header
-        w.writeAll("  Name                   Ratio    Level     Sample\n") catch {};
-        w.writeAll("  ────────────────────── ──────── ───────── ──────────────\n") catch {};
+        try w.writeAll("  Name                   Ratio    Level     Sample\n");
+        try w.writeAll("  ────────────────────── ──────── ───────── ──────────────\n");
 
         // Color pairs
         for (&self.pairs, 0..) |*pair, i| {
@@ -86,50 +86,50 @@ const Model = struct {
 
             // Row indicator
             const prefix: []const u8 = if (i == self.selected) "> " else "  ";
-            w.writeAll(prefix) catch {};
+            try w.writeAll(prefix);
 
             // Name (padded to 23 chars)
-            w.print("{s}", .{pair.name}) catch {};
+            try w.print("{s}", .{pair.name});
             const name_len = pair.name.len;
             if (name_len < 23) {
-                for (0..23 - name_len) |_| w.writeByte(' ') catch {};
+                for (0..23 - name_len) |_| try w.writeByte(' ');
             }
 
             // Ratio
-            w.print("{d:.1}:1   ", .{ratio}) catch {};
+            try w.print("{d:.1}:1   ", .{ratio});
 
             // Level badge
-            const badge = (zz.Style{})
+            const badge = try (zz.Style{})
                 .fg(level_color)
                 .bold(true)
                 .inline_style(true)
-                .render(ctx.allocator, level_name) catch level_name;
-            w.print("{s}", .{badge}) catch {};
+                .render(ctx.allocator, level_name);
+            try w.print("{s}", .{badge});
             const badge_len = level_name.len;
             if (badge_len < 10) {
-                for (0..10 - badge_len) |_| w.writeByte(' ') catch {};
+                for (0..10 - badge_len) |_| try w.writeByte(' ');
             }
 
             // Sample text with the actual colors
-            const sample = (zz.Style{})
+            const sample = try (zz.Style{})
                 .fg(pair.fg)
                 .bg(pair.bg)
                 .inline_style(true)
-                .render(ctx.allocator, " Sample Text ") catch "Sample";
-            w.print("{s}", .{sample}) catch {};
+                .render(ctx.allocator, " Sample Text ");
+            try w.print("{s}", .{sample});
 
-            w.writeByte('\n') catch {};
+            try w.writeByte('\n');
         }
 
         // Selected pair detail
         const pair = &self.pairs[self.selected];
-        w.writeAll("\n") catch {};
+        try w.writeAll("\n");
 
         // Accessible label demo
         const a11y_label = zz.AccessibleLabel{
             .role = .status,
             .name = pair.name,
-            .value = std.fmt.allocPrint(ctx.allocator, "contrast {d:.1}:1", .{pair.fg.contrastRatio(pair.bg)}) catch "",
+            .value = try std.fmt.allocPrint(ctx.allocator, "contrast {d:.1}:1", .{pair.fg.contrastRatio(pair.bg)}),
             .state = switch (zz.a11y.checkContrast(pair.fg, pair.bg)) {
                 .aaa => "passes AAA",
                 .aa => "passes AA",
@@ -137,27 +137,27 @@ const Model = struct {
                 .fail => "fails WCAG requirements",
             },
         };
-        const label_text = a11y_label.format(ctx.allocator) catch "?";
-        const label = (zz.Style{})
+        const label_text = try a11y_label.format(ctx.allocator);
+        const label = try (zz.Style{})
             .fg(.gray(14))
             .inline_style(true)
-            .render(ctx.allocator, label_text) catch label_text;
-        w.print("Screen reader: {s}\n", .{label}) catch {};
+            .render(ctx.allocator, label_text);
+        try w.print("Screen reader: {s}\n", .{label});
 
         // Suggested foreground
         const suggested = zz.a11y.suggestForeground(pair.bg);
         const sugg_name: []const u8 = if (std.meta.eql(suggested, .white)) "white" else "black";
-        w.print("Suggested foreground for this bg: {s}\n", .{sugg_name}) catch {};
+        try w.print("Suggested foreground for this bg: {s}\n", .{sugg_name});
 
         // Help
-        w.writeAll("\n") catch {};
-        const help = (zz.Style{})
+        try w.writeAll("\n");
+        const help = try (zz.Style{})
             .fg(.gray(12))
             .inline_style(true)
-            .render(ctx.allocator, "Up/Down: select pair | q: quit") catch "";
-        w.writeAll(help) catch {};
+            .render(ctx.allocator, "Up/Down: select pair | q: quit");
+        try w.writeAll(help);
 
-        return result.toOwnedSlice() catch "Error";
+        return result.toOwnedSlice();
     }
 };
 

--- a/examples/action_system.zig
+++ b/examples/action_system.zig
@@ -15,69 +15,69 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         const persistent = ctx.persistent_allocator;
         var reg = zz.ActionRegistry.init(persistent);
 
-        // Footer-visible actions.
+        try // Footer-visible actions.
         reg.register(.{
             .id = "app.quit",
             .label = "Quit",
             .description = "Exit the program",
             .binding = .{ .key = .{ .char = 'q' } },
             .show_in_footer = true,
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "counter.inc",
             .label = "Increment",
             .description = "Add one to the counter",
             .binding = .{ .key = .{ .char = '+' } },
             .show_in_footer = true,
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "counter.dec",
             .label = "Decrement",
             .description = "Subtract one from the counter",
             .binding = .{ .key = .{ .char = '-' } },
             .show_in_footer = true,
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "palette.open",
             .label = "Command Palette",
             .description = "Open the searchable command list",
             .binding = .{ .key = .{ .char = 'p' }, .modifiers = .{ .ctrl = true } },
             .show_in_footer = true,
-        }) catch {};
+        });
 
-        // Hidden-from-footer actions still show up in the palette.
+        try // Hidden-from-footer actions still show up in the palette.
         reg.register(.{
             .id = "counter.reset",
             .label = "Reset counter",
             .description = "Set the counter back to zero",
             .category = "Counter",
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "counter.times_ten",
             .label = "Multiply by 10",
             .description = "Multiply the counter by ten",
             .category = "Counter",
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "counter.negate",
             .label = "Negate",
             .description = "Flip the counter sign",
             .category = "Counter",
-        }) catch {};
-        reg.register(.{
+        });
+        try reg.register(.{
             .id = "help.about",
             .label = "About this demo",
             .description = "Show what this example illustrates",
             .category = "Help",
-        }) catch {};
+        });
 
-        // Aliases let multiple keys map to the same action.
-        reg.addAlias("counter.inc", .{ .key = .up }) catch {};
-        reg.addAlias("counter.dec", .{ .key = .down }) catch {};
+        try // Aliases let multiple keys map to the same action.
+        reg.addAlias("counter.inc", .{ .key = .up });
+        try reg.addAlias("counter.dec", .{ .key = .down });
 
         var palette = zz.CommandPalette.init(persistent) catch return .quit;
         palette.placeholder = "Search commands…";
@@ -93,7 +93,7 @@ const Model = struct {
         // One-shot integration: pull every registered action into the
         // palette, formatting bindings as shortcut hints. The palette owns
         // the strings, so no lifetime tracking on our side.
-        self.palette.setFromRegistry(&self.registry) catch {};
+        try self.palette.setFromRegistry(&self.registry);
 
         return .none;
     }
@@ -151,16 +151,16 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title = zz.Style{};
         title = title.bold(true);
         title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
-        const title_str = title.render(alloc, "ActionRegistry — one source of truth") catch "";
+        const title_str = try title.render(alloc, "ActionRegistry — one source of truth");
 
-        const body = std.fmt.allocPrint(
+        const body = try std.fmt.allocPrint(
             alloc,
             \\Counter        {d}
             \\Last action    {s}
@@ -170,28 +170,28 @@ const Model = struct {
             \\including ones with no key binding (try "negate" or "ten").
         ,
             .{ self.counter, self.last_action },
-        ) catch "";
+        );
 
         var box = zz.Style{};
         box = box.borderAll(zz.Border.rounded);
         box = box.borderForeground(zz.Color.gray(8));
         box = box.paddingAll(1);
-        const boxed = box.render(alloc, body) catch body;
+        const boxed = try box.render(alloc, body);
 
         var footer = zz.ActionFooter.init(&self.registry);
         footer.setWidth(@intCast(ctx.width));
-        const footer_str = footer.view(alloc) catch "";
+        const footer_str = try footer.view(alloc);
 
-        const main_view = std.fmt.allocPrint(
+        const main_view = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}",
             .{ title_str, boxed, footer_str },
-        ) catch "";
+        );
 
         if (!self.palette_open) return main_view;
 
         // Overlay the palette centered on top of the main view.
-        const palette_view = self.palette.view(alloc) catch "";
+        const palette_view = try self.palette.view(alloc);
         return zz.place.placeFloat(
             alloc,
             ctx.width,
@@ -199,7 +199,7 @@ const Model = struct {
             0.5,
             0.5,
             palette_view,
-        ) catch main_view;
+        );
     }
 };
 

--- a/examples/animation.zig
+++ b/examples/animation.zig
@@ -85,17 +85,17 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Animation & Easing Demo") catch "Animation";
+        const title = try title_style.render(ctx.allocator, "Animation & Easing Demo");
 
         var buf: Writer.Allocating = .init(ctx.allocator);
         const writer = &buf.writer;
-        writer.writeAll(title) catch {};
-        writer.writeAll("\n\n") catch {};
+        try writer.writeAll(title);
+        try writer.writeAll("\n\n");
 
         // Render each tween as a bar
         for (&self.tweens, self.easing_names) |*tw, name| {
@@ -103,9 +103,9 @@ const Model = struct {
             var label_style = zz.Style{};
             label_style = label_style.fg(zz.Color.cyan);
             label_style = label_style.inline_style(true);
-            const label = std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name}) catch "";
-            const styled_label = label_style.render(ctx.allocator, label) catch label;
-            writer.writeAll(styled_label) catch {};
+            const label = try std.fmt.allocPrint(ctx.allocator, "{s:>20}: ", .{name});
+            const styled_label = try label_style.render(ctx.allocator, label);
+            try writer.writeAll(styled_label);
 
             // Bar
             const pos = @as(usize, @intFromFloat(@max(0, tw.value())));
@@ -115,26 +115,26 @@ const Model = struct {
                     dot_style = dot_style.fg(zz.Color.green);
                     dot_style = dot_style.bold(true);
                     dot_style = dot_style.inline_style(true);
-                    const dot = dot_style.render(ctx.allocator, "●") catch "o";
-                    writer.writeAll(dot) catch {};
+                    const dot = try dot_style.render(ctx.allocator, "●");
+                    try writer.writeAll(dot);
                 } else {
                     var track_style = zz.Style{};
                     track_style = track_style.fg(zz.Color.gray(6));
                     track_style = track_style.inline_style(true);
-                    const track = track_style.render(ctx.allocator, "─") catch "-";
-                    writer.writeAll(track) catch {};
+                    const track = try track_style.render(ctx.allocator, "─");
+                    try writer.writeAll(track);
                 }
             }
-            writer.writeByte('\n') catch {};
+            try writer.writeByte('\n');
         }
 
         // Color tween demo
-        writer.writeAll("\n") catch {};
+        try writer.writeAll("\n");
         var color_label_style = zz.Style{};
         color_label_style = color_label_style.fg(zz.Color.cyan);
         color_label_style = color_label_style.inline_style(true);
-        const color_label = color_label_style.render(ctx.allocator, "     Color tween: ") catch "";
-        writer.writeAll(color_label) catch {};
+        const color_label = try color_label_style.render(ctx.allocator, "     Color tween: ");
+        try writer.writeAll(color_label);
 
         const ct = self.color_tween.value();
         const color = zz.tweenColor(zz.Color.red, zz.Color.cyan, ct);
@@ -142,18 +142,18 @@ const Model = struct {
         cs = cs.fg(color);
         cs = cs.bold(true);
         cs = cs.inline_style(true);
-        const color_block = cs.render(ctx.allocator, "████████████████████████████████") catch "";
-        writer.writeAll(color_block) catch {};
+        const color_block = try cs.render(ctx.allocator, "████████████████████████████████");
+        try writer.writeAll(color_block);
 
         // Help
-        writer.writeAll("\n\n") catch {};
+        try writer.writeAll("\n\n");
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "r: restart animations | q: quit") catch "";
-        writer.writeAll(help) catch {};
+        const help = try help_style.render(ctx.allocator, "r: restart animations | q: quit");
+        try writer.writeAll(help);
 
-        return buf.toOwnedSlice() catch "Error";
+        return buf.toOwnedSlice();
     }
 };
 

--- a/examples/async_tasks.zig
+++ b/examples/async_tasks.zig
@@ -103,7 +103,7 @@ const Model = struct {
         return .{ .task_complete = .{ .id = 2, .value = "Task 3: file processed OK" } };
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -121,28 +121,28 @@ const Model = struct {
         box_s = box_s.paddingAll(1);
         box_s = box_s.width(45);
 
-        const results_text = std.fmt.allocPrint(
+        const results_text = try std.fmt.allocPrint(
             alloc,
             "1: {s}\n2: {s}\n3: {s}",
             .{ self.results[0], self.results[1], self.results[2] },
-        ) catch "";
+        );
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, "Async Tasks Demo") catch "Async Tasks",
-                status_s.render(alloc, self.status) catch self.status,
-                box_s.render(alloc, results_text) catch results_text,
-                help_s.render(alloc, "s: start tasks  q: quit") catch "",
+                try title_s.render(alloc, "Async Tasks Demo"),
+                try status_s.render(alloc, self.status),
+                try box_s.render(alloc, results_text),
+                try help_s.render(alloc, "s: start tasks  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/braille_canvas.zig
+++ b/examples/braille_canvas.zig
@@ -70,7 +70,7 @@ const Model = struct {
         self.ball_y = std.math.clamp(self.ball_y, 4, max_y - 4);
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
         var c = @constCast(&self.canvas);
         c.clear();
@@ -101,31 +101,31 @@ const Model = struct {
         ball_style = ball_style.inline_style(true);
         c.drawCircleStyled(tx, ty, 1, ball_style);
 
-        const canvas_view = c.view(alloc) catch "";
+        const canvas_view = try c.view(alloc);
 
         var title = zz.Style{};
         title = title.bold(true);
         title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
-        const t = title.render(alloc, "BrailleCanvas — bouncing ball") catch "";
+        const t = try title.render(alloc, "BrailleCanvas — bouncing ball");
 
         var box = zz.Style{};
         box = box.borderAll(zz.Border.rounded);
         box = box.borderForeground(zz.Color.gray(8));
-        const boxed = box.render(alloc, canvas_view) catch canvas_view;
+        const boxed = try box.render(alloc, canvas_view);
 
         var help = zz.Style{};
         help = help.fg(zz.Color.gray(10));
         help = help.inline_style(true);
         const status = if (self.paused) "PAUSED  " else "        ";
-        const help_text = std.fmt.allocPrint(
+        const help_text = try std.fmt.allocPrint(
             alloc,
             "{s}space pause  r reset  q quit   |   frame {d}",
             .{ status, self.frame },
-        ) catch "";
-        const help_str = help.render(alloc, help_text) catch "";
+        );
+        const help_str = try help.render(alloc, help_text);
 
-        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str }) catch "Error";
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str });
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/calendar.zig
+++ b/examples/calendar.zig
@@ -42,7 +42,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -56,28 +56,28 @@ const Model = struct {
         box_style = box_style.paddingAll(1);
 
         const cal_view = self.cal.view(alloc);
-        const boxed = box_style.render(alloc, cal_view) catch cal_view;
+        const boxed = try box_style.render(alloc, cal_view);
 
-        const selected_str = std.fmt.allocPrint(alloc, "Selected: {d}/{d}/{d}", .{
+        const selected_str = try std.fmt.allocPrint(alloc, "Selected: {d}/{d}/{d}", .{
             self.cal.selected_day, self.cal.month, self.cal.year,
-        }) catch "";
+        });
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, "Calendar Demo") catch "Calendar",
+                try title_s.render(alloc, "Calendar Demo"),
                 boxed,
                 selected_str,
-                help_s.render(alloc, "Arrows: navigate  Enter: select  Shift+L/R: month  PgUp/Dn: month  q: quit") catch "",
+                try help_s.render(alloc, "Arrows: navigate  Enter: select  Shift+L/R: month  PgUp/Dn: month  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/charts.zig
+++ b/examples/charts.zig
@@ -143,10 +143,10 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         @constCast(self).syncChartsLayout(ctx);
         const content = self.composeContent(ctx) catch return "Error rendering charts";
-        return zz.place.place(ctx.allocator, ctx.width, ctx.height, .center, .top, content) catch content;
+        return zz.place.place(ctx.allocator, ctx.width, ctx.height, .center, .top, content);
     }
 
     fn chartsCompact(ctx: *const zz.Context) bool {

--- a/examples/checkbox_radio.zig
+++ b/examples/checkbox_radio.zig
@@ -25,30 +25,30 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.agree_terms = zz.Checkbox.init("I agree to the terms");
         self.newsletter = zz.Checkbox.init("Subscribe to newsletter");
         self.newsletter.checked = true;
 
         self.languages = zz.CheckboxGroup(Language).init(ctx.persistent_allocator);
         self.languages.height = 6;
-        self.languages.addItems(&.{
+        try self.languages.addItems(&.{
             .{ .value = .zig, .label = "Zig", .description = "Systems programming", .enabled = true, .checked = false },
             .{ .value = .rust, .label = "Rust", .description = "Memory safe", .enabled = true, .checked = false },
             .{ .value = .go, .label = "Go", .description = "Concurrency", .enabled = true, .checked = false },
             .{ .value = .python, .label = "Python", .description = "Scripting", .enabled = true, .checked = false },
             .{ .value = .javascript, .label = "JavaScript", .description = "Web", .enabled = true, .checked = false },
             .{ .value = .c, .label = "C", .description = "Classic", .enabled = true, .checked = false },
-        }) catch {};
+        });
 
         self.experience = zz.RadioGroup(Experience).init(ctx.persistent_allocator);
         self.experience.height = 4;
-        self.experience.addOptions(&.{
+        try self.experience.addOptions(&.{
             .{ .value = .beginner, .label = "Beginner", .description = "", .enabled = true },
             .{ .value = .intermediate, .label = "Intermediate", .description = "", .enabled = true },
             .{ .value = .advanced, .label = "Advanced", .description = "", .enabled = true },
             .{ .value = .expert, .label = "Expert", .description = "", .enabled = true },
-        }) catch {};
+        });
 
         self.focus_group = .{};
         self.focus_group.add(&self.agree_terms);
@@ -80,7 +80,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
@@ -91,36 +91,33 @@ const Model = struct {
         section_style = section_style.fg(zz.Color.cyan);
         section_style = section_style.inline_style(true);
 
-        const title = title_style.render(ctx.allocator, "Checkbox & Radio Example") catch "Title";
+        const title = try title_style.render(ctx.allocator, "Checkbox & Radio Example");
 
         // Standalone checkboxes
-        const cb_title = section_style.render(ctx.allocator, "Preferences:") catch "Preferences:";
-        const terms_view = self.agree_terms.view(ctx.allocator) catch "error";
-        const news_view = self.newsletter.view(ctx.allocator) catch "error";
+        const cb_title = try section_style.render(ctx.allocator, "Preferences:");
+        const terms_view = try self.agree_terms.view(ctx.allocator);
+        const news_view = try self.newsletter.view(ctx.allocator);
 
         // Checkbox group
-        const lang_title = section_style.render(ctx.allocator, "Languages (Space to toggle, a/n/i: all/none/invert):") catch "Languages:";
-        const lang_view = self.languages.view(ctx.allocator) catch "error";
-        const lang_count = std.fmt.allocPrint(ctx.allocator, "Selected: {d}", .{self.languages.checkedCount()}) catch "?";
+        const lang_title = try section_style.render(ctx.allocator, "Languages (Space to toggle, a/n/i: all/none/invert):");
+        const lang_view = try self.languages.view(ctx.allocator);
+        const lang_count = try std.fmt.allocPrint(ctx.allocator, "Selected: {d}", .{self.languages.checkedCount()});
 
         // Radio group
-        const exp_title = section_style.render(ctx.allocator, "Experience Level (Space/Enter to select):") catch "Experience:";
-        const exp_view = self.experience.view(ctx.allocator) catch "error";
-        const exp_val = if (self.experience.selectedItem()) |item|
-            std.fmt.allocPrint(ctx.allocator, "Selected: {s}", .{item.label}) catch "?"
-        else
-            "None selected";
+        const exp_title = try section_style.render(ctx.allocator, "Experience Level (Space/Enter to select):");
+        const exp_view = try self.experience.view(ctx.allocator);
+        const exp_val = if (self.experience.selectedItem()) |item| try std.fmt.allocPrint(ctx.allocator, "Selected: {s}", .{item.label}) else "None selected";
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "Tab: switch focus | Space/Enter: toggle/select | q: quit") catch "";
+        const help = try help_style.render(ctx.allocator, "Tab: switch focus | Space/Enter: toggle/select | q: quit");
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n{s}\n{s}\n\n{s}\n{s}\n{s}\n\n{s}\n{s}\n{s}\n\n{s}",
             .{ title, cb_title, terms_view, news_view, lang_title, lang_view, lang_count, exp_title, exp_view, exp_val, help },
-        ) catch "Error";
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/clipboard_osc52.zig
+++ b/examples/clipboard_osc52.zig
@@ -150,7 +150,7 @@ const Model = struct {
         };
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
@@ -164,23 +164,23 @@ const Model = struct {
         hint_style = hint_style.fg(zz.Color.gray(12));
         hint_style = hint_style.inline_style(true);
 
-        const title = title_style.render(ctx.allocator, "OSC 52 Clipboard Demo") catch "OSC 52 Clipboard Demo";
-        const mode_line = std.fmt.allocPrint(ctx.allocator, "terminator={s}  passthrough={s}", .{
+        const title = try title_style.render(ctx.allocator, "OSC 52 Clipboard Demo");
+        const mode_line = try std.fmt.allocPrint(ctx.allocator, "terminator={s}  passthrough={s}", .{
             self.terminatorName(),
             self.passthroughName(),
-        }) catch "";
-        const mode = info_style.render(ctx.allocator, mode_line) catch mode_line;
-        const status = info_style.render(ctx.allocator, self.status) catch self.status;
-        const hints = hint_style.render(ctx.allocator, "c copy(default)  g read(query)  paste shortcut sends Msg.paste  1/2/3/4 target(c/p/q/s)  t terminator  p passthrough  q quit") catch "";
+        });
+        const mode = try info_style.render(ctx.allocator, mode_line);
+        const status = try info_style.render(ctx.allocator, self.status);
+        const hints = try hint_style.render(ctx.allocator, "c copy(default)  g read(query)  paste shortcut sends Msg.paste  1/2/3/4 target(c/p/q/s)  t terminator  p passthrough  q quit");
 
-        const content = std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}\n{s}\n\n{s}", .{
+        const content = try std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}\n{s}\n\n{s}", .{
             title,
             mode,
             status,
             hints,
-        }) catch "render error";
+        });
 
-        return zz.place.place(ctx.allocator, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(ctx.allocator, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/code_view.zig
+++ b/examples/code_view.zig
@@ -67,7 +67,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -93,22 +93,22 @@ const Model = struct {
         box_s = box_s.paddingAll(1);
 
         const code_output = cv.view(alloc);
-        const boxed = box_s.render(alloc, code_output) catch code_output;
+        const boxed = try box_s.render(alloc, code_output);
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const header = std.fmt.allocPrint(alloc, "{s}  [{s}]", .{
-            title_s.render(alloc, "Code Viewer") catch "Code Viewer",
+        const header = try std.fmt.allocPrint(alloc, "{s}  [{s}]", .{
+            try title_s.render(alloc, "Code Viewer"),
             lang_name,
-        }) catch "";
+        });
 
         return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{
             header,
             boxed,
-            help_s.render(alloc, "1: Zig  2: Python  Tab: switch  q: quit") catch "",
-        }) catch "Error";
+            try help_s.render(alloc, "1: Zig  2: Python  Tab: switch  q: quit"),
+        });
     }
 };
 

--- a/examples/context_menu.zig
+++ b/examples/context_menu.zig
@@ -82,60 +82,60 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Context Menu Example") catch "Context Menu";
+        const title = try title_style.render(ctx.allocator, "Context Menu Example");
 
         // File list
         var list_buf: Writer.Allocating = .init(ctx.allocator);
         const lw = &list_buf.writer;
         for (self.items, 0..) |item, i| {
-            if (i > 0) lw.writeByte('\n') catch {};
+            if (i > 0) try lw.writeByte('\n');
             if (i == self.selected) {
                 var sel_style = zz.Style{};
                 sel_style = sel_style.bold(true);
                 sel_style = sel_style.fg(zz.Color.cyan);
                 sel_style = sel_style.inline_style(true);
-                const line = std.fmt.allocPrint(ctx.allocator, "  > {s}", .{item}) catch "";
-                const styled = sel_style.render(ctx.allocator, line) catch line;
-                lw.writeAll(styled) catch {};
+                const line = try std.fmt.allocPrint(ctx.allocator, "  > {s}", .{item});
+                const styled = try sel_style.render(ctx.allocator, line);
+                try lw.writeAll(styled);
             } else {
-                const line = std.fmt.allocPrint(ctx.allocator, "    {s}", .{item}) catch "";
-                lw.writeAll(line) catch {};
+                const line = try std.fmt.allocPrint(ctx.allocator, "    {s}", .{item});
+                try lw.writeAll(line);
             }
         }
-        const file_list = list_buf.toOwnedSlice() catch "";
+        const file_list = try list_buf.toOwnedSlice();
 
         // Status
         var status_style = zz.Style{};
         status_style = status_style.fg(zz.Color.green);
         status_style = status_style.inline_style(true);
-        const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;
+        const styled_status = try status_style.render(ctx.allocator, self.status);
 
         // Context menu overlay
-        const menu_view = self.menu.view(ctx.allocator) catch "";
+        const menu_view = try self.menu.view(ctx.allocator);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "Up/Down: navigate | Space/Enter: context menu | Esc: close | q: quit") catch "";
+        const help = try help_style.render(ctx.allocator, "Up/Down: navigate | Space/Enter: context menu | Esc: close | q: quit");
 
         if (self.menu.isVisible()) {
             return std.fmt.allocPrint(
                 ctx.allocator,
                 "{s}\n\n{s}\n\n{s}\n\n{s}\n\n{s}",
                 .{ title, file_list, menu_view, styled_status, help },
-            ) catch "Error";
+            );
         }
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{ title, file_list, styled_status, help },
-        ) catch "Error";
+        );
     }
 };
 

--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -81,35 +81,35 @@ const Model = struct {
         return zz.Cmd(Msg).tickMs(16);
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.hex("#FF6B6B"));
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Dashboard") catch "Dashboard";
+        const title = try title_style.render(ctx.allocator, "Dashboard");
 
         // Stats section
-        const stats_box = self.renderStats(ctx) catch "";
+        const stats_box = try self.renderStats(ctx);
 
         // Progress section
-        const progress_box = self.renderProgress(ctx) catch "";
+        const progress_box = try self.renderProgress(ctx);
 
         // Activity section
-        const activity_box = self.renderActivity(ctx) catch "";
+        const activity_box = try self.renderActivity(ctx);
 
         // Layout - join horizontally
-        const top_row = zz.joinHorizontal(ctx.allocator, &.{ stats_box, "  ", progress_box }) catch stats_box;
-        const main_content = zz.joinVertical(ctx.allocator, &.{ top_row, "", activity_box }) catch top_row;
+        const top_row = try zz.joinHorizontal(ctx.allocator, &.{ stats_box, "  ", progress_box });
+        const main_content = try zz.joinVertical(ctx.allocator, &.{ top_row, "", activity_box });
 
         // Help
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Space: Pause/Resume timer  r: Reset  q: Quit",
-        ) catch "";
+        );
 
         // Get max width for centering
         const main_width = zz.measure.maxLineWidth(main_content);
@@ -118,15 +118,15 @@ const Model = struct {
         const max_width = @max(main_width, @max(title_width, help_width));
 
         // Center elements
-        const centered_title = zz.place.place(ctx.allocator, max_width, 1, .center, .top, title) catch title;
-        const centered_main = zz.place.place(ctx.allocator, max_width, zz.measure.height(main_content), .center, .top, main_content) catch main_content;
-        const centered_help = zz.place.place(ctx.allocator, max_width, 1, .center, .top, help) catch help;
+        const centered_title = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, title);
+        const centered_main = try zz.place.place(ctx.allocator, max_width, zz.measure.height(main_content), .center, .top, main_content);
+        const centered_help = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, help);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}",
             .{ centered_title, centered_main, centered_help },
-        ) catch "Error";
+        );
 
         // Center in terminal
         return zz.place.place(
@@ -136,7 +136,7 @@ const Model = struct {
             .center,
             .middle,
             content,
-        ) catch content;
+        );
     }
 
     fn renderStats(self: *const Model, ctx: *const zz.Context) ![]const u8 {

--- a/examples/data_table.zig
+++ b/examples/data_table.zig
@@ -35,10 +35,10 @@ const Model = struct {
         &.{ "10", "Judy", "Platform", "Tokyo", "Engineer", "3y", "4.2", "$118k" },
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         var t = zz.components.DataTable.init(ctx.persistent_allocator);
         t.setColumns(&headers) catch return .quit;
-        for (rows) |r| t.addRow(r) catch {};
+        for (rows) |r| try t.addRow(r);
         t.setSize(60, 15);
         t.setFrozenColumns(2); // id + name stay visible while you scroll right.
         self.* = .{ .table = t };
@@ -61,29 +61,29 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(alloc, "DataTable — frozen columns + cell cursor") catch "";
+        const title = try title_style.render(alloc, "DataTable — frozen columns + cell cursor");
 
         var table_mut = @constCast(&self.table);
-        const table_view = table_mut.view(alloc) catch "";
+        const table_view = try table_mut.view(alloc);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(10));
         help_style = help_style.inline_style(true);
-        const help_text = std.fmt.allocPrint(
+        const help_text = try std.fmt.allocPrint(
             alloc,
             "cursor row {d}, col {d}   |   ←→↑↓ / hjkl move   home/end col   g/G row   q quit",
             .{ self.table.cursor_row, self.table.cursor_col },
-        ) catch "";
-        const help = help_style.render(alloc, help_text) catch "";
+        );
+        const help = try help_style.render(alloc, help_text);
 
-        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ title, table_view, help }) catch "Error";
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ title, table_view, help });
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/dev_console.zig
+++ b/examples/dev_console.zig
@@ -58,16 +58,16 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title = zz.Style{};
         title = title.bold(true);
         title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
-        const t = title.render(alloc, "DevConsole — log streamer") catch "";
+        const t = try title.render(alloc, "DevConsole — log streamer");
 
-        const body = std.fmt.allocPrint(
+        const body = try std.fmt.allocPrint(
             alloc,
             \\Counter: {d}
             \\
@@ -82,20 +82,20 @@ const Model = struct {
             \\You'll see entries stream in as you press keys here.
         ,
             .{self.counter},
-        ) catch "";
+        );
 
         var box = zz.Style{};
         box = box.borderAll(zz.Border.rounded);
         box = box.borderForeground(zz.Color.gray(8));
         box = box.paddingAll(1);
-        const boxed = box.render(alloc, body) catch body;
+        const boxed = try box.render(alloc, body);
 
         var help = zz.Style{};
         help = help.fg(zz.Color.gray(10));
         help = help.inline_style(true);
-        const help_str = help.render(alloc, "space warn · r reset · q quit") catch "";
+        const help_str = try help.render(alloc, "space warn · r reset · q quit");
 
-        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str }) catch "Error";
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}", .{ t, boxed, help_str });
     }
 };
 

--- a/examples/diff_view.zig
+++ b/examples/diff_view.zig
@@ -58,7 +58,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -79,7 +79,7 @@ const Model = struct {
         box_s = box_s.paddingAll(1);
 
         const diff_output = dv.view(alloc);
-        const boxed = box_s.render(alloc, diff_output) catch diff_output;
+        const boxed = try box_s.render(alloc, diff_output);
 
         const mode_label: []const u8 = if (self.side_by_side) "side-by-side" else "unified";
 
@@ -88,11 +88,11 @@ const Model = struct {
         help_s = help_s.inline_style(true);
 
         return std.fmt.allocPrint(alloc, "{s}  [{s}]\n\n{s}\n\n{s}", .{
-            title_s.render(alloc, "Diff Viewer") catch "Diff Viewer",
+            try title_s.render(alloc, "Diff Viewer"),
             mode_label,
             boxed,
-            help_s.render(alloc, "m: toggle mode  q: quit") catch "",
-        }) catch "Error";
+            try help_s.render(alloc, "m: toggle mode  q: quit"),
+        });
     }
 };
 

--- a/examples/dropdown.zig
+++ b/examples/dropdown.zig
@@ -19,11 +19,11 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.color_dropdown = zz.Dropdown(Color).init(ctx.persistent_allocator);
         self.color_dropdown.label = "Color:";
         self.color_dropdown.placeholder = "Pick a color...";
-        self.color_dropdown.addItems(&.{
+        try self.color_dropdown.addItems(&.{
             .{ .value = .red, .label = "Red", .description = "", .enabled = true },
             .{ .value = .green, .label = "Green", .description = "", .enabled = true },
             .{ .value = .blue, .label = "Blue", .description = "", .enabled = true },
@@ -31,7 +31,7 @@ const Model = struct {
             .{ .value = .magenta, .label = "Magenta", .description = "", .enabled = true },
             .{ .value = .cyan, .label = "Cyan", .description = "", .enabled = true },
             .{ .value = .white, .label = "White", .description = "", .enabled = false },
-        }) catch {};
+        });
 
         self.topping_dropdown = zz.Dropdown(Topping).init(ctx.persistent_allocator);
         self.topping_dropdown.label = "Toppings:";
@@ -39,7 +39,7 @@ const Model = struct {
         self.topping_dropdown.multi_select = true;
         self.topping_dropdown.close_on_select = false;
         self.topping_dropdown.max_visible = 5;
-        self.topping_dropdown.addItems(&.{
+        try self.topping_dropdown.addItems(&.{
             .{ .value = .cheese, .label = "Cheese", .description = "", .enabled = true },
             .{ .value = .pepperoni, .label = "Pepperoni", .description = "", .enabled = true },
             .{ .value = .mushrooms, .label = "Mushrooms", .description = "", .enabled = true },
@@ -48,7 +48,7 @@ const Model = struct {
             .{ .value = .olives, .label = "Olives", .description = "", .enabled = true },
             .{ .value = .bacon, .label = "Bacon", .description = "", .enabled = true },
             .{ .value = .pineapple, .label = "Pineapple", .description = "", .enabled = true },
-        }) catch {};
+        });
 
         self.focus_group = .{};
         self.focus_group.add(&self.color_dropdown);
@@ -79,38 +79,35 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Dropdown Example") catch "Dropdown Example";
+        const title = try title_style.render(ctx.allocator, "Dropdown Example");
 
-        const color_view = self.color_dropdown.view(ctx.allocator) catch "error";
-        const topping_view = self.topping_dropdown.view(ctx.allocator) catch "error";
+        const color_view = try self.color_dropdown.view(ctx.allocator);
+        const topping_view = try self.topping_dropdown.view(ctx.allocator);
 
         // Selection info
-        const color_info = if (self.color_dropdown.selectedItem()) |item|
-            std.fmt.allocPrint(ctx.allocator, "Selected color: {s}", .{item.label}) catch "?"
-        else
-            "No color selected";
+        const color_info = if (self.color_dropdown.selectedItem()) |item| try std.fmt.allocPrint(ctx.allocator, "Selected color: {s}", .{item.label}) else "No color selected";
 
         const topping_count = self.topping_dropdown.selected_indices.count();
-        const topping_info = std.fmt.allocPrint(ctx.allocator, "Selected toppings: {d}", .{topping_count}) catch "?";
+        const topping_info = try std.fmt.allocPrint(ctx.allocator, "Selected toppings: {d}", .{topping_count});
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Tab: switch | Enter/Space: open/select | Esc: close | /: filter | q: quit",
-        ) catch "";
+        );
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n{s}\n\n{s}\n{s}\n\n{s}",
             .{ title, color_view, color_info, topping_view, topping_info, help },
-        ) catch "Error";
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/file_browser.zig
+++ b/examples/file_browser.zig
@@ -13,14 +13,14 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.file_picker = zz.components.FilePicker.init(ctx.persistent_allocator);
         self.file_picker.height = ctx.height -| 10;
         self.file_picker.setHomePath(ctx.home_dir);
 
         // Start at home directory
         self.file_picker.navigateHome(ctx.io) catch {
-            self.file_picker.navigate(ctx.io, "/") catch {};
+            try self.file_picker.navigate(ctx.io, "/");
         };
 
         self.preview = std.array_list.Managed(u8).init(ctx.persistent_allocator);
@@ -85,16 +85,16 @@ const Model = struct {
         }
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "File Browser") catch "File Browser";
+        const title = try title_style.render(ctx.allocator, "File Browser");
 
         // File picker
-        const picker_view = self.file_picker.view(ctx.allocator) catch "";
+        const picker_view = try self.file_picker.view(ctx.allocator);
 
         // Preview section
         var preview_section: []const u8 = "";
@@ -102,7 +102,7 @@ const Model = struct {
             var path_style = zz.Style{};
             path_style = path_style.fg(zz.Color.green);
             path_style = path_style.inline_style(true);
-            const path_display = path_style.render(ctx.allocator, path) catch path;
+            const path_display = try path_style.render(ctx.allocator, path);
 
             var preview_style = zz.Style{};
             preview_style = preview_style.borderAll(zz.Border.normal);
@@ -115,23 +115,23 @@ const Model = struct {
             else
                 "(empty file)";
 
-            const preview_box = preview_style.render(ctx.allocator, preview_content) catch preview_content;
+            const preview_box = try preview_style.render(ctx.allocator, preview_content);
 
-            preview_section = std.fmt.allocPrint(
+            preview_section = try std.fmt.allocPrint(
                 ctx.allocator,
                 "\nSelected: {s}\n\n{s}",
                 .{ path_display, preview_box },
-            ) catch "";
+            );
         }
 
         // Help
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Up/Down: Navigate  Enter: Open/Select  Backspace: Parent  h: Toggle hidden  ~: Home  q: Quit",
-        ) catch "";
+        );
 
         // Get max width for centering title and help
         const picker_width = zz.measure.maxLineWidth(picker_view);
@@ -140,16 +140,16 @@ const Model = struct {
         const max_width = @max(picker_width, @max(title_width, help_width));
 
         // Center title and help
-        const centered_title = zz.place.place(ctx.allocator, max_width, 1, .center, .top, title) catch title;
-        const centered_help = zz.place.place(ctx.allocator, max_width, 1, .center, .top, help) catch help;
+        const centered_title = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, title);
+        const centered_help = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, help);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}{s}\n\n{s}",
             .{ centered_title, picker_view, preview_section, centered_help },
-        ) catch "Error";
+        );
 
-        // Center horizontally, but keep at top vertically (file browser needs vertical space)
+        // Center horizontally but keep at top vertically (file browser needs vertical space)
         return zz.place.place(
             ctx.allocator,
             ctx.width,
@@ -157,7 +157,7 @@ const Model = struct {
             .center,
             .top,
             content,
-        ) catch content;
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/flex_layout.zig
+++ b/examples/flex_layout.zig
@@ -37,7 +37,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
         const w: u16 = @intCast(@min(ctx.width, std.math.maxInt(u16)));
         const h: u16 = @intCast(@min(ctx.height, std.math.maxInt(u16)));
@@ -80,14 +80,14 @@ const Model = struct {
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const footer_text = help_style.render(alloc, "Tab: cycle panels  1/2/3: select panel  q: quit") catch "Tab: cycle  q: quit";
+        const footer_text = try help_style.render(alloc, "Tab: cycle panels  1/2/3: select panel  q: quit");
         const footer = renderPanel(alloc, footer_text, rows[2].width, rows[2].height, zz.Color.gray(8), false);
 
         // Compose the body row: sidebar | main
-        const body = zz.join.horizontal(alloc, .top, &.{ sidebar, main_panel }) catch main_panel;
+        const body = try zz.join.horizontal(alloc, .top, &.{ sidebar, main_panel });
 
         // Stack vertically
-        return zz.join.vertical(alloc, .left, &.{ header, body, footer }) catch "render error";
+        return zz.join.vertical(alloc, .left, &.{ header, body, footer });
     }
 
     fn renderPanel(alloc: std.mem.Allocator, content: []const u8, w: u16, h: u16, border_color: zz.Color, highlight: bool) []const u8 {

--- a/examples/focus_form.zig
+++ b/examples/focus_form.zig
@@ -81,19 +81,19 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.hex("#FF6B6B"));
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Contact Form") catch "Contact Form";
+        const title = try title_style.render(ctx.allocator, "Contact Form");
 
         // Subtitle
         var sub_style = zz.Style{};
         sub_style = sub_style.fg(zz.Color.gray(15));
         sub_style = sub_style.inline_style(true);
-        const subtitle = sub_style.render(ctx.allocator, "Tab/Shift+Tab to navigate • Enter to submit • Esc to quit") catch "";
+        const subtitle = try sub_style.render(ctx.allocator, "Tab/Shift+Tab to navigate • Enter to submit • Esc to quit");
 
         // Field labels
         var label_style = zz.Style{};
@@ -107,24 +107,24 @@ const Model = struct {
 
         // Render each field with focus indicator
         const name_label = if (self.focus_group.isFocused(0))
-            focused_label.render(ctx.allocator, "▸ Name") catch "Name"
+            try focused_label.render(ctx.allocator, "▸ Name")
         else
-            label_style.render(ctx.allocator, "  Name") catch "Name";
+            try label_style.render(ctx.allocator, "  Name");
 
         const email_label = if (self.focus_group.isFocused(1))
-            focused_label.render(ctx.allocator, "▸ Email") catch "Email"
+            try focused_label.render(ctx.allocator, "▸ Email")
         else
-            label_style.render(ctx.allocator, "  Email") catch "Email";
+            try label_style.render(ctx.allocator, "  Email");
 
         const message_label = if (self.focus_group.isFocused(2))
-            focused_label.render(ctx.allocator, "▸ Message") catch "Message"
+            try focused_label.render(ctx.allocator, "▸ Message")
         else
-            label_style.render(ctx.allocator, "  Message") catch "Message";
+            try label_style.render(ctx.allocator, "  Message");
 
         // Render inputs
-        const name_view = self.name_input.view(ctx.allocator) catch "";
-        const email_view = self.email_input.view(ctx.allocator) catch "";
-        const message_view = self.message_input.view(ctx.allocator) catch "";
+        const name_view = try self.name_input.view(ctx.allocator);
+        const email_view = try self.email_input.view(ctx.allocator);
+        const message_view = try self.message_input.view(ctx.allocator);
 
         // Wrap each input in a focus-styled box
         const name_box = self.renderField(ctx, name_label, name_view, 0);
@@ -142,7 +142,7 @@ const Model = struct {
             const email_val = self.email_input.getValue();
             const msg_val = self.message_input.getValue();
 
-            const text = std.fmt.allocPrint(
+            const text = try std.fmt.allocPrint(
                 ctx.allocator,
                 "✓ Submitted! Name: {s}, Email: {s}, Message: {s}",
                 .{
@@ -150,8 +150,8 @@ const Model = struct {
                     if (email_val.len > 0) email_val else "(empty)",
                     if (msg_val.len > 0) msg_val else "(empty)",
                 },
-            ) catch "✓ Submitted!";
-            break :blk success_style.render(ctx.allocator, text) catch text;
+            );
+            break :blk try success_style.render(ctx.allocator, text);
         } else blk: {
             var hint_style = zz.Style{};
             hint_style = hint_style.fg(zz.Color.gray(12));
@@ -162,12 +162,12 @@ const Model = struct {
                 2 => "Message",
                 else => "?",
             };
-            const text = std.fmt.allocPrint(
+            const text = try std.fmt.allocPrint(
                 ctx.allocator,
                 "Editing: {s} (field {d}/{d})",
                 .{ field_name, self.focus_group.focused() + 1, self.focus_group.len() },
-            ) catch "";
-            break :blk hint_style.render(ctx.allocator, text) catch text;
+            );
+            break :blk try hint_style.render(ctx.allocator, text);
         };
 
         // Get max width
@@ -178,15 +178,15 @@ const Model = struct {
         const max_width = @max(box_width, @max(zz.measure.width(title), zz.measure.width(subtitle)));
 
         // Center elements
-        const centered_title = zz.place.place(ctx.allocator, max_width, 1, .center, .top, title) catch title;
-        const centered_sub = zz.place.place(ctx.allocator, max_width, 1, .center, .top, subtitle) catch subtitle;
-        const centered_status = zz.place.place(ctx.allocator, max_width, 1, .center, .top, status) catch status;
+        const centered_title = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, title);
+        const centered_sub = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, subtitle);
+        const centered_status = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, status);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n{s}\n\n{s}\n{s}\n{s}\n\n{s}",
             .{ centered_title, centered_sub, name_box, email_box, message_box, centered_status },
-        ) catch "Error rendering view";
+        );
 
         return zz.place.place(
             ctx.allocator,
@@ -195,7 +195,7 @@ const Model = struct {
             .center,
             .middle,
             content,
-        ) catch content;
+        );
     }
 
     fn renderField(self: *const Model, ctx: *const zz.Context, label: []const u8, input_view: []const u8, index: usize) []const u8 {

--- a/examples/form.zig
+++ b/examples/form.zig
@@ -56,20 +56,20 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const form_view = self.form.view(ctx.allocator) catch "error";
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+        const form_view = try self.form.view(ctx.allocator);
 
         var status_style = zz.Style{};
         status_style = status_style.fg(zz.Color.green);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
-        const styled_status = status_style.render(ctx.allocator, self.status) catch self.status;
+        const styled_status = try status_style.render(ctx.allocator, self.status);
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}",
             .{ form_view, styled_status },
-        ) catch "Error";
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/gauge.zig
+++ b/examples/gauge.zig
@@ -43,14 +43,14 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
         title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
-        const title = title_s.render(alloc, "Gauge Component Demo") catch "Gauge Demo";
+        const title = try title_s.render(alloc, "Gauge Component Demo");
 
         const thresholds = &[_]zz.Gauge.Threshold{
             .{ .value = 70, .color = zz.Color.yellow },
@@ -90,7 +90,7 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}\n\n{s}\n\n{s}",
             .{
@@ -98,11 +98,11 @@ const Model = struct {
                 bar_view,
                 level_view,
                 blocks_view,
-                help_s.render(alloc, "Up/Down: adjust  r: reset  q: quit") catch "",
+                try help_s.render(alloc, "Up/Down: adjust  r: reset  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/heatmap.zig
+++ b/examples/heatmap.zig
@@ -25,7 +25,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(_: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(_: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         // Activity heatmap (7 days x 12 weeks)
@@ -69,11 +69,11 @@ const Model = struct {
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(alloc, "{s}\n\n\n{s}\n\n{s}", .{
+        const content = try std.fmt.allocPrint(alloc, "{s}\n\n\n{s}\n\n{s}", .{
             activity_view,
             load_view,
-            help_s.render(alloc, "Press q to quit") catch "",
-        }) catch "Error";
+            try help_s.render(alloc, "Press q to quit"),
+        });
 
         return content;
     }

--- a/examples/layers.zig
+++ b/examples/layers.zig
@@ -41,7 +41,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
         const w: u16 = @intCast(@min(ctx.width, std.math.maxInt(u16)));
         const h: u16 = @intCast(@min(ctx.height, std.math.maxInt(u16)));
@@ -56,13 +56,13 @@ const Model = struct {
 
         var bg_content = std.array_list.Managed(u8).init(alloc);
         for (0..h) |row| {
-            if (row > 0) bg_content.append('\n') catch {};
+            if (row > 0) try bg_content.append('\n');
             for (0..w) |col| {
                 const c: u8 = if ((row + col) % 2 == 0) '.' else ' ';
-                bg_content.append(c) catch {};
+                try bg_content.append(c);
             }
         }
-        stack.push(.{ .content = bg_content.items, .z = 0, .transparent = false }) catch {};
+        try stack.push(.{ .content = bg_content.items, .z = 0, .transparent = false });
 
         // Main info panel (z=1)
         var info_style = zz.Style{};
@@ -73,8 +73,8 @@ const Model = struct {
         info_style = info_style.height(8);
 
         const info_text = "Layer Compositing Demo\n\np: toggle popup\nt: toggle tooltip\nq: quit";
-        const info_panel = info_style.render(alloc, info_text) catch info_text;
-        stack.push(.{ .content = info_panel, .x = 5, .y = 2, .z = 1 }) catch {};
+        const info_panel = try info_style.render(alloc, info_text);
+        try stack.push(.{ .content = info_panel, .x = 5, .y = 2, .z = 1 });
 
         // Popup (z=10)
         if (self.show_popup) {
@@ -86,10 +86,10 @@ const Model = struct {
             popup_style = popup_style.height(5);
 
             const popup_text = "Modal Popup\n\nThis is on top!\nEsc to close";
-            const popup = popup_style.render(alloc, popup_text) catch popup_text;
+            const popup = try popup_style.render(alloc, popup_text);
             const px: u16 = if (w > 34) (w - 34) / 2 else 0;
             const py: u16 = if (h > 9) (h - 9) / 2 else 0;
-            stack.push(.{ .content = popup, .x = px, .y = py, .z = 10 }) catch {};
+            try stack.push(.{ .content = popup, .x = px, .y = py, .z = 10 });
         }
 
         // Tooltip (z=20)
@@ -99,8 +99,8 @@ const Model = struct {
             tt_style = tt_style.borderForeground(zz.Color.green);
             tt_style = tt_style.width(20);
 
-            const tt = tt_style.render(alloc, "Tooltip z=20") catch "tooltip";
-            stack.push(.{ .content = tt, .x = 15, .y = 5, .z = 20 }) catch {};
+            const tt = try tt_style.render(alloc, "Tooltip z=20");
+            try stack.push(.{ .content = tt, .x = 15, .y = 5, .z = 20 });
         }
 
         return stack.render(alloc);

--- a/examples/markdown.zig
+++ b/examples/markdown.zig
@@ -48,7 +48,7 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.md = zz.Markdown.init();
         self.md.width = @min(ctx.width -| 4, 80);
 
@@ -56,9 +56,9 @@ const Model = struct {
         // Viewport.setContent dupes; render output is ephemeral.
         if (self.md.render(ctx.persistent_allocator, sample_md)) |rendered| {
             defer ctx.persistent_allocator.free(rendered);
-            self.viewport.setContent(rendered) catch {};
+            try self.viewport.setContent(rendered);
         } else |_| {
-            self.viewport.setContent("render error") catch {};
+            try self.viewport.setContent("render error");
         }
 
         return .none;
@@ -78,15 +78,15 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const content = self.viewport.view(ctx.allocator) catch "error";
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+        const content = try self.viewport.view(ctx.allocator);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "j/k or Up/Down: scroll | q: quit") catch "";
+        const help = try help_style.render(ctx.allocator, "j/k or Up/Down: scroll | q: quit");
 
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ content, help }) catch "Error";
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n{s}", .{ content, help });
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/menu_bar.zig
+++ b/examples/menu_bar.zig
@@ -123,35 +123,35 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const menu_view = self.menu.view(ctx.allocator, ctx.width) catch "error";
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+        const menu_view = try self.menu.view(ctx.allocator, ctx.width);
 
         var content_style = zz.Style{};
         content_style = content_style.fg(zz.Color.gray(16));
         content_style = content_style.inline_style(true);
 
-        const content = content_style.render(
+        const content = try content_style.render(
             ctx.allocator,
             "Press F9 or Alt+F/E/V/H to open menus\nUse arrow keys to navigate, Enter to select",
-        ) catch "";
+        );
 
         var status_style = zz.Style{};
         status_style = status_style.fg(zz.Color.cyan);
         status_style = status_style.bold(true);
         status_style = status_style.inline_style(true);
-        const status = std.fmt.allocPrint(ctx.allocator, "Status: {s}", .{self.status}) catch "?";
-        const styled_status = status_style.render(ctx.allocator, status) catch status;
+        const status = try std.fmt.allocPrint(ctx.allocator, "Status: {s}", .{self.status});
+        const styled_status = try status_style.render(ctx.allocator, status);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator, "F9: activate menu | Alt+letter: open menu | q/Esc: quit") catch "";
+        const help = try help_style.render(ctx.allocator, "F9: activate menu | Alt+letter: open menu | q/Esc: quit");
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}\n\n{s}",
             .{ menu_view, content, styled_status, help },
-        ) catch "Error";
+        );
     }
 };
 

--- a/examples/modal.zig
+++ b/examples/modal.zig
@@ -110,12 +110,12 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         // If modal is visible, render it with backdrop
         if (self.modal.isVisible()) {
-            return self.modal.viewWithBackdrop(alloc, ctx.width, ctx.height) catch "Error";
+            return self.modal.viewWithBackdrop(alloc, ctx.width, ctx.height);
         }
 
         // Main view
@@ -131,16 +131,16 @@ const Model = struct {
         var status_s = zz.Style{};
         status_s = status_s.fg(zz.Color.gray(12)).inline_style(true);
 
-        const title = title_s.render(alloc, "Modal Component Demo") catch "Modal Component Demo";
-        const hint = hint_s.render(alloc, "1: Info  2: Confirm  3: Warning  4: Error  5: Custom  q: Quit") catch "";
-        const result_label = result_s.render(alloc, std.fmt.allocPrint(alloc, "Last result: {s}", .{self.last_result}) catch "") catch "";
-        const status = status_s.render(alloc, self.status) catch "";
+        const title = try title_s.render(alloc, "Modal Component Demo");
+        const hint = try hint_s.render(alloc, "1: Info  2: Confirm  3: Warning  4: Error  5: Custom  q: Quit");
+        const result_label = try result_s.render(alloc, try std.fmt.allocPrint(alloc, "Last result: {s}", .{self.last_result}));
+        const status = try status_s.render(alloc, self.status);
 
-        const content = std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}\n{s}", .{
+        const content = try std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}\n{s}", .{
             title, hint, result_label, status,
-        }) catch "Error";
+        });
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/mouse.zig
+++ b/examples/mouse.zig
@@ -88,24 +88,24 @@ const Model = struct {
         return zz.HitBox.init(x, 4, 14, 3);
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.white);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Mouse Demo") catch "Mouse Demo";
+        const title = try title_style.render(ctx.allocator, "Mouse Demo");
 
-        const coords = std.fmt.allocPrint(
+        const coords = try std.fmt.allocPrint(
             ctx.allocator,
             "Mouse: ({d}, {d})  |  {s}",
             .{ self.mouse_x, self.mouse_y, self.last_event },
-        ) catch "";
+        );
 
-        const count_str = std.fmt.allocPrint(
+        const count_str = try std.fmt.allocPrint(
             ctx.allocator,
             "Click count: {d}",
             .{self.click_count},
-        ) catch "";
+        );
 
         // Render each button as its own bordered box, then place the boxes
         // side by side with joinHorizontal. Each box is multi-line, so simply
@@ -122,22 +122,22 @@ const Model = struct {
             }
             s = s.fg(btn.color);
             s = s.inline_style(false);
-            boxes[i] = s.render(ctx.allocator, btn.label) catch btn.label;
+            boxes[i] = try s.render(ctx.allocator, btn.label);
         }
-        const buttons = zz.joinHorizontal(ctx.allocator, &.{
+        const buttons = try zz.joinHorizontal(ctx.allocator, &.{
             boxes[0], "  ", boxes[1], "  ", boxes[2],
-        }) catch boxes[0];
+        });
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(12));
         help_s = help_s.inline_style(true);
-        const help = help_s.render(ctx.allocator, "Click the buttons above | q: quit") catch "";
+        const help = try help_s.render(ctx.allocator, "Click the buttons above | q: quit");
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n{s}\n{s}\n\n{s}\n\n{s}",
             .{ title, coords, count_str, buttons, help },
-        ) catch "Error";
+        );
     }
 };
 

--- a/examples/rich_log.zig
+++ b/examples/rich_log.zig
@@ -15,16 +15,16 @@ const Model = struct {
         tick: zz.msg.Tick,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         var log = zz.components.RichLog.init(ctx.persistent_allocator, 500);
         log.setSize(80, 14);
         log.show_timestamps = true;
 
-        // Seed with a few entries.
-        log.append(ctx.io, .info, "RichLog example started") catch {};
-        log.append(ctx.io, .debug, "buffer capacity = 500 entries") catch {};
-        log.append(ctx.io, .info, "follow-mode enabled — new entries scroll into view") catch {};
-        log.append(ctx.io, .warn, "press '/' to filter, 'l' to cycle min level") catch {};
+        try // Seed with a few entries.
+        log.append(ctx.io, .info, "RichLog example started");
+        try log.append(ctx.io, .debug, "buffer capacity = 500 entries");
+        try log.append(ctx.io, .info, "follow-mode enabled — new entries scroll into view");
+        try log.append(ctx.io, .warn, "press '/' to filter, 'l' to cycle min level");
 
         self.* = .{
             .log = log,
@@ -116,26 +116,26 @@ const Model = struct {
         }
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
         var log_mut = @constCast(&self.log);
-        const log_view = log_mut.view(alloc) catch "";
+        const log_view = try log_mut.view(alloc);
 
         var box = zz.Style{};
         box = box.borderAll(zz.Border.rounded);
         box = box.borderForeground(zz.Color.gray(8));
-        const boxed = box.render(alloc, log_view) catch log_view;
+        const boxed = try box.render(alloc, log_view);
 
         var title = zz.Style{};
         title = title.bold(true);
         title = title.fg(zz.Color.cyan);
         title = title.inline_style(true);
-        const t = title.render(alloc, "RichLog — append-only with level filter & search") catch "";
+        const t = try title.render(alloc, "RichLog — append-only with level filter & search");
 
         const status = if (self.typing_search)
-            std.fmt.allocPrint(alloc, "search: {s}_  (enter to apply, esc to cancel)", .{self.search_term.items}) catch ""
+            try std.fmt.allocPrint(alloc, "search: {s}_  (enter to apply, esc to cancel)", .{self.search_term.items})
         else
-            std.fmt.allocPrint(
+            try std.fmt.allocPrint(
                 alloc,
                 "follow={s}  level≥{s}  search={s}",
                 .{
@@ -143,20 +143,20 @@ const Model = struct {
                     self.log.min_level.label(),
                     if (self.log.search_term.items.len == 0) "—" else self.log.search_term.items,
                 },
-            ) catch "";
+            );
 
         var status_style = zz.Style{};
         status_style = status_style.fg(zz.Color.gray(12));
         status_style = status_style.inline_style(true);
-        const status_str = status_style.render(alloc, status) catch "";
+        const status_str = try status_style.render(alloc, status);
 
         var help = zz.Style{};
         help = help.fg(zz.Color.gray(10));
         help = help.inline_style(true);
         const help_text = "↑↓ scroll · g/G top/bottom · / search · c clear · l cycle level · q quit";
-        const help_str = help.render(alloc, help_text) catch "";
+        const help_str = try help.render(alloc, help_text);
 
-        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}\n{s}", .{ t, boxed, status_str, help_str }) catch "Error";
+        return std.fmt.allocPrint(alloc, "{s}\n\n{s}\n\n{s}\n{s}", .{ t, boxed, status_str, help_str });
     }
 };
 

--- a/examples/screen_stack.zig
+++ b/examples/screen_stack.zig
@@ -159,24 +159,24 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const view_str = self.stack.view(ctx, ctx.allocator) catch "Error";
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+        const view_str = try self.stack.view(ctx, ctx.allocator);
 
         var trail: Writer.Allocating = .init(ctx.allocator);
         defer trail.deinit();
         const w = &trail.writer;
-        w.writeAll("stack: ") catch {};
+        try w.writeAll("stack: ");
         for (self.stack.stack.items, 0..) |s, i| {
-            if (i > 0) w.writeAll(" › ") catch {};
-            w.writeAll(s.title) catch {};
+            if (i > 0) try w.writeAll(" › ");
+            try w.writeAll(s.title);
         }
 
         var trail_style = zz.Style{};
         trail_style = trail_style.fg(zz.Color.gray(10));
         trail_style = trail_style.inline_style(true);
-        const trail_str = trail_style.render(ctx.allocator, trail.writer.buffered()) catch "";
+        const trail_str = try trail_style.render(ctx.allocator, trail.writer.buffered());
 
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ trail_str, view_str }) catch view_str;
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ trail_str, view_str });
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/showcase.zig
+++ b/examples/showcase.zig
@@ -72,7 +72,7 @@ const Model = struct {
         window_size: struct { width: u16, height: u16 },
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         // Dashboard
         self.spinner = zz.Spinner.init();
         self.spinner.setFrames(zz.Spinner.Styles.dots);
@@ -161,16 +161,16 @@ const Model = struct {
         self.table.alt_row_style = alt_style;
         self.table.visible_rows = 8;
 
-        self.table.addRow(.{ "web-01", "online", "45d 3h", "0.42" }) catch {};
-        self.table.addRow(.{ "web-02", "online", "45d 3h", "0.38" }) catch {};
-        self.table.addRow(.{ "db-01", "online", "120d 7h", "0.71" }) catch {};
-        self.table.addRow(.{ "db-02", "standby", "120d 7h", "0.12" }) catch {};
-        self.table.addRow(.{ "cache-01", "online", "30d 2h", "0.55" }) catch {};
-        self.table.addRow(.{ "cache-02", "warning", "30d 2h", "0.89" }) catch {};
-        self.table.addRow(.{ "worker-01", "online", "15d 8h", "0.63" }) catch {};
-        self.table.addRow(.{ "worker-02", "offline", "0d 0h", "0.00" }) catch {};
-        self.table.addRow(.{ "monitor", "online", "60d 1h", "0.22" }) catch {};
-        self.table.addRow(.{ "lb-01", "online", "90d 5h", "0.45" }) catch {};
+        try self.table.addRow(.{ "web-01", "online", "45d 3h", "0.42" });
+        try self.table.addRow(.{ "web-02", "online", "45d 3h", "0.38" });
+        try self.table.addRow(.{ "db-01", "online", "120d 7h", "0.71" });
+        try self.table.addRow(.{ "db-02", "standby", "120d 7h", "0.12" });
+        try self.table.addRow(.{ "cache-01", "online", "30d 2h", "0.55" });
+        try self.table.addRow(.{ "cache-02", "warning", "30d 2h", "0.89" });
+        try self.table.addRow(.{ "worker-01", "online", "15d 8h", "0.63" });
+        try self.table.addRow(.{ "worker-02", "offline", "0d 0h", "0.00" });
+        try self.table.addRow(.{ "monitor", "online", "60d 1h", "0.22" });
+        try self.table.addRow(.{ "lb-01", "online", "90d 5h", "0.45" });
         self.table.focus();
 
         // Tree
@@ -183,31 +183,31 @@ const Model = struct {
         };
         const root = self.tree.addRoot({}, "project/") catch 0;
         const src = self.tree.addChild(root, {}, "src/") catch 0;
-        _ = self.tree.addChild(src, {}, "main.zig") catch {};
-        _ = self.tree.addChild(src, {}, "lib.zig") catch {};
+        _ = try self.tree.addChild(src, {}, "main.zig");
+        _ = try self.tree.addChild(src, {}, "lib.zig");
         const comp = self.tree.addChild(src, {}, "components/") catch 0;
-        _ = self.tree.addChild(comp, {}, "button.zig") catch {};
-        _ = self.tree.addChild(comp, {}, "input.zig") catch {};
+        _ = try self.tree.addChild(comp, {}, "button.zig");
+        _ = try self.tree.addChild(comp, {}, "input.zig");
         const tests = self.tree.addChild(root, {}, "tests/") catch 0;
-        _ = self.tree.addChild(tests, {}, "unit_test.zig") catch {};
-        _ = self.tree.addChild(root, {}, "build.zig") catch {};
-        _ = self.tree.addChild(root, {}, "README.md") catch {};
+        _ = try self.tree.addChild(tests, {}, "unit_test.zig");
+        _ = try self.tree.addChild(root, {}, "build.zig");
+        _ = try self.tree.addChild(root, {}, "README.md");
 
         // Styled list
         self.styled_list = zz.StyledList.init(ctx.persistent_allocator);
         self.styled_list.setEnumerator(.roman);
-        self.styled_list.addItem("Setup development environment") catch {};
-        self.styled_list.addItem("Implement core features") catch {};
-        self.styled_list.addItemNested("Style system", 1) catch {};
-        self.styled_list.addItemNested("Component library", 1) catch {};
-        self.styled_list.addItem("Write tests") catch {};
-        self.styled_list.addItem("Deploy to production") catch {};
+        try self.styled_list.addItem("Setup development environment");
+        try self.styled_list.addItem("Implement core features");
+        try self.styled_list.addItemNested("Style system", 1);
+        try self.styled_list.addItemNested("Component library", 1);
+        try self.styled_list.addItem("Write tests");
+        try self.styled_list.addItem("Deploy to production");
 
         self.data_focus = .table_focus;
 
         // Files tab - viewport
         self.file_viewport = zz.components.Viewport.init(ctx.persistent_allocator, 60, 15);
-        self.file_viewport.setContent(
+        try self.file_viewport.setContent(
             \\  Directory listing:
             \\
             \\  drwxr-xr-x  src/
@@ -220,14 +220,14 @@ const Model = struct {
             \\  -rw-r--r--  .gitignore
             \\
             \\  Use j/k to scroll, Tab to switch tabs.
-        ) catch {};
+        );
 
         // Editor tab
         self.text_area = zz.TextArea.init(ctx.persistent_allocator);
         self.text_area.setSize(@min(ctx.width -| 4, 70), @min(ctx.height -| 8, 20));
         self.text_area.line_numbers = true;
         self.text_area.word_wrap = true;
-        self.text_area.setValue(
+        try self.text_area.setValue(
             \\const std = @import("std");
             \\
             \\pub fn main() !void {
@@ -237,7 +237,7 @@ const Model = struct {
             \\// Edit this code with the text area component.
             \\// Supports line numbers, word wrap, and full
             \\// cursor navigation.
-        ) catch {};
+        );
 
         // Global
         self.active_tab = .dashboard;
@@ -245,9 +245,9 @@ const Model = struct {
         self.show_quit_confirm = false;
 
         self.help = zz.components.Help.init(ctx.persistent_allocator);
-        self.help.addBinding("1-6", "tabs") catch {};
-        self.help.addBinding("Tab", "next tab") catch {};
-        self.help.addBinding("Ctrl+Q", "quit") catch {};
+        try self.help.addBinding("1-6", "tabs");
+        try self.help.addBinding("Tab", "next tab");
+        try self.help.addBinding("Ctrl+Q", "quit");
 
         return zz.Cmd(Msg).tickMs(16);
     }
@@ -454,7 +454,7 @@ const Model = struct {
         }
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Build layout
         const tab_bar = self.renderTabBar(ctx) catch return "Error rendering tab bar";
         const content = self.renderActiveTab(ctx) catch return "Error rendering content";
@@ -462,15 +462,15 @@ const Model = struct {
 
         // Confirmation overlay
         const confirm_view = if (self.show_quit_confirm)
-            self.confirm.view(ctx.allocator) catch ""
+            try self.confirm.view(ctx.allocator)
         else
             "";
 
         // Compose full view
         const main_view = if (self.show_quit_confirm)
-            zz.joinVertical(ctx.allocator, &.{ tab_bar, "", content, "", confirm_view, "", status }) catch tab_bar
+            try zz.joinVertical(ctx.allocator, &.{ tab_bar, "", content, "", confirm_view, "", status })
         else
-            zz.joinVertical(ctx.allocator, &.{ tab_bar, "", content, "", status }) catch tab_bar;
+            try zz.joinVertical(ctx.allocator, &.{ tab_bar, "", content, "", status });
 
         return zz.place.place(
             ctx.allocator,
@@ -479,7 +479,7 @@ const Model = struct {
             .center,
             .top,
             main_view,
-        ) catch main_view;
+        );
     }
 
     fn chartsCompact(ctx: *const zz.Context) bool {

--- a/examples/slider.zig
+++ b/examples/slider.zig
@@ -76,31 +76,31 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Slider Example") catch "Slider Example";
+        const title = try title_style.render(ctx.allocator, "Slider Example");
 
-        const vol = self.volume.view(ctx.allocator) catch "error";
-        const bright = self.brightness.view(ctx.allocator) catch "error";
-        const temp = self.temperature.view(ctx.allocator) catch "error";
-        const spd = self.progress_slider.view(ctx.allocator) catch "error";
+        const vol = try self.volume.view(ctx.allocator);
+        const bright = try self.brightness.view(ctx.allocator);
+        const temp = try self.temperature.view(ctx.allocator);
+        const spd = try self.progress_slider.view(ctx.allocator);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Tab: switch | Left/Right or h/l: adjust | Home/End: min/max | PgUp/PgDn: large step | q: quit",
-        ) catch "";
+        );
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}\n\n{s}\n\n{s}\n\n{s}",
             .{ title, vol, bright, temp, spd, help },
-        ) catch "Error";
+        );
     }
 };
 

--- a/examples/sortable_table.zig
+++ b/examples/sortable_table.zig
@@ -11,17 +11,17 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, _: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, _: *zz.Context) !zz.Cmd(Msg) {
         self.table = zz.components.sortable_table.SortableTable(4).init(std.heap.page_allocator);
         self.table.setHeaders(.{ "Name", "Role", "City", "Score" });
-        self.table.addRow(.{ "Alice", "Engineer", "NYC", "95" }) catch {};
-        self.table.addRow(.{ "Bob", "Designer", "London", "87" }) catch {};
-        self.table.addRow(.{ "Carol", "Manager", "Tokyo", "92" }) catch {};
-        self.table.addRow(.{ "Dave", "Engineer", "Berlin", "78" }) catch {};
-        self.table.addRow(.{ "Eve", "Designer", "Paris", "91" }) catch {};
-        self.table.addRow(.{ "Frank", "Manager", "NYC", "85" }) catch {};
-        self.table.addRow(.{ "Grace", "Engineer", "London", "99" }) catch {};
-        self.table.addRow(.{ "Hank", "Designer", "Tokyo", "72" }) catch {};
+        try self.table.addRow(.{ "Alice", "Engineer", "NYC", "95" });
+        try self.table.addRow(.{ "Bob", "Designer", "London", "87" });
+        try self.table.addRow(.{ "Carol", "Manager", "Tokyo", "92" });
+        try self.table.addRow(.{ "Dave", "Engineer", "Berlin", "78" });
+        try self.table.addRow(.{ "Eve", "Designer", "Paris", "91" });
+        try self.table.addRow(.{ "Frank", "Manager", "NYC", "85" });
+        try self.table.addRow(.{ "Grace", "Engineer", "London", "99" });
+        try self.table.addRow(.{ "Hank", "Designer", "Tokyo", "72" });
         return .none;
     }
 
@@ -39,7 +39,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -53,23 +53,23 @@ const Model = struct {
         box_s = box_s.paddingAll(1);
 
         const table_view = self.table.view(alloc);
-        const boxed = box_s.render(alloc, table_view) catch table_view;
+        const boxed = try box_s.render(alloc, table_view);
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, "Sortable Table Demo") catch "",
+                try title_s.render(alloc, "Sortable Table Demo"),
                 boxed,
-                help_s.render(alloc, "1-4: sort by column  /: filter  Up/Down: navigate  q: quit") catch "",
+                try help_s.render(alloc, "1-4: sort by column  /: filter  Up/Down: navigate  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/sub_program.zig
+++ b/examples/sub_program.zig
@@ -32,9 +32,9 @@ const Counter = struct {
         return .none;
     }
 
-    pub fn view(self: *const Counter, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Counter, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
-        return std.fmt.allocPrint(alloc, "{s}: {d}", .{ self.label, self.count }) catch "?";
+        return std.fmt.allocPrint(alloc, "{s}: {d}", .{ self.label, self.count });
     }
 };
 
@@ -85,7 +85,7 @@ const Model = struct {
         }
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -106,10 +106,10 @@ const Model = struct {
         box_b = box_b.paddingAll(1);
         box_b = box_b.width(30);
 
-        const view_a = box_a.render(alloc, self.counter_a.view(ctx)) catch "";
-        const view_b = box_b.render(alloc, self.counter_b.view(ctx)) catch "";
+        const view_a = try box_a.render(alloc, try self.counter_a.view(ctx));
+        const view_b = try box_b.render(alloc, try self.counter_b.view(ctx));
 
-        const panels = zz.join.horizontal(alloc, .top, &.{ view_a, view_b }) catch "";
+        const panels = try zz.join.horizontal(alloc, .top, &.{ view_a, view_b });
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
@@ -117,18 +117,18 @@ const Model = struct {
 
         const active_label = if (self.active == 0) "A" else "B";
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\nActive: {s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, "Sub-Program Demo") catch "Sub-Program",
+                try title_s.render(alloc, "Sub-Program Demo"),
                 active_label,
                 panels,
-                help_s.render(alloc, "Tab: switch  Up/Down: count  r: reset  q: quit") catch "",
+                try help_s.render(alloc, "Tab: switch  Up/Down: count  r: reset  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 };
 

--- a/examples/tabs.zig
+++ b/examples/tabs.zig
@@ -74,7 +74,7 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.tabs = zz.TabGroup.init(ctx.persistent_allocator);
         self.tabs.show_numbers = true;
         self.tabs.max_width = 60;
@@ -82,7 +82,7 @@ const Model = struct {
         self.home = .{};
         self.counter = .{};
 
-        _ = self.tabs.addTab(.{
+        _ = try self.tabs.addTab(.{
             .id = "home",
             .title = "Home",
             .route = .{
@@ -91,9 +91,9 @@ const Model = struct {
                 .key_fn = ScreenA.onKey,
                 .on_enter_fn = ScreenA.onEnter,
             },
-        }) catch {};
+        });
 
-        _ = self.tabs.addTab(.{
+        _ = try self.tabs.addTab(.{
             .id = "counter",
             .title = "Counter",
             .route = .{
@@ -101,7 +101,7 @@ const Model = struct {
                 .render_fn = ScreenB.render,
                 .key_fn = ScreenB.onKey,
             },
-        }) catch {};
+        });
 
         return .none;
     }
@@ -120,15 +120,15 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
-        const body = self.tabs.viewWithContent(ctx.allocator, "No active route") catch "render error";
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
+        const body = try self.tabs.viewWithContent(ctx.allocator, "No active route");
 
         var hint_style = zz.Style{};
         hint_style = hint_style.fg(zz.Color.gray(12));
         hint_style = hint_style.inline_style(true);
-        const help = hint_style.render(ctx.allocator, "q: quit | ←/→: switch | 1..9: jump | +/- or ↑/↓: counter actions") catch "";
+        const help = try hint_style.render(ctx.allocator, "q: quit | ←/→: switch | 1..9: jump | +/- or ↑/↓: counter actions");
 
-        return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ body, help }) catch body;
+        return std.fmt.allocPrint(ctx.allocator, "{s}\n\n{s}", .{ body, help });
     }
 };
 

--- a/examples/text_editor.zig
+++ b/examples/text_editor.zig
@@ -12,13 +12,13 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.editor = zz.components.TextArea.init(ctx.persistent_allocator);
         self.editor.setSize(ctx.width -| 4, ctx.height -| 8);
         self.editor.line_numbers = true;
         self.editor.placeholder = "Start typing...";
 
-        // Sample text
+        try // Sample text
         self.editor.setValue(
             \\// Welcome to ZigZag Text Editor!
             \\//
@@ -30,7 +30,7 @@ const Model = struct {
             \\pub fn main() !void {
             \\    std.debug.print("Hello, World!\n", .{});
             \\}
-        ) catch {};
+        );
 
         self.status_message = "";
         return .none;
@@ -72,48 +72,48 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         // Title
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "ZigZag Text Editor") catch "Text Editor";
+        const title = try title_style.render(ctx.allocator, "ZigZag Text Editor");
 
         // Editor with border
         var editor_style = zz.Style{};
         editor_style = editor_style.borderAll(zz.Border.rounded);
         editor_style = editor_style.borderForeground(zz.Color.gray(12));
 
-        const editor_content = self.editor.view(ctx.allocator) catch "";
-        const editor_box = editor_style.render(ctx.allocator, editor_content) catch editor_content;
+        const editor_content = try self.editor.view(ctx.allocator);
+        const editor_box = try editor_style.render(ctx.allocator, editor_content);
 
         // Status bar
-        const cursor_info = std.fmt.allocPrint(
+        const cursor_info = try std.fmt.allocPrint(
             ctx.allocator,
             "Ln {d}, Col {d} | {d} lines",
             .{ self.editor.cursor_row + 1, self.editor.cursorDisplayColumn() + 1, self.editor.lineCount() },
-        ) catch "";
+        );
 
         var status_style = zz.Style{};
         status_style = status_style.fg(zz.Color.gray(18));
         status_style = status_style.inline_style(true);
-        const status = status_style.render(ctx.allocator, cursor_info) catch "";
+        const status = try status_style.render(ctx.allocator, cursor_info);
 
         // Status message
         var msg_style = zz.Style{};
         msg_style = msg_style.fg(zz.Color.green);
         msg_style = msg_style.inline_style(true);
-        const msg = msg_style.render(ctx.allocator, self.status_message) catch "";
+        const msg = try msg_style.render(ctx.allocator, self.status_message);
 
         // Help
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(
+        const help = try help_style.render(
             ctx.allocator,
             "Ctrl+S: Save  Ctrl+Q: Quit  Arrow keys: Navigate",
-        ) catch "";
+        );
 
         // Get max width for centering
         const editor_width = zz.measure.maxLineWidth(editor_box);
@@ -122,14 +122,14 @@ const Model = struct {
         const max_width = @max(editor_width, @max(title_width, help_width));
 
         // Center title and help relative to editor width
-        const centered_title = zz.place.place(ctx.allocator, max_width, 1, .center, .top, title) catch title;
-        const centered_help = zz.place.place(ctx.allocator, max_width, 1, .center, .top, help) catch help;
+        const centered_title = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, title);
+        const centered_help = try zz.place.place(ctx.allocator, max_width, 1, .center, .top, help);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}  {s}\n{s}",
             .{ centered_title, editor_box, status, msg, centered_help },
-        ) catch "Error";
+        );
 
         // Center horizontally, keep at top vertically (editor needs space)
         return zz.place.place(
@@ -139,7 +139,7 @@ const Model = struct {
             .center,
             .top,
             content,
-        ) catch content;
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/text_overflow.zig
+++ b/examples/text_overflow.zig
@@ -25,7 +25,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(_: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(_: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
         const long_text = "The quick brown fox jumps over the lazy dog. This is a long sentence that demonstrates how text overflow policies work in the ZigZag TUI framework.";
         const box_width: u16 = 35;
@@ -35,7 +35,7 @@ const Model = struct {
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(alloc, "Text Overflow Policies") catch "Text Overflow Policies";
+        const title = try title_style.render(alloc, "Text Overflow Policies");
 
         // visible (no overflow handling)
         var vis_style = zz.Style{};
@@ -43,7 +43,7 @@ const Model = struct {
         vis_style = vis_style.borderAll(zz.Border.rounded);
         vis_style = vis_style.borderForeground(zz.Color.gray(8));
         vis_style = vis_style.overflow(.visible);
-        const vis = vis_style.render(alloc, long_text) catch "";
+        const vis = try vis_style.render(alloc, long_text);
 
         // hidden (clip)
         var clip_style = zz.Style{};
@@ -51,7 +51,7 @@ const Model = struct {
         clip_style = clip_style.borderAll(zz.Border.rounded);
         clip_style = clip_style.borderForeground(zz.Color.yellow);
         clip_style = clip_style.overflow(.hidden);
-        const clip = clip_style.render(alloc, long_text) catch "";
+        const clip = try clip_style.render(alloc, long_text);
 
         // ellipsis
         var ell_style = zz.Style{};
@@ -59,7 +59,7 @@ const Model = struct {
         ell_style = ell_style.borderAll(zz.Border.rounded);
         ell_style = ell_style.borderForeground(zz.Color.green);
         ell_style = ell_style.overflow(.ellipsis);
-        const ell = ell_style.render(alloc, long_text) catch "";
+        const ell = try ell_style.render(alloc, long_text);
 
         // word_wrap
         var ww_style = zz.Style{};
@@ -67,7 +67,7 @@ const Model = struct {
         ww_style = ww_style.borderAll(zz.Border.rounded);
         ww_style = ww_style.borderForeground(zz.Color.blue);
         ww_style = ww_style.overflow(.word_wrap);
-        const ww = ww_style.render(alloc, long_text) catch "";
+        const ww = try ww_style.render(alloc, long_text);
 
         // char_wrap
         var cw_style = zz.Style{};
@@ -75,30 +75,30 @@ const Model = struct {
         cw_style = cw_style.borderAll(zz.Border.rounded);
         cw_style = cw_style.borderForeground(zz.Color.magenta);
         cw_style = cw_style.overflow(.char_wrap);
-        const cw = cw_style.render(alloc, long_text) catch "";
+        const cw = try cw_style.render(alloc, long_text);
 
         // Labels
         var label_style = zz.Style{};
         label_style = label_style.fg(zz.Color.gray(12));
         label_style = label_style.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s} visible (default):\n{s}\n\n{s} hidden (clip):\n{s}\n\n{s} ellipsis:\n{s}\n\n{s} word_wrap:\n{s}\n\n{s} char_wrap:\n{s}\n\nPress q to quit",
             .{
                 title,
-                label_style.render(alloc, "\xe2\x96\xb8") catch ">",
+                try label_style.render(alloc, "\xe2\x96\xb8"),
                 vis,
-                label_style.render(alloc, "\xe2\x96\xb8") catch ">",
+                try label_style.render(alloc, "\xe2\x96\xb8"),
                 clip,
-                label_style.render(alloc, "\xe2\x96\xb8") catch ">",
+                try label_style.render(alloc, "\xe2\x96\xb8"),
                 ell,
-                label_style.render(alloc, "\xe2\x96\xb8") catch ">",
+                try label_style.render(alloc, "\xe2\x96\xb8"),
                 ww,
-                label_style.render(alloc, "\xe2\x96\xb8") catch ">",
+                try label_style.render(alloc, "\xe2\x96\xb8"),
                 cw,
             },
-        ) catch "Error";
+        );
 
         return content;
     }

--- a/examples/theming.zig
+++ b/examples/theming.zig
@@ -58,36 +58,36 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const t = &self.tm.current;
         const p = &t.palette;
 
         // Title
         const title_style = zz.Theme.boldStyleWith(p.primary);
-        const title = title_style.render(ctx.allocator, "Theme Preview (ThemeManager)") catch "Theme Preview";
+        const title = try title_style.render(ctx.allocator, "Theme Preview (ThemeManager)");
 
         // Theme name and count
         const name_style = zz.Theme.boldStyleWith(p.accent);
-        const theme_name = name_style.render(ctx.allocator, self.tm.currentName()) catch "?";
-        const theme_line = std.fmt.allocPrint(
+        const theme_name = try name_style.render(ctx.allocator, self.tm.currentName());
+        const theme_line = try std.fmt.allocPrint(
             ctx.allocator,
             "Current: {s}  ({d}/{d})",
             .{ theme_name, self.tm.palette_index + 1, zz.ThemeManager.builtinCount() },
-        ) catch "?";
+        );
 
         // Color swatches in two rows
-        const primary_s = zz.Theme.boldStyleWith(p.primary).render(ctx.allocator, "██ Primary") catch "";
-        const secondary_s = zz.Theme.boldStyleWith(p.secondary).render(ctx.allocator, "██ Secondary") catch "";
-        const accent_s = zz.Theme.boldStyleWith(p.accent).render(ctx.allocator, "██ Accent") catch "";
-        const success_s = zz.Theme.styleWith(p.success).render(ctx.allocator, "██ Success") catch "";
-        const warning_s = zz.Theme.styleWith(p.warning).render(ctx.allocator, "██ Warning") catch "";
-        const danger_s = zz.Theme.styleWith(p.danger).render(ctx.allocator, "██ Danger") catch "";
-        const info_s = zz.Theme.styleWith(p.info).render(ctx.allocator, "██ Info") catch "";
+        const primary_s = try zz.Theme.boldStyleWith(p.primary).render(ctx.allocator, "██ Primary");
+        const secondary_s = try zz.Theme.boldStyleWith(p.secondary).render(ctx.allocator, "██ Secondary");
+        const accent_s = try zz.Theme.boldStyleWith(p.accent).render(ctx.allocator, "██ Accent");
+        const success_s = try zz.Theme.styleWith(p.success).render(ctx.allocator, "██ Success");
+        const warning_s = try zz.Theme.styleWith(p.warning).render(ctx.allocator, "██ Warning");
+        const danger_s = try zz.Theme.styleWith(p.danger).render(ctx.allocator, "██ Danger");
+        const info_s = try zz.Theme.styleWith(p.info).render(ctx.allocator, "██ Info");
 
         // Text styles
-        const fg_s = zz.Theme.styleWith(p.foreground).render(ctx.allocator, "Foreground text") catch "";
-        const muted_s = zz.Theme.styleWith(p.muted).render(ctx.allocator, "Muted text") catch "";
-        const subtle_s = zz.Theme.styleWith(p.subtle).render(ctx.allocator, "Subtle text") catch "";
+        const fg_s = try zz.Theme.styleWith(p.foreground).render(ctx.allocator, "Foreground text");
+        const muted_s = try zz.Theme.styleWith(p.muted).render(ctx.allocator, "Muted text");
+        const subtle_s = try zz.Theme.styleWith(p.subtle).render(ctx.allocator, "Subtle text");
 
         // Border preview
         var box_style = zz.Style{};
@@ -95,8 +95,8 @@ const Model = struct {
         box_style = box_style.borderForeground(p.border_focus);
         box_style = box_style.paddingAll(1);
         box_style = box_style.fg(p.foreground);
-        const box_content = std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}", .{ fg_s, muted_s, subtle_s }) catch "?";
-        const bordered = box_style.render(ctx.allocator, box_content) catch box_content;
+        const box_content = try std.fmt.allocPrint(ctx.allocator, "{s}\n{s}\n{s}", .{ fg_s, muted_s, subtle_s });
+        const bordered = try box_style.render(ctx.allocator, box_content);
 
         // Surface/overlay preview
         var surface_style = zz.Style{};
@@ -105,7 +105,7 @@ const Model = struct {
         surface_style = surface_style.bg(p.surface);
         surface_style = surface_style.fg(p.foreground);
         surface_style = surface_style.paddingLeft(1).paddingRight(1);
-        const surface_box = surface_style.render(ctx.allocator, "Surface") catch "Surface";
+        const surface_box = try surface_style.render(ctx.allocator, "Surface");
 
         var overlay_style = zz.Style{};
         overlay_style = overlay_style.borderAll(zz.Border.normal);
@@ -113,14 +113,14 @@ const Model = struct {
         overlay_style = overlay_style.bg(p.overlay);
         overlay_style = overlay_style.fg(p.foreground);
         overlay_style = overlay_style.paddingLeft(1).paddingRight(1);
-        const overlay_box = overlay_style.render(ctx.allocator, "Overlay") catch "Overlay";
+        const overlay_box = try overlay_style.render(ctx.allocator, "Overlay");
 
         // Highlight preview
         var hl_style = zz.Style{};
         hl_style = hl_style.bg(p.highlight);
         hl_style = hl_style.fg(p.highlight_text);
         hl_style = hl_style.inline_style(true);
-        const hl_box = hl_style.render(ctx.allocator, " Highlighted ") catch "Highlighted";
+        const hl_box = try hl_style.render(ctx.allocator, " Highlighted ");
 
         // Progress bar using theme colors
         var prog = zz.Progress.init();
@@ -134,21 +134,21 @@ const Model = struct {
         empty_s = empty_s.fg(p.subtle);
         empty_s = empty_s.inline_style(true);
         prog.empty_style = empty_s;
-        const prog_view = prog.view(ctx.allocator) catch "error";
+        const prog_view = try prog.view(ctx.allocator);
 
         // Help
         const help_style = zz.Theme.styleWith(p.muted);
-        const help = help_style.render(ctx.allocator,
+        const help = try help_style.render(ctx.allocator,
             \\Left/Right or n/p: switch theme | q: quit
             \\All built-in palettes: Default Dark/Light, Catppuccin,
             \\Dracula, Nord, Tokyo Night, Gruvbox, Solarized, High Contrast
-        ) catch "";
+        );
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n{s}\n\n{s}  {s}  {s}\n{s}  {s}  {s}  {s}\n\n{s}\n\n{s}  {s}  {s}\n\nProgress: {s}\n\n{s}",
             .{ title, theme_line, primary_s, secondary_s, accent_s, success_s, warning_s, danger_s, info_s, bordered, surface_box, overlay_box, hl_box, prog_view, help },
-        ) catch "Error";
+        );
     }
 };
 

--- a/examples/toast.zig
+++ b/examples/toast.zig
@@ -16,7 +16,7 @@ const Model = struct {
         tick: zz.msg.Tick,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.toast = zz.Toast.init(ctx.persistent_allocator);
         self.toast.position = .top_right;
         self.toast.show_countdown = true;
@@ -27,8 +27,8 @@ const Model = struct {
         self.width_preset_idx = 1;
         self.border_style_idx = 0;
 
-        // Initial welcome toast
-        self.toast.push("Welcome to the Toast demo!", .info, 5000, 0) catch {};
+        try // Initial welcome toast
+        self.toast.push("Welcome to the Toast demo!", .info, 5000, 0);
 
         return .{ .every = 100_000_000 };
     }
@@ -103,12 +103,12 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.magenta);
         title_style = title_style.inline_style(true);
-        const title = title_style.render(ctx.allocator, "Toast Notifications") catch "Toast";
+        const title = try title_style.render(ctx.allocator, "Toast Notifications");
 
         const pos_name = self.positionName();
         const order_name: []const u8 = if (self.toast.stack_order == .newest_first) "newest first" else "oldest first";
@@ -121,7 +121,7 @@ const Model = struct {
         var info_style = zz.Style{};
         info_style = info_style.fg(zz.Color.cyan);
         info_style = info_style.inline_style(true);
-        const info = std.fmt.allocPrint(
+        const info = try std.fmt.allocPrint(
             ctx.allocator,
             "Position: {s} | Order: {s} | Active: {d} | Width: {d}-{d} | Border style: {s} | Borders: {s} | Icons: {s} | Countdown: {s}",
             .{
@@ -135,28 +135,28 @@ const Model = struct {
                 if (self.toast.show_icons) "on" else "off",
                 if (self.toast.show_countdown) "on" else "off",
             },
-        ) catch "?";
-        const styled_info = info_style.render(ctx.allocator, info) catch info;
+        );
+        const styled_info = try info_style.render(ctx.allocator, info);
 
         var help_style = zz.Style{};
         help_style = help_style.fg(zz.Color.gray(12));
         help_style = help_style.inline_style(true);
-        const help = help_style.render(ctx.allocator,
+        const help = try help_style.render(ctx.allocator,
             \\Quick start: press p to move the toast around the screen.
             \\1: info  2: success  3: warning  4: error  5: persistent  6: long toast
             \\d: dismiss newest  x: dismiss oldest  D: dismiss all
             \\b: borders  i: icons  c: countdown  w: width preset  t: border style
             \\p/P: switch position  s: stack order  q: quit
-        ) catch "";
+        );
 
         // Render toast notifications
-        const toast_view = self.toast.viewPositioned(ctx.allocator, ctx.width, ctx.height -| 8, self.last_elapsed) catch "";
+        const toast_view = try self.toast.viewPositioned(ctx.allocator, ctx.width, ctx.height -| 8, self.last_elapsed);
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n{s}\n\n{s}\n\n{s}",
             .{ title, styled_info, help, toast_view },
-        ) catch "Error";
+        );
     }
 
     pub fn deinit(self: *Model) void {

--- a/examples/todo_list.zig
+++ b/examples/todo_list.zig
@@ -21,7 +21,7 @@ const Model = struct {
         key: zz.KeyEvent,
     };
 
-    pub fn init(self: *Model, ctx: *zz.Context) zz.Cmd(Msg) {
+    pub fn init(self: *Model, ctx: *zz.Context) !zz.Cmd(Msg) {
         self.list = zz.List(Todo).init(ctx.persistent_allocator);
         self.list.multi_select = true;
         self.list.height = 10;
@@ -30,11 +30,11 @@ const Model = struct {
 
         // Add some sample items
         const Item = zz.List(Todo).Item;
-        self.list.addItem(Item.init(.{ .id = 1, .done = false }, "Learn Zig")) catch {};
-        self.list.addItem(Item.init(.{ .id = 2, .done = true }, "Build a TUI app")) catch {};
-        self.list.addItem(Item.init(.{ .id = 3, .done = false }, "Write documentation")) catch {};
-        self.list.addItem(Item.init(.{ .id = 4, .done = false }, "Add more features")) catch {};
-        self.list.addItem(Item.init(.{ .id = 5, .done = false }, "Test everything")) catch {};
+        try self.list.addItem(Item.init(.{ .id = 1, .done = false }, "Learn Zig"));
+        try self.list.addItem(Item.init(.{ .id = 2, .done = true }, "Build a TUI app"));
+        try self.list.addItem(Item.init(.{ .id = 3, .done = false }, "Write documentation"));
+        try self.list.addItem(Item.init(.{ .id = 4, .done = false }, "Add more features"));
+        try self.list.addItem(Item.init(.{ .id = 5, .done = false }, "Test everything"));
 
         self.input_mode = false;
         self.input = zz.TextInput.init(ctx.persistent_allocator);
@@ -135,7 +135,7 @@ const Model = struct {
         }
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_style = zz.Style{};
         title_style = title_style.bold(true);
         title_style = title_style.fg(zz.Color.cyan);
@@ -146,7 +146,7 @@ const Model = struct {
         box_style = box_style.borderForeground(zz.Color.gray(15));
         box_style = box_style.paddingAll(1);
 
-        const title = title_style.render(ctx.allocator, "Todo List") catch "Todo List";
+        const title = try title_style.render(ctx.allocator, "Todo List");
 
         // Build todo list display using filtered_indices
         var list_content: Writer.Allocating = .init(ctx.allocator);
@@ -157,31 +157,31 @@ const Model = struct {
             var filter_style = zz.Style{};
             filter_style = filter_style.fg(zz.Color.yellow);
             filter_style = filter_style.inline_style(true);
-            const filter_text = std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{self.list.filter_text.items}) catch "Filter:";
-            const styled_filter = filter_style.render(ctx.allocator, filter_text) catch filter_text;
-            writer.writeAll(styled_filter) catch {};
-            writer.writeByte('\n') catch {};
+            const filter_text = try std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{self.list.filter_text.items});
+            const styled_filter = try filter_style.render(ctx.allocator, filter_text);
+            try writer.writeAll(styled_filter);
+            try writer.writeByte('\n');
         }
 
         const visible = self.list.filtered_indices.items;
 
         for (visible, 0..) |item_idx, i| {
-            if (i > 0) writer.writeByte('\n') catch {};
+            if (i > 0) try writer.writeByte('\n');
 
             const item = self.list.items.items[item_idx];
 
             // Cursor indicator
             if (i == self.list.cursor) {
-                writer.writeAll("> ") catch {};
+                try writer.writeAll("> ");
             } else {
-                writer.writeAll("  ") catch {};
+                try writer.writeAll("  ");
             }
 
             // Checkbox
             if (item.value.done) {
-                writer.writeAll("[x] ") catch {};
+                try writer.writeAll("[x] ");
             } else {
-                writer.writeAll("[ ] ") catch {};
+                try writer.writeAll("[ ] ");
             }
 
             // Title with strikethrough if done
@@ -190,26 +190,26 @@ const Model = struct {
                 done_style = done_style.strikethrough(true);
                 done_style = done_style.fg(zz.Color.gray(12));
                 done_style = done_style.inline_style(true);
-                const styled = done_style.render(ctx.allocator, item.title) catch item.title;
-                writer.writeAll(styled) catch {};
+                const styled = try done_style.render(ctx.allocator, item.title);
+                try writer.writeAll(styled);
             } else if (i == self.list.cursor) {
                 var selected_style = zz.Style{};
                 selected_style = selected_style.bold(true);
                 selected_style = selected_style.fg(zz.Color.magenta);
                 selected_style = selected_style.inline_style(true);
-                const styled = selected_style.render(ctx.allocator, item.title) catch item.title;
-                writer.writeAll(styled) catch {};
+                const styled = try selected_style.render(ctx.allocator, item.title);
+                try writer.writeAll(styled);
             } else {
-                writer.writeAll(item.title) catch {};
+                try writer.writeAll(item.title);
             }
         }
 
-        const list_view = list_content.toOwnedSlice() catch "";
-        const boxed_list = box_style.render(ctx.allocator, list_view) catch list_view;
+        const list_view = try list_content.toOwnedSlice();
+        const boxed_list = try box_style.render(ctx.allocator, list_view);
 
         // Input line
         const input_line = if (self.input_mode)
-            self.input.view(ctx.allocator) catch ""
+            try self.input.view(ctx.allocator)
         else
             "";
 
@@ -223,7 +223,7 @@ const Model = struct {
             "Type to filter  Esc: Clear filter"
         else
             "j/k: Navigate  Space: Select  x: Toggle  a: Add  d: Delete  /: Filter  q: Quit";
-        const help = help_style.render(ctx.allocator, help_text) catch "";
+        const help = try help_style.render(ctx.allocator, help_text);
 
         // Get the max width of all elements for proper centering
         const box_width = zz.measure.maxLineWidth(boxed_list);
@@ -232,49 +232,49 @@ const Model = struct {
         const max_width = @max(box_width, @max(help_width, title_width));
 
         // Center all elements to the max width
-        const centered_title = zz.place.place(
+        const centered_title = try zz.place.place(
             ctx.allocator,
             max_width,
             1,
             .center,
             .top,
             title,
-        ) catch title;
+        );
 
-        const centered_box = zz.place.place(
+        const centered_box = try zz.place.place(
             ctx.allocator,
             max_width,
             zz.measure.height(boxed_list),
             .center,
             .top,
             boxed_list,
-        ) catch boxed_list;
+        );
 
-        const centered_help = zz.place.place(
+        const centered_help = try zz.place.place(
             ctx.allocator,
             max_width,
             1,
             .center,
             .top,
             help,
-        ) catch help;
+        );
 
         // Build content
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\n{s}\n\n{s}{s}",
             .{ centered_title, centered_box, input_line, centered_help },
-        ) catch "Error";
+        );
 
         // Center the content in the terminal
-        const centered = zz.place.place(
+        const centered = try zz.place.place(
             ctx.allocator,
             ctx.width,
             ctx.height,
             .center,
             .middle,
             content,
-        ) catch content;
+        );
 
         return centered;
     }

--- a/examples/tooltip.zig
+++ b/examples/tooltip.zig
@@ -115,18 +115,18 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         // Title
         var title_s = zz.Style{};
         title_s = title_s.bold(true).fg(zz.Color.hex("#FF6B6B")).inline_style(true);
-        const title = title_s.render(alloc, "Tooltip Component Demo") catch "Tooltip Component Demo";
+        const title = try title_s.render(alloc, "Tooltip Component Demo");
 
         // Status
         var status_s = zz.Style{};
         status_s = status_s.fg(zz.Color.gray(12)).inline_style(true);
-        const status = status_s.render(alloc, self.status) catch "";
+        const status = try status_s.render(alloc, self.status);
 
         // Button labels
         const labels = [_][]const u8{
@@ -145,21 +145,21 @@ const Model = struct {
 
         var btn_parts: [7][]const u8 = undefined;
         for (labels, 0..) |label, i| {
-            const padded = std.fmt.allocPrint(alloc, " {s} ", .{label}) catch label;
-            btn_parts[i] = btn_s.render(alloc, padded) catch padded;
+            const padded = try std.fmt.allocPrint(alloc, " {s} ", .{label});
+            btn_parts[i] = try btn_s.render(alloc, padded);
         }
 
         // Join buttons with gaps
-        const row1 = std.fmt.allocPrint(alloc, "{s}  {s}  {s}  {s}", .{
+        const row1 = try std.fmt.allocPrint(alloc, "{s}  {s}  {s}  {s}", .{
             btn_parts[0], btn_parts[1], btn_parts[2], btn_parts[3],
-        }) catch "";
-        const row2 = std.fmt.allocPrint(alloc, "{s}  {s}  {s}", .{
+        });
+        const row2 = try std.fmt.allocPrint(alloc, "{s}  {s}  {s}", .{
             btn_parts[4], btn_parts[5], btn_parts[6],
-        }) catch "";
+        });
 
-        const content = std.fmt.allocPrint(alloc, "{s}\n\n{s}\n{s}\n\n{s}", .{
+        const content = try std.fmt.allocPrint(alloc, "{s}\n\n{s}\n{s}\n\n{s}", .{
             title, row1, row2, status,
-        }) catch "Error";
+        });
 
         // Center content
         const content_w = zz.measure.maxLineWidth(content);
@@ -167,7 +167,7 @@ const Model = struct {
         const h_pad = if (ctx.width > content_w) (ctx.width - content_w) / 2 else 0;
         const v_pad = if (ctx.height > content_h) (ctx.height - content_h) / 2 else 0;
 
-        const base = zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        const base = try zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
 
         // Compute button positions for tooltip targeting
         // Row 1 buttons: title line is at v_pad, blank line, then row1 at v_pad+2
@@ -201,7 +201,7 @@ const Model = struct {
 
         // Overlay tooltip if visible
         if (self.tooltip.isVisible()) {
-            return self.tooltip.overlay(alloc, base, ctx.width, ctx.height) catch base;
+            return self.tooltip.overlay(alloc, base, ctx.width, ctx.height);
         }
 
         return base;

--- a/examples/virtual_list.zig
+++ b/examples/virtual_list.zig
@@ -35,7 +35,7 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         const alloc = ctx.allocator;
 
         var title_s = zz.Style{};
@@ -48,23 +48,23 @@ const Model = struct {
         box_s = box_s.borderForeground(zz.Color.cyan);
 
         const list_view = self.vlist.view(alloc);
-        const boxed = box_s.render(alloc, list_view) catch list_view;
+        const boxed = try box_s.render(alloc, list_view);
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(10));
         help_s = help_s.inline_style(true);
 
-        const content = std.fmt.allocPrint(
+        const content = try std.fmt.allocPrint(
             alloc,
             "{s}\n\n{s}\n\n{s}",
             .{
-                title_s.render(alloc, std.fmt.allocPrint(alloc, "Virtual List - {d} items", .{TOTAL_ITEMS}) catch "Virtual List") catch "Virtual List",
+                try title_s.render(alloc, try std.fmt.allocPrint(alloc, "Virtual List - {d} items", .{TOTAL_ITEMS})),
                 boxed,
-                help_s.render(alloc, "Up/Down: navigate  PgUp/PgDn: page  Home/End: jump  q: quit") catch "",
+                try help_s.render(alloc, "Up/Down: navigate  PgUp/PgDn: page  Home/End: jump  q: quit"),
             },
-        ) catch "Error";
+        );
 
-        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content) catch content;
+        return zz.place.place(alloc, ctx.width, ctx.height, .center, .middle, content);
     }
 
     fn renderItem(item: usize, _: usize, _: bool, allocator: std.mem.Allocator) []const u8 {

--- a/examples/wasm_app.zig
+++ b/examples/wasm_app.zig
@@ -56,36 +56,36 @@ const Model = struct {
         return .none;
     }
 
-    pub fn view(self: *const Model, ctx: *const zz.Context) []const u8 {
+    pub fn view(self: *const Model, ctx: *const zz.Context) ![]const u8 {
         var title_s = zz.Style{};
         title_s = title_s.bold(true);
         title_s = title_s.fg(zz.Color.cyan);
         title_s = title_s.inline_style(true);
-        const title = title_s.render(ctx.allocator, "ZigZag WASM Demo") catch "ZigZag WASM";
+        const title = try title_s.render(ctx.allocator, "ZigZag WASM Demo");
 
         var count_s = zz.Style{};
         count_s = count_s.fg(zz.Color.green);
         count_s = count_s.bold(true);
         count_s = count_s.inline_style(true);
-        const count_text = std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count}) catch "?";
-        const count_styled = count_s.render(ctx.allocator, count_text) catch count_text;
+        const count_text = try std.fmt.allocPrint(ctx.allocator, "{d}", .{self.count});
+        const count_styled = try count_s.render(ctx.allocator, count_text);
 
-        const size_info = std.fmt.allocPrint(
+        const size_info = try std.fmt.allocPrint(
             ctx.allocator,
             "Terminal: {d}x{d}",
             .{ ctx.width, ctx.height },
-        ) catch "";
+        );
 
         var help_s = zz.Style{};
         help_s = help_s.fg(zz.Color.gray(12));
         help_s = help_s.inline_style(true);
-        const help = help_s.render(ctx.allocator, "Up/Down: change count | q: quit") catch "";
+        const help = try help_s.render(ctx.allocator, "Up/Down: change count | q: quit");
 
         return std.fmt.allocPrint(
             ctx.allocator,
             "{s}\n\nCount: {s}\nLast key: {s}\n{s}\n\n{s}",
             .{ title, count_styled, self.last_key, size_info, help },
-        ) catch "Error";
+        );
     }
 };
 


### PR DESCRIPTION
> **Stacked on #132.**

Item 3 from the review.

**418 of the 521 `catch` sites in `examples/` are gone.** Every one of them was a rendering fallback that turned an allocation failure into output a user cannot tell apart from real content — a `"?"` where a number belongs, a title that silently loses its styling, a whole frame replaced by the word `"Error"`.

```diff
-        const title = title_style.render(ctx.allocator, "Todo List") catch "Todo List";
-        const filter_text = std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{...}) catch "Filter:";
-        writer.writeAll(styled_filter) catch {};
+        const title = try title_style.render(ctx.allocator, "Todo List");
+        const filter_text = try std.fmt.allocPrint(ctx.allocator, "Filter: {s}", .{...});
+        try writer.writeAll(styled_filter);
```

Every `view` that had such a fallback now returns `![]const u8`. `init` bodies that dropped registrations on the floor were migrated too — `showcase.zig` alone had 28 of these:

```diff
-        self.table.addRow(.{ "web-01", "online", "45d 3h", "0.42" }) catch {};
+        try self.table.addRow(.{ "web-01", "online", "45d 3h", "0.42" });
```

A row that fails to be added is a bug, not a display variation.

## What was deliberately left alone

`catch return .none` in `update`, the file-open failures in `file_browser`, `catch unreachable` where a call genuinely cannot fail. Those are error *handling*, not fallbacks — 103 sites, and they stay.

## How it was done, and how it was checked

Mechanically, then reviewed. The transform only touched `catch <value>` and `catch {}`, never `catch return` / `catch continue` / `catch |err|`. Verified afterwards that:

- the diff contains no removed line matching `catch (return|break|continue|\|)` — no control flow was rewritten
- no `try` landed inside a string literal or a comment (three comments that a regex pass did mangle were repaired)
- no `try try`, no `try` in a syntactically odd position
- `zig build`, `zig build test`, and `zig build test -Doptimize=ReleaseSafe` are all clean

42 files, 566 insertions, 566 deletions — every changed line is one of the two shapes above.