### PR TITLE
chore: release v0.1.6

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zigzag,
-    .version = "0.1.2",
+    .version = "0.1.6",
     .fingerprint = 0xdffe16194b187c61,
     .minimum_zig_version = "0.16.0",
     .paths = .{


### PR DESCRIPTION
Bumps the manifest version ahead of cutting the v0.1.6 tag.

`build.zig.zon` was still reading 0.1.2 even though v0.1.3 and v0.1.5 both shipped, so anyone consuming the package saw a version that had not been true for a while. This catches it up to the tag.

Version only, no code changes. `build.zig.zon` is the only place in the repo that carries it.