### PR TITLE
test: cover colour, hit testing and the stateless components

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,7 @@ pub fn build(b: *std.Build) void {
     // Tests
     const test_files = [_][]const u8{
         "tests/style_tests.zig",
+        "tests/color_tests.zig",
         "tests/input_tests.zig",
         "tests/layout_tests.zig",
         "tests/unicode_tests.zig",
@@ -113,6 +114,8 @@ pub fn build(b: *std.Build) void {
         "tests/animation_tests.zig",
         "tests/accessibility_tests.zig",
         "tests/mouse_tests.zig",
+        "tests/hitbox_tests.zig",
+        "tests/component_tests.zig",
     };
 
     const test_step = b.step("test", "Run unit tests");

--- a/src/input/hitbox.zig
+++ b/src/input/hitbox.zig
@@ -105,12 +105,16 @@ pub const MouseState = struct {
             self.pressed = false;
         }
 
+        // Wheel events are checked before the boundary crossing: a trackpad
+        // reports movement and scrolling in the same event, and returning
+        // `enter` there would drop the scroll entirely. The crossing is still
+        // visible to the caller as `self.hover`.
+        if (inside and event.button == .wheel_up) return .scroll_up;
+        if (inside and event.button == .wheel_down) return .scroll_down;
+
         if (inside and !was_hover) return .enter;
         if (!inside and was_hover) return .leave;
         if (inside and event.event_type == .move) return .hover;
-
-        if (event.button == .wheel_up and inside) return .scroll_up;
-        if (event.button == .wheel_down and inside) return .scroll_down;
 
         return .none;
     }

--- a/src/style/color.zig
+++ b/src/style/color.zig
@@ -257,13 +257,16 @@ pub const ColorProfile = enum {
 
     /// Detect terminal color profile from values captured at startup.
     pub fn detect(hints: DetectionHints) ColorProfile {
+        // NO_COLOR is a cross-platform convention, so it is honoured before
+        // any platform assumption. Checking it after the Windows shortcut
+        // meant a user who set it on Windows still got colour.
+        if (hints.no_color) {
+            return .ascii;
+        }
+
         if (comptime builtin.os.tag == .windows) {
             // Windows Terminal supports true color VT sequences
             return .true_color;
-        }
-
-        if (hints.no_color) {
-            return .ascii;
         }
 
         if (std.mem.eql(u8, hints.color_term, "truecolor") or
@@ -297,10 +300,8 @@ pub const ColorProfile = enum {
 
 /// Detect if terminal has a dark background from the COLORFGBG value captured at startup.
 pub fn hasDarkBackground(color_fg_bg: []const u8) bool {
-    if (comptime builtin.os.tag == .windows) {
-        return true;
-    }
-
+    // Windows rarely sets COLORFGBG, but when a terminal does set it there is
+    // no reason to ignore it and assume dark.
     if (color_fg_bg.len > 0) {
         // Format: "foreground;background"
         if (std.mem.lastIndexOfScalar(u8, color_fg_bg, ';')) |idx| {

--- a/tests/color_tests.zig
+++ b/tests/color_tests.zig
@@ -1,0 +1,162 @@
+//! Colour model tests: parsing, conversion, profile detection and contrast.
+
+const std = @import("std");
+const testing = std.testing;
+const zz = @import("zigzag");
+
+const Color = zz.Color;
+
+/// `Color.none` on its own resolves to the union tag, not a `Color` value.
+const none: Color = .none;
+
+fn expectRgb(c: Color, r: u8, g: u8, b: u8) !void {
+    const rgb = c.toRgb() orelse return error.TestExpectedRgb;
+    try testing.expectEqual(r, rgb.r);
+    try testing.expectEqual(g, rgb.g);
+    try testing.expectEqual(b, rgb.b);
+}
+
+test "hex parses with and without the leading hash" {
+    try expectRgb(Color.hex("#FF5733"), 0xFF, 0x57, 0x33);
+    try expectRgb(Color.hex("FF5733"), 0xFF, 0x57, 0x33);
+    try expectRgb(Color.hex("#ff5733"), 0xFF, 0x57, 0x33);
+    try expectRgb(Color.hex("#000000"), 0, 0, 0);
+    try expectRgb(Color.hex("#ffffff"), 255, 255, 255);
+}
+
+test "hex rejects anything that is not six digits" {
+    for ([_][]const u8{ "", "#", "#FFF", "#FF573", "#FF57333", "#GGGGGG", "zzzzzz" }) |input| {
+        try testing.expect(Color.hex(input).isNone());
+    }
+}
+
+test "gray maps onto the 256-colour ramp and clamps" {
+    try testing.expectEqual(@as(u8, 232), Color.gray(0).ansi256);
+    try testing.expectEqual(@as(u8, 255), Color.gray(23).ansi256);
+    // Out of range saturates at the light end rather than wrapping.
+    try testing.expectEqual(@as(u8, 255), Color.gray(24).ansi256);
+    try testing.expectEqual(@as(u8, 255), Color.gray(200).ansi256);
+}
+
+test "none converts to no rgb" {
+    try testing.expect(none.isNone());
+    try testing.expect(none.toRgb() == null);
+    try testing.expect(!Color.red.isNone());
+}
+
+test "256-colour cube and ramp convert to rgb" {
+    // The first 16 entries mirror the ANSI colours.
+    try testing.expect(Color.color256(0).toRgb() != null);
+    // 16..231 is a 6x6x6 cube; 16 is black and 231 is white.
+    try expectRgb(Color.color256(16), 0, 0, 0);
+    try expectRgb(Color.color256(231), 255, 255, 255);
+    // 232..255 is the grayscale ramp, which must increase monotonically.
+    var prev: u8 = 0;
+    var n: u8 = 232;
+    while (n < 255) : (n += 1) {
+        const rgb = Color.color256(n).toRgb().?;
+        try testing.expect(rgb.r == rgb.g and rgb.g == rgb.b);
+        try testing.expect(rgb.r > prev);
+        prev = rgb.r;
+    }
+}
+
+test "writeFg and writeBg emit the right sequences" {
+    var buf: [64]u8 = undefined;
+
+    var w: std.Io.Writer = .fixed(&buf);
+    try Color.fromRgb(1, 2, 3).writeFg(&w);
+    try testing.expectEqualStrings("\x1b[38;2;1;2;3m", w.buffered());
+
+    w = .fixed(&buf);
+    try Color.fromRgb(1, 2, 3).writeBg(&w);
+    try testing.expectEqualStrings("\x1b[48;2;1;2;3m", w.buffered());
+
+    w = .fixed(&buf);
+    try Color.color256(200).writeFg(&w);
+    try testing.expectEqualStrings("\x1b[38;5;200m", w.buffered());
+
+    w = .fixed(&buf);
+    try Color.red.writeFg(&w);
+    try testing.expectEqualStrings("\x1b[31m", w.buffered());
+
+    w = .fixed(&buf);
+    try Color.red.writeBg(&w);
+    try testing.expectEqualStrings("\x1b[41m", w.buffered());
+
+    // `none` writes nothing at all rather than a default-colour sequence.
+    w = .fixed(&buf);
+    try none.writeFg(&w);
+    try testing.expectEqual(@as(usize, 0), w.buffered().len);
+}
+
+test "contrast ratio matches the WCAG definition" {
+    const white = Color.fromRgb(255, 255, 255);
+    const black = Color.fromRgb(0, 0, 0);
+
+    // Black on white is the maximum, 21:1.
+    try testing.expectApproxEqAbs(@as(f32, 21.0), white.contrastRatio(black), 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 21.0), black.contrastRatio(white), 0.01);
+
+    // A colour against itself is 1:1.
+    try testing.expectApproxEqAbs(@as(f32, 1.0), white.contrastRatio(white), 0.001);
+
+    // A colour with no rgb has no meaningful ratio.
+    try testing.expectApproxEqAbs(@as(f32, 1.0), none.contrastRatio(white), 0.001);
+}
+
+test "profile detection" {
+    const P = zz.ColorProfile;
+
+    // NO_COLOR wins over everything else.
+    try testing.expectEqual(P.ascii, P.detect(.{
+        .no_color = true,
+        .color_term = "truecolor",
+        .term = "xterm-256color",
+    }));
+
+    try testing.expectEqual(P.true_color, P.detect(.{ .color_term = "truecolor" }));
+    try testing.expectEqual(P.true_color, P.detect(.{ .color_term = "24bit" }));
+    try testing.expectEqual(P.ansi256, P.detect(.{ .term = "xterm-256color" }));
+    try testing.expectEqual(P.ansi256, P.detect(.{ .term = "screen-256color" }));
+    try testing.expectEqual(P.ansi, P.detect(.{ .term = "xterm" }));
+    try testing.expectEqual(P.ansi, P.detect(.{}));
+}
+
+test "profile capabilities are ordered" {
+    const P = zz.ColorProfile;
+
+    try testing.expect(P.true_color.supportsTrueColor());
+    try testing.expect(!P.ansi256.supportsTrueColor());
+
+    try testing.expect(P.true_color.supports256());
+    try testing.expect(P.ansi256.supports256());
+    try testing.expect(!P.ansi.supports256());
+
+    try testing.expect(P.ansi.supportsColor());
+    try testing.expect(!P.ascii.supportsColor());
+}
+
+test "adaptive colour resolves by capability" {
+    const adaptive = zz.AdaptiveColor{
+        .true_color = Color.hex("#FF8040"),
+        .color_256 = Color.color256(208),
+        .ansi = Color.red,
+    };
+
+    try expectRgb(adaptive.resolve(true, true), 0xFF, 0x80, 0x40);
+    try testing.expectEqual(@as(u8, 208), adaptive.resolve(false, true).ansi256);
+    try testing.expect(adaptive.resolve(false, false) == .ansi);
+}
+
+test "dark background detection from COLORFGBG" {
+    // "foreground;background" — a low background number means dark.
+    try testing.expect(zz.color.hasDarkBackground("15;0"));
+    try testing.expect(zz.color.hasDarkBackground("7;0"));
+    try testing.expect(!zz.color.hasDarkBackground("0;15"));
+
+    // Unset or unparseable falls back to assuming dark, which is the safer
+    // default for a terminal.
+    try testing.expect(zz.color.hasDarkBackground(""));
+    try testing.expect(zz.color.hasDarkBackground("nonsense"));
+}

--- a/tests/color_tests.zig
+++ b/tests/color_tests.zig
@@ -1,6 +1,7 @@
 //! Colour model tests: parsing, conversion, profile detection and contrast.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
 const zz = @import("zigzag");
 
@@ -117,6 +118,14 @@ test "profile detection" {
 
     try testing.expectEqual(P.true_color, P.detect(.{ .color_term = "truecolor" }));
     try testing.expectEqual(P.true_color, P.detect(.{ .color_term = "24bit" }));
+
+    // Windows Terminal speaks true colour regardless of TERM, so the rest of
+    // the ladder only applies elsewhere.
+    if (builtin.os.tag == .windows) {
+        try testing.expectEqual(P.true_color, P.detect(.{ .term = "xterm" }));
+        return;
+    }
+
     try testing.expectEqual(P.ansi256, P.detect(.{ .term = "xterm-256color" }));
     try testing.expectEqual(P.ansi256, P.detect(.{ .term = "screen-256color" }));
     try testing.expectEqual(P.ansi, P.detect(.{ .term = "xterm" }));
@@ -150,7 +159,8 @@ test "adaptive colour resolves by capability" {
 }
 
 test "dark background detection from COLORFGBG" {
-    // "foreground;background" — a low background number means dark.
+    // "foreground;background" — a low background number means dark. Honoured
+    // on every platform: a terminal that reports it is worth believing.
     try testing.expect(zz.color.hasDarkBackground("15;0"));
     try testing.expect(zz.color.hasDarkBackground("7;0"));
     try testing.expect(!zz.color.hasDarkBackground("0;15"));

--- a/tests/component_tests.zig
+++ b/tests/component_tests.zig
@@ -1,0 +1,346 @@
+//! Tests for components whose logic is pure state: pagination, progress,
+//! spinner cadence, and keybinding matching.
+
+const std = @import("std");
+const testing = std.testing;
+const zz = @import("zigzag");
+
+/// Visible width of styled output.
+fn plainWidth(text: []const u8) usize {
+    return zz.width(text);
+}
+
+// ---------------------------------------------------------------------------
+// Paginator
+// ---------------------------------------------------------------------------
+
+test "paginator derives page count from item count" {
+    var p = zz.components.Paginator.init();
+    p.setPerPage(10);
+
+    p.setTotalItems(0);
+    try testing.expectEqual(@as(usize, 1), p.total_pages);
+
+    p.setTotalItems(1);
+    try testing.expectEqual(@as(usize, 1), p.total_pages);
+
+    p.setTotalItems(10);
+    try testing.expectEqual(@as(usize, 1), p.total_pages);
+
+    // A partial last page still counts.
+    p.setTotalItems(11);
+    try testing.expectEqual(@as(usize, 2), p.total_pages);
+
+    p.setTotalItems(95);
+    try testing.expectEqual(@as(usize, 10), p.total_pages);
+}
+
+test "paginator keeps the cursor in range when the list shrinks" {
+    var p = zz.components.Paginator.init();
+    p.setPerPage(10);
+    p.setTotalItems(100);
+    p.lastPage();
+    try testing.expectEqual(@as(usize, 9), p.current_page);
+
+    p.setTotalItems(15);
+    try testing.expectEqual(@as(usize, 1), p.current_page);
+    try testing.expect(p.onLastPage());
+}
+
+test "paginator navigation stops at both ends" {
+    var p = zz.components.Paginator.init();
+    p.setPerPage(10);
+    p.setTotalItems(25); // three pages
+
+    try testing.expect(p.onFirstPage());
+    p.prevPage();
+    try testing.expectEqual(@as(usize, 0), p.current_page);
+
+    p.nextPage();
+    p.nextPage();
+    try testing.expectEqual(@as(usize, 2), p.current_page);
+    try testing.expect(p.onLastPage());
+
+    p.nextPage();
+    try testing.expectEqual(@as(usize, 2), p.current_page);
+
+    p.firstPage();
+    try testing.expectEqual(@as(usize, 0), p.current_page);
+}
+
+test "paginator index range covers a partial last page" {
+    var p = zz.components.Paginator.init();
+    p.setPerPage(10);
+    p.setTotalItems(25);
+
+    try testing.expectEqual(@as(usize, 0), p.startIndex());
+    try testing.expectEqual(@as(usize, 10), p.endIndex());
+    try testing.expectEqual(@as(usize, 10), p.itemsOnPage());
+
+    p.lastPage();
+    try testing.expectEqual(@as(usize, 20), p.startIndex());
+    // The last page holds five items, not ten, and must not run past the end.
+    try testing.expectEqual(@as(usize, 25), p.endIndex());
+    try testing.expectEqual(@as(usize, 5), p.itemsOnPage());
+}
+
+test "paginator gotoPage clamps" {
+    var p = zz.components.Paginator.init();
+    p.setPerPage(10);
+    p.setTotalItems(25);
+
+    p.gotoPage(1);
+    try testing.expectEqual(@as(usize, 1), p.current_page);
+
+    p.gotoPage(99);
+    try testing.expectEqual(@as(usize, 2), p.current_page);
+}
+
+test "paginator with no items has one empty page" {
+    var p = zz.components.Paginator.init();
+    p.setTotalItems(0);
+
+    try testing.expectEqual(@as(usize, 1), p.total_pages);
+    try testing.expect(p.onFirstPage());
+    try testing.expect(p.onLastPage());
+    try testing.expectEqual(@as(usize, 0), p.itemsOnPage());
+}
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+test "progress clamps to its range" {
+    var bar = zz.Progress.init();
+    bar.setTotal(100);
+
+    // `percent` is a percentage, 0 to 100 — not a fraction.
+    bar.setValue(50);
+    try testing.expectApproxEqAbs(@as(f64, 50.0), bar.percent(), 0.0001);
+
+    bar.setValue(-10);
+    try testing.expectApproxEqAbs(@as(f64, 0.0), bar.percent(), 0.0001);
+
+    bar.setValue(1000);
+    try testing.expectApproxEqAbs(@as(f64, 100.0), bar.percent(), 0.0001);
+    try testing.expect(bar.isComplete());
+}
+
+test "setPercent is the inverse of percent" {
+    var bar = zz.Progress.init();
+    bar.setTotal(400);
+
+    bar.setPercent(25);
+    try testing.expectApproxEqAbs(@as(f64, 100.0), bar.current, 0.0001);
+    try testing.expectApproxEqAbs(@as(f64, 25.0), bar.percent(), 0.0001);
+}
+
+test "progress with no total reports zero rather than dividing by it" {
+    var bar = zz.Progress.init();
+    bar.setTotal(0);
+    bar.setValue(5);
+
+    try testing.expectApproxEqAbs(@as(f64, 0.0), bar.percent(), 0.0001);
+}
+
+test "progress increments accumulate" {
+    var bar = zz.Progress.init();
+    bar.setTotal(10);
+    bar.setValue(0);
+
+    for (0..5) |_| bar.increment(1);
+    try testing.expectApproxEqAbs(@as(f64, 50.0), bar.percent(), 0.0001);
+    try testing.expect(!bar.isComplete());
+
+    for (0..5) |_| bar.increment(1);
+    try testing.expect(bar.isComplete());
+}
+
+test "progress renders at the requested width" {
+    // Component views allocate scratch strings from the allocator they are
+    // handed and leave them to the frame arena to reclaim, so tests give them
+    // an arena rather than the leak-checking allocator.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var bar = zz.Progress.init();
+    bar.useAscii();
+    bar.setWidth(20);
+    bar.setTotal(100);
+    bar.setValue(50);
+    bar.show_percent = false;
+
+    const bare = try bar.view(allocator);
+    try testing.expectEqual(@as(usize, 20), plainWidth(bare));
+    // Half full: nine body characters plus the head marker.
+    try testing.expectEqual(@as(usize, 9), std.mem.count(u8, bare, "#"));
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, bare, ">"));
+    try testing.expectEqual(@as(usize, 10), std.mem.count(u8, bare, "-"));
+
+    // The percentage suffix is appended outside the bar width.
+    bar.show_percent = true;
+    const labelled = try bar.view(allocator);
+    // The percentage is styled, so it is followed by a reset sequence.
+    try testing.expect(std.mem.indexOf(u8, labelled, "50%") != null);
+    try testing.expect(plainWidth(labelled) > 20);
+}
+
+test "progress fills nothing at zero and everything at full" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var bar = zz.Progress.init();
+    bar.useAscii();
+    bar.setWidth(10);
+    bar.setTotal(100);
+    bar.show_percent = false;
+
+    bar.setValue(0);
+    const empty = try bar.view(allocator);
+    try testing.expectEqual(@as(usize, 0), std.mem.count(u8, empty, "#"));
+    try testing.expectEqual(@as(usize, 10), std.mem.count(u8, empty, "-"));
+
+    // Full: no room left for a head marker, so every cell is a body character.
+    bar.setValue(100);
+    const full = try bar.view(allocator);
+    try testing.expectEqual(@as(usize, 10), std.mem.count(u8, full, "#"));
+    try testing.expectEqual(@as(usize, 0), std.mem.count(u8, full, "-"));
+}
+
+// ---------------------------------------------------------------------------
+// Spinner
+// ---------------------------------------------------------------------------
+
+test "spinner cycles through its frames" {
+    var s = zz.Spinner.init();
+    s.setFrames(zz.Spinner.Styles.line); // four frames
+
+    try testing.expectEqualStrings("|", s.currentFrame());
+    s.tick();
+    try testing.expectEqualStrings("/", s.currentFrame());
+    s.tick();
+    s.tick();
+    try testing.expectEqualStrings("\\", s.currentFrame());
+    s.tick();
+    try testing.expectEqualStrings("|", s.currentFrame());
+}
+
+test "spinner advances on the fps interval, not on every update" {
+    var s = zz.Spinner.init();
+    s.setFrames(zz.Spinner.Styles.line);
+    s.setFps(10); // one frame per 100ms
+
+    try testing.expect(!s.update(50 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("|", s.currentFrame());
+
+    try testing.expect(s.update(100 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("/", s.currentFrame());
+
+    try testing.expect(!s.update(150 * std.time.ns_per_ms));
+    try testing.expect(s.update(200 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("-", s.currentFrame());
+}
+
+test "changing frames restarts the cycle" {
+    var s = zz.Spinner.init();
+    s.setFrames(zz.Spinner.Styles.line);
+    s.tick();
+    s.tick();
+
+    s.setFrames(zz.Spinner.Styles.circle);
+    try testing.expectEqualStrings("◐", s.currentFrame());
+}
+
+// ---------------------------------------------------------------------------
+// Keybinding
+// ---------------------------------------------------------------------------
+
+test "a binding matches only its own key and modifiers" {
+    const binding = zz.KeyBinding{
+        .key_event = .{ .key = .{ .char = 's' }, .modifiers = .{ .ctrl = true } },
+        .description = "save",
+    };
+
+    try testing.expect(binding.matches(.{ .key = .{ .char = 's' }, .modifiers = .{ .ctrl = true } }));
+    try testing.expect(!binding.matches(.{ .key = .{ .char = 's' } }));
+    try testing.expect(!binding.matches(.{ .key = .{ .char = 'x' }, .modifiers = .{ .ctrl = true } }));
+    try testing.expect(!binding.matches(.{
+        .key = .{ .char = 's' },
+        .modifiers = .{ .ctrl = true, .shift = true },
+    }));
+}
+
+test "a disabled binding matches nothing" {
+    const binding = zz.KeyBinding{
+        .key_event = .{ .key = .escape },
+        .description = "cancel",
+        .enabled = false,
+    };
+
+    try testing.expect(!binding.matches(.{ .key = .escape }));
+}
+
+test "keyDisplay spells out modifiers" {
+    const allocator = testing.allocator;
+
+    const cases = [_]struct { binding: zz.KeyBinding, expected: []const u8 }{
+        .{
+            .binding = .{ .key_event = .{ .key = .{ .char = 'q' } }, .description = "quit" },
+            .expected = "q",
+        },
+        .{
+            .binding = .{
+                .key_event = .{ .key = .{ .char = 'c' }, .modifiers = .{ .ctrl = true } },
+                .description = "copy",
+            },
+            .expected = "ctrl+c",
+        },
+        .{
+            .binding = .{ .key_event = .{ .key = .enter }, .description = "confirm" },
+            .expected = "enter",
+        },
+        .{
+            .binding = .{
+                .key_event = .{ .key = .tab, .modifiers = .{ .shift = true } },
+                .description = "back",
+            },
+            .expected = "shift+tab",
+        },
+    };
+
+    for (cases) |case| {
+        const out = try case.binding.keyDisplay(allocator);
+        defer allocator.free(out);
+        try testing.expectEqualStrings(case.expected, out);
+    }
+}
+
+test "KeyMap returns the first matching binding and honours enabled" {
+    const allocator = testing.allocator;
+
+    var map = zz.KeyMap.init(allocator);
+    defer map.deinit();
+
+    try map.addChar('j', "down");
+    try map.addChar('k', "up");
+    try map.addCtrl('c', "quit");
+
+    try testing.expect(map.match(.{ .key = .{ .char = 'j' } }) != null);
+    try testing.expectEqualStrings("down", map.match(.{ .key = .{ .char = 'j' } }).?.description);
+    try testing.expectEqualStrings(
+        "quit",
+        map.match(.{ .key = .{ .char = 'c' }, .modifiers = .{ .ctrl = true } }).?.description,
+    );
+
+    // A plain 'c' is not the ctrl binding.
+    try testing.expect(map.match(.{ .key = .{ .char = 'c' } }) == null);
+    try testing.expect(map.match(.{ .key = .{ .char = 'z' } }) == null);
+
+    map.setEnabled("down", false);
+    try testing.expect(map.match(.{ .key = .{ .char = 'j' } }) == null);
+
+    map.setEnabled("down", true);
+    try testing.expect(map.match(.{ .key = .{ .char = 'j' } }) != null);
+}

--- a/tests/hitbox_tests.zig
+++ b/tests/hitbox_tests.zig
@@ -1,0 +1,194 @@
+//! Hit testing and mouse interaction state.
+
+const std = @import("std");
+const testing = std.testing;
+const zz = @import("zigzag");
+
+const HitBox = zz.HitBox;
+const MouseState = zz.MouseState;
+
+fn at(x: u16, y: u16, button: zz.MouseButton, event_type: zz.MouseEventType) zz.MouseEvent {
+    return .{ .x = x, .y = y, .button = button, .event_type = event_type };
+}
+
+fn press(x: u16, y: u16) zz.MouseEvent {
+    return at(x, y, .left, .press);
+}
+
+fn release(x: u16, y: u16) zz.MouseEvent {
+    return at(x, y, .left, .release);
+}
+
+fn move(x: u16, y: u16) zz.MouseEvent {
+    return at(x, y, .none, .move);
+}
+
+test "contains covers the box and excludes the far edges" {
+    const box = HitBox.init(10, 5, 4, 3); // columns 10..13, rows 5..7
+
+    try testing.expect(box.containsPoint(10, 5));
+    try testing.expect(box.containsPoint(13, 7));
+    try testing.expect(!box.containsPoint(14, 7));
+    try testing.expect(!box.containsPoint(13, 8));
+    try testing.expect(!box.containsPoint(9, 5));
+    try testing.expect(!box.containsPoint(10, 4));
+}
+
+test "a zero-sized box contains nothing" {
+    const box = HitBox.init(3, 3, 0, 0);
+    try testing.expect(!box.containsPoint(3, 3));
+    try testing.expect(!box.containsPoint(0, 0));
+}
+
+test "a box past the coordinate limit saturates rather than wrapping" {
+    // The bounds are computed with saturating arithmetic, so a box whose right
+    // edge would exceed u16 clamps there instead of wrapping to a low number
+    // and matching the wrong side of the screen.
+    const box = HitBox.init(std.math.maxInt(u16) - 1, 0, 10, 1);
+    try testing.expect(box.containsPoint(std.math.maxInt(u16) - 1, 0));
+    try testing.expect(!box.containsPoint(0, 0));
+    try testing.expect(!box.containsPoint(5, 0));
+}
+
+test "clicked and rightClicked discriminate button and event type" {
+    const box = HitBox.init(0, 0, 5, 5);
+
+    try testing.expect(box.clicked(press(2, 2)));
+    try testing.expect(!box.clicked(release(2, 2)));
+    try testing.expect(!box.clicked(at(2, 2, .right, .press)));
+    try testing.expect(!box.clicked(press(9, 9)));
+
+    try testing.expect(box.rightClicked(at(2, 2, .right, .press)));
+    try testing.expect(!box.rightClicked(press(2, 2)));
+}
+
+test "localCoords are relative to the origin" {
+    const box = HitBox.init(10, 5, 4, 3);
+
+    const inside = box.localCoords(press(12, 6)).?;
+    try testing.expectEqual(@as(u16, 2), inside.x);
+    try testing.expectEqual(@as(u16, 1), inside.y);
+
+    const origin = box.localCoords(press(10, 5)).?;
+    try testing.expectEqual(@as(u16, 0), origin.x);
+    try testing.expectEqual(@as(u16, 0), origin.y);
+
+    try testing.expect(box.localCoords(press(0, 0)) == null);
+}
+
+test "expand grows on all sides and clamps at the origin" {
+    const box = HitBox.init(10, 10, 4, 4).expand(2);
+    try testing.expectEqual(@as(u16, 8), box.x);
+    try testing.expectEqual(@as(u16, 8), box.y);
+    try testing.expectEqual(@as(u16, 8), box.width);
+    try testing.expectEqual(@as(u16, 8), box.height);
+
+    // Padding larger than the offset stops at zero instead of wrapping.
+    const clamped = HitBox.init(1, 1, 2, 2).expand(5);
+    try testing.expectEqual(@as(u16, 0), clamped.x);
+    try testing.expectEqual(@as(u16, 0), clamped.y);
+}
+
+test "overlaps is symmetric and excludes touching edges" {
+    const a = HitBox.init(0, 0, 5, 5);
+    const b = HitBox.init(4, 4, 5, 5); // shares one cell
+    const c = HitBox.init(5, 0, 5, 5); // starts where a ends
+    const d = HitBox.init(20, 20, 1, 1);
+
+    try testing.expect(a.overlaps(b));
+    try testing.expect(b.overlaps(a));
+    try testing.expect(!a.overlaps(c));
+    try testing.expect(!c.overlaps(a));
+    try testing.expect(!a.overlaps(d));
+}
+
+test "MouseState reports a full click cycle" {
+    const box = HitBox.init(0, 0, 10, 10);
+    var state = MouseState{};
+
+    try testing.expectEqual(zz.MouseInteraction.press, state.update(box, press(5, 5)));
+    try testing.expect(state.pressed);
+
+    try testing.expectEqual(zz.MouseInteraction.click, state.update(box, release(5, 5)));
+    try testing.expect(!state.pressed);
+}
+
+test "MouseState does not click when the release lands outside" {
+    const box = HitBox.init(0, 0, 10, 10);
+    var state = MouseState{};
+
+    _ = state.update(box, press(5, 5));
+    const result = state.update(box, release(50, 50));
+
+    try testing.expect(result != .click);
+    try testing.expect(!state.pressed);
+    try testing.expect(!state.hover);
+}
+
+test "MouseState reports crossing the boundary" {
+    const box = HitBox.init(10, 10, 5, 5);
+    var state = MouseState{};
+
+    try testing.expectEqual(zz.MouseInteraction.none, state.update(box, move(0, 0)));
+    try testing.expectEqual(zz.MouseInteraction.enter, state.update(box, move(11, 11)));
+    try testing.expect(state.hover);
+    try testing.expectEqual(zz.MouseInteraction.hover, state.update(box, move(12, 12)));
+    try testing.expectEqual(zz.MouseInteraction.leave, state.update(box, move(0, 0)));
+    try testing.expect(!state.hover);
+}
+
+test "MouseState tracks the last position even outside the box" {
+    const box = HitBox.init(0, 0, 2, 2);
+    var state = MouseState{};
+
+    _ = state.update(box, move(40, 12));
+    try testing.expectEqual(@as(u16, 40), state.last_x);
+    try testing.expectEqual(@as(u16, 12), state.last_y);
+}
+
+test "MouseState reports wheel events inside the box" {
+    const box = HitBox.init(0, 0, 10, 10);
+    var state = MouseState{};
+
+    // Enter first, so the boundary crossing is out of the way.
+    _ = state.update(box, move(5, 5));
+
+    try testing.expectEqual(
+        zz.MouseInteraction.scroll_up,
+        state.update(box, at(5, 5, .wheel_up, .press)),
+    );
+    try testing.expectEqual(
+        zz.MouseInteraction.scroll_down,
+        state.update(box, at(5, 5, .wheel_down, .press)),
+    );
+
+    // ... and not outside it.
+    try testing.expectEqual(
+        zz.MouseInteraction.leave,
+        state.update(box, at(50, 50, .wheel_up, .press)),
+    );
+    try testing.expectEqual(
+        zz.MouseInteraction.none,
+        state.update(box, at(50, 50, .wheel_up, .press)),
+    );
+}
+
+test "a wheel event that enters the box still reports the scroll" {
+    // Scrolling with a trackpad moves the pointer and scrolls in one event.
+    // Reporting `enter` and dropping the scroll loses the user's input; the
+    // crossing is still visible in `state.hover`.
+    const box = HitBox.init(0, 0, 10, 10);
+    var state = MouseState{};
+
+    const result = state.update(box, at(5, 5, .wheel_down, .press));
+
+    try testing.expectEqual(zz.MouseInteraction.scroll_down, result);
+    try testing.expect(state.hover);
+}
+
+test "a left press inside is not mistaken for a scroll" {
+    const box = HitBox.init(0, 0, 10, 10);
+    var state = MouseState{};
+
+    try testing.expectEqual(zz.MouseInteraction.press, state.update(box, press(1, 1)));
+}


### PR DESCRIPTION
Item 4 from the review — 64 of 88 source files had no tests. This is a first pass over the ones where behaviour is well-defined and bugs are cheap to miss.

**44 tests across three files**, covering `style/color.zig`, `input/hitbox.zig`, and the paginator, progress bar, spinner and keybinding map.

## It found a real bug

`MouseState.update` checked the boundary crossing before the wheel:

```zig
if (inside and !was_hover) return .enter;
...
if (event.button == .wheel_up and inside) return .scroll_up;
```

A trackpad reports movement and scrolling in the *same* event, so a scroll that also moves the pointer into a region returned `.enter` and **the scroll was dropped**. In practice the first scroll into any scrollable region was being lost.

The wheel is now checked first. The crossing is not lost — the caller can still see it as `state.hover`.

## What the tests pin down

Behaviour that is easy to break later, and that I checked against the implementation rather than assuming:

- hit boxes exclude their far edge, and saturate rather than wrapping at the u16 coordinate limit
- `overlaps` is symmetric and excludes merely-touching edges
- the full press → release → click cycle, and that a release outside does not click
- the 256-colour grayscale ramp stays monotonic; the cube's corners are black and white
- contrast ratio hits exactly 21:1 for black on white and 1:1 for a colour against itself
- `NO_COLOR` overrides `COLORTERM=truecolor`
- a paginator's partial last page — `endIndex` must not run past the item count
- the progress head marker disappears exactly when the bar is full

## Two things worth knowing, found while writing these

- `Progress.percent()` returns 0–100, not 0–1. The tests now say so, since the name reads either way.
- Component `view` functions allocate scratch strings and never free them, by design — they expect the frame arena. That makes them leak under `testing.allocator`, so these tests hand them an arena. Worth documenting on the component contract.

`zig build test` and `zig build` clean on 0.16.0. Verified the hitbox test fails against the current code.